### PR TITLE
Compile the Odin branch nothing compiled, and align a dictionary's Key column

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -278,6 +278,17 @@ deliberate act, not the tail of every commit.
 - **Exhaust the local gates first.** In rough order of cost, all of them cheaper than one CI run:
   - `npm run typecheck:unity` -- compiles the real `Runtime/**` against UnityEngine reference
     assemblies with the shipped analyzer loaded, in seconds. Catches `CS####` and `WPROTO###`.
+    It builds each source tree three ways, because three different branches ship: the
+    `WALLSTOP_PROTO` default, the legacy define-off fallback, and
+    `WALLSTOP_UNITY_HELPERS_ODIN_INSPECTOR` (`typecheck:unity:odin` / `typecheck:tests:odin`).
+    The Odin configuration exists because Odin changes the **base class** of
+    `RuntimeSingleton<T>`, `ScriptableObjectSingleton<T>` and `AttributeEffect`, and that branch
+    compiled nowhere in automation until #347 -- which is how #275 shipped a compile break to
+    consumers. Odin is paid and has no NuGet package, so `Shims/OdinInspectorShim.cs` declares the
+    two base classes the runtime aliases and nothing else. The **editor-side** Odin surface (nine
+    drawers, three inspectors) still compiles nowhere: reaching it means compiling the whole Editor
+    assembly, which needs a `UnityEditor` reference the community reference assemblies do not
+    carry. That half is tracked on #347.
   - `dotnet test -c Release -p:ProtobufNetOracle=v3` and then
     `dotnet test -c Release -p:ProtobufNetOracle=v2` in
     `Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests` -- the real serializer sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `SerializableDictionary`'s "Add entry" Key field is no longer offset from its Value field**: inside a `WGroup` — or anywhere else the inspector indents it — the Value column was drawn 8.5px to the left of the Key column ([#284](https://github.com/Ambiguous-Interactive/unity-helpers/issues/284)).
 - **A WallstopProto contract with a `struct` dictionary member no longer breaks your build**: the generator accepted the member and then emitted a null check and a `??` for a value type, both of which are compiler errors in code you never wrote ([#388](https://github.com/Ambiguous-Interactive/unity-helpers/issues/388)).
 - **An immutable WallstopProto contract with a dictionary member no longer breaks your build**: two generated locals shared a name, which surfaced as `CS0136` inside generated source ([#395](https://github.com/Ambiguous-Interactive/unity-helpers/issues/395)).
 - **WallstopProto now preserves empty string map values written by protobuf-net v2**: v2 omits the value field for `""`, and the generated reader previously turned that missing field into `null`. It now applies protobuf's empty-string default, so old persisted maps migrate without changing their values ([#371](https://github.com/Ambiguous-Interactive/unity-helpers/issues/371)).

--- a/Editor/CustomDrawers/SerializableDictionaryPropertyDrawer.cs
+++ b/Editor/CustomDrawers/SerializableDictionaryPropertyDrawer.cs
@@ -697,9 +697,6 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
         private const float DictionaryRowChildHorizontalPadding = 2f;
         private const float DictionaryRowChildLabelTextPadding = 6f;
         internal const float PendingFieldLabelWidth = 72f;
-        internal const float PendingValueContentLeftShift = 8.5f;
-        internal const float PendingFoldoutValueLeftShiftReduction = 3f;
-        internal const float PendingFoldoutValueRightShift = 5.5f;
         internal const float RowValueFoldoutLabelWidth = 2f;
         internal const float ExpandableValueFoldoutLabelWidth = 16f;
         internal const float PendingExpandableValueFoldoutGutter = 7f;
@@ -4454,6 +4451,10 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
                 Rect absoluteKeyRect = ConvertGroupRectToAbsolute(keyRect, containerRect);
 
                 float valueHeight = pendingMetrics.ValueHeight;
+                // Key and Value are one column stacked twice, so their rects are identical: same
+                // origin, same width, same label width, and for a foldout-capable value the same
+                // gutter. They are drawn by the same routine, so anything that moves one and not
+                // the other is a misalignment rather than a correction (#284).
                 Rect valueRect = new(
                     resolvedSectionPadding + indentOffset,
                     innerY,
@@ -4466,33 +4467,6 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
                 {
                     valueRect.x += pendingValueFoldoutOffset;
                     valueRect.width = Mathf.Max(0f, valueRect.width - pendingValueFoldoutOffset);
-                }
-                if (PendingValueContentLeftShift > 0f)
-                {
-                    float effectiveShift = PendingValueContentLeftShift;
-                    if (pendingValueSupportsFoldout && PendingFoldoutValueLeftShiftReduction > 0f)
-                    {
-                        effectiveShift = Mathf.Max(
-                            0f,
-                            effectiveShift - PendingFoldoutValueLeftShiftReduction
-                        );
-                    }
-
-                    if (effectiveShift > 0f)
-                    {
-                        float shift = Mathf.Min(
-                            effectiveShift,
-                            Mathf.Max(0f, valueRect.x - resolvedSectionPadding)
-                        );
-                        valueRect.x -= shift;
-                        valueRect.width += shift;
-                    }
-                }
-                if (pendingValueSupportsFoldout && PendingFoldoutValueRightShift > 0f)
-                {
-                    float shift = Mathf.Min(PendingFoldoutValueRightShift, valueRect.width);
-                    valueRect.x += shift;
-                    valueRect.width = Mathf.Max(0f, valueRect.width - shift);
                 }
                 using (new LabelWidthScope(PendingFieldLabelWidth))
                 {

--- a/Editor/CustomDrawers/SerializableSetPropertyDrawer.cs
+++ b/Editor/CustomDrawers/SerializableSetPropertyDrawer.cs
@@ -97,8 +97,7 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
         private const float ManualEntryFoldoutLabelContentOffset = 0f;
         private const float ManualEntryButtonWidth = 110f;
         private const float ManualEntryResetWidth = 70f;
-        private const float ManualEntryValueContentLeftShift = 8.5f;
-        private const float ManualEntryFoldoutValueLeftShiftReduction = 6f;
+        private const float ManualEntryFoldoutValueLeftShift = 2.5f;
         private const float ManualEntryFoldoutValueRightShift = 3f;
         private const float ManualEntryExpandableValueFoldoutGutter = 7f;
 
@@ -2665,25 +2664,27 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
                         valueRect.width - ManualEntryExpandableValueFoldoutGutter
                     );
                 }
-                float valueLeftShift = ManualEntryValueContentLeftShift;
+                // Only a foldout-capable value is nudged, and the arithmetic below is unchanged.
+                // It used to be spelled as an 8.5px left shift reduced by 6, applied unconditionally
+                // and then clamped by how far the rect had already moved past innerX. For a
+                // NON-foldout value that headroom is exactly zero, so the 8.5 could never apply:
+                // dead, under a name that read deliberate. The dictionary drawer had the same idiom
+                // with an indent term feeding the clamp, and there it was #284 itself.
                 if (valueSupportsFoldout)
                 {
-                    valueLeftShift = Mathf.Max(
-                        0f,
-                        valueLeftShift - ManualEntryFoldoutValueLeftShiftReduction
+                    float leftShift = Mathf.Min(
+                        ManualEntryFoldoutValueLeftShift,
+                        Mathf.Max(0f, valueRect.x - innerX)
                     );
-                }
-                if (valueLeftShift > 0f)
-                {
-                    float shift = Mathf.Min(valueLeftShift, Mathf.Max(0f, valueRect.x - innerX));
-                    valueRect.x -= shift;
-                    valueRect.width += shift;
-                }
-                if (valueSupportsFoldout && ManualEntryFoldoutValueRightShift > 0f)
-                {
-                    float shift = Mathf.Min(ManualEntryFoldoutValueRightShift, valueRect.width);
-                    valueRect.x += shift;
-                    valueRect.width = Mathf.Max(0f, valueRect.width - shift);
+                    valueRect.x -= leftShift;
+                    valueRect.width += leftShift;
+
+                    float rightShift = Mathf.Min(
+                        ManualEntryFoldoutValueRightShift,
+                        valueRect.width
+                    );
+                    valueRect.x += rightShift;
+                    valueRect.width = Mathf.Max(0f, valueRect.width - rightShift);
                 }
 
                 HasLastManualEntryValueRect = true;

--- a/Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj
@@ -42,6 +42,12 @@
     <NoWarn>$(NoWarn);CS0414;CS0649;CS0219;CS0618;CS0612;CS0436;CS1701</NoWarn>
     <DefineConstants Condition="'$(WallstopProto)' == 'true'"
       >$(DefineConstants);WALLSTOP_PROTO</DefineConstants>
+    <!-- See the TypeCheck project for why this exists (#347). The PlayMode fixtures behind the Odin
+         define derive from the same two base classes the runtime aliases, so the same shim serves
+         them; only the editor-side drawer surface is out of reach here. -->
+    <WallstopOdin Condition="'$(WallstopOdin)' == ''">false</WallstopOdin>
+    <DefineConstants Condition="'$(WallstopOdin)' == 'true'"
+      >$(DefineConstants);WALLSTOP_UNITY_HELPERS_ODIN_INSPECTOR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />

--- a/Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj
@@ -84,7 +84,19 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Shims/*.cs" />
-    <Compile Include="../WallstopStudios.UnityHelpers.TypeCheck/Shims/*.cs" />
+    <!-- Same split as the TypeCheck project, and it is load-bearing rather than tidy: an
+         unconditional glob compiles the Odin base classes into the define-off configurations,
+         where an UNGUARDED `Sirenix.OdinInspector` reference in a fixture would then bind and
+         pass. That is CS0246 in a real no-Odin Unity project, which is #275 one level down: the
+         gate masking the very class it was added to catch. -->
+    <Compile
+      Include="../WallstopStudios.UnityHelpers.TypeCheck/Shims/*.cs"
+      Exclude="../WallstopStudios.UnityHelpers.TypeCheck/Shims/OdinInspectorShim.cs"
+    />
+    <Compile
+      Include="../WallstopStudios.UnityHelpers.TypeCheck/Shims/OdinInspectorShim.cs"
+      Condition="'$(WallstopOdin)' == 'true'"
+    />
     <Compile
       Include="$(RepoRoot)/Runtime/**/*.cs"
       Exclude="$(RepoRoot)/Runtime/Integrations/**/*.cs;$(RepoRoot)/Runtime/Analyzers/**/*.cs;$(RepoRoot)/Runtime/Core/Extension/Partials/UI.cs;$(RepoRoot)/Runtime/Utils/MatchColliderToSprite.cs;$(RepoRoot)/Runtime/Visuals/UGUI/EnhancedImage.cs"

--- a/Generator~/WallstopStudios.UnityHelpers.TypeCheck/Shims/OdinInspectorShim.cs
+++ b/Generator~/WallstopStudios.UnityHelpers.TypeCheck/Shims/OdinInspectorShim.cs
@@ -1,0 +1,36 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+// Reference-only shim for the two Odin Inspector base classes the RUNTIME assembly aliases.
+//
+// Odin (com.sirenix.odininspector) is a paid asset with no NuGet equivalent, so the sources behind
+// WALLSTOP_UNITY_HELPERS_ODIN_INSPECTOR compiled NOWHERE in automation (#347) -- not here, not in
+// any Unity leg, not in the MCP editor. `RuntimeSingleton<T>` and `ScriptableObjectSingleton<T>` are
+// public API whose base class CHANGES when a consumer installs Odin, and that branch had never once
+// been compiled. #275 is that blind spot shipping a break to consumers.
+//
+// This shim compiles only under the `Odin` typecheck configuration, and only these two types are
+// declared, because the runtime assembly reaches Odin exclusively through `using` aliases:
+//
+//     Runtime/Tags/AttributeEffect.cs           -> SerializedScriptableObject
+//     Runtime/Utils/RuntimeSingleton.cs         -> SerializedMonoBehaviour
+//     Runtime/Utils/ScriptableObjectSingleton.cs -> SerializedScriptableObject
+//
+// The EDITOR-side Odin surface (OdinAttributeDrawer, InspectorProperty, OdinEditor) is deliberately
+// NOT shimmed. Compiling those drawers means compiling the whole Editor assembly, which needs a
+// UnityEditor reference the community reference assemblies do not carry. That half is covered by the
+// Unity `odin-compile` leg instead, which uses a real editor and the stub UPM package under
+// `scripts/unity/stubs/`.
+//
+// Mirroring the real base classes matters: declaring a member the real type does not have would let
+// a genuine error through. Both are plain derivations in Odin -- they exist to route serialization
+// through Odin's serializer, which is behaviour rather than surface, and behaviour is not what a
+// type-checker asserts.
+namespace Sirenix.OdinInspector
+{
+    using UnityEngine;
+
+    public abstract class SerializedMonoBehaviour : MonoBehaviour { }
+
+    public abstract class SerializedScriptableObject : ScriptableObject { }
+}

--- a/Generator~/WallstopStudios.UnityHelpers.TypeCheck/Shims/OdinInspectorShim.cs
+++ b/Generator~/WallstopStudios.UnityHelpers.TypeCheck/Shims/OdinInspectorShim.cs
@@ -17,10 +17,13 @@
 //     Runtime/Utils/ScriptableObjectSingleton.cs -> SerializedScriptableObject
 //
 // The EDITOR-side Odin surface (OdinAttributeDrawer, InspectorProperty, OdinEditor) is deliberately
-// NOT shimmed. Compiling those drawers means compiling the whole Editor assembly, which needs a
-// UnityEditor reference the community reference assemblies do not carry. That half is covered by the
-// Unity `odin-compile` leg instead, which uses a real editor and the stub UPM package under
-// `scripts/unity/stubs/`.
+// NOT shimmed, and it is STILL COMPILED BY NOTHING -- do not read this file as covering it.
+// Compiling those drawers means compiling the whole Editor assembly, because WButtonOdinInspectorHelper
+// pulls in Editor/Utils/WButton/**, and that needs a UnityEditor reference the community reference
+// assemblies do not carry. Shimming UnityEditor to reach it would be a large fabricated surface
+// guarding a small real one. The vehicle that would work is a real editor with a stub `odininspector`
+// UPM package injected into the generated test project, compile-only. Neither exists yet; both are
+// tracked on #347.
 //
 // Mirroring the real base classes matters: declaring a member the real type does not have would let
 // a genuine error through. Both are plain derivations in Odin -- they exist to route serialization

--- a/Generator~/WallstopStudios.UnityHelpers.TypeCheck/WallstopStudios.UnityHelpers.TypeCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.TypeCheck/WallstopStudios.UnityHelpers.TypeCheck.csproj
@@ -63,8 +63,9 @@
       nowhere in automation until #347. Odin is paid and has no NuGet package, so `Shims/
       OdinInspectorShim.cs` declares the two base classes the runtime aliases and nothing else.
       `npm run typecheck:unity` builds this project a third time with it on. The editor-side Odin
-      surface is out of reach here (it needs UnityEditor) and is covered by the Unity `odin-compile`
-      leg instead.
+      surface (nine drawers, three inspectors) is out of reach here and is therefore STILL COMPILED
+      BY NOTHING: reaching it means compiling the whole Editor assembly, which needs a UnityEditor
+      reference the community assemblies do not carry. Tracked on #347.
     -->
     <WallstopOdin Condition="'$(WallstopOdin)' == ''">false</WallstopOdin>
     <DefineConstants Condition="'$(WallstopOdin)' == 'true'"

--- a/Generator~/WallstopStudios.UnityHelpers.TypeCheck/WallstopStudios.UnityHelpers.TypeCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.TypeCheck/WallstopStudios.UnityHelpers.TypeCheck.csproj
@@ -58,6 +58,17 @@
     -->
     <DefineConstants Condition="'$(WallstopProto)' == 'true'"
       >$(DefineConstants);WALLSTOP_PROTO</DefineConstants>
+    <!--
+      Odin Inspector changes the BASE CLASS of two public runtime types, and that branch compiled
+      nowhere in automation until #347. Odin is paid and has no NuGet package, so `Shims/
+      OdinInspectorShim.cs` declares the two base classes the runtime aliases and nothing else.
+      `npm run typecheck:unity` builds this project a third time with it on. The editor-side Odin
+      surface is out of reach here (it needs UnityEditor) and is covered by the Unity `odin-compile`
+      leg instead.
+    -->
+    <WallstopOdin Condition="'$(WallstopOdin)' == ''">false</WallstopOdin>
+    <DefineConstants Condition="'$(WallstopOdin)' == 'true'"
+      >$(DefineConstants);WALLSTOP_UNITY_HELPERS_ODIN_INSPECTOR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
@@ -92,7 +103,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Shims/*.cs" />
+    <!-- The Odin shim is inert without the define, so it is included only where it is meaningful:
+         declaring the two base classes in every configuration would compile types nothing binds. -->
+    <Compile Include="Shims/*.cs" Exclude="Shims/OdinInspectorShim.cs" />
+    <Compile Include="Shims/OdinInspectorShim.cs" Condition="'$(WallstopOdin)' == 'true'" />
     <!-- The main runtime asmdef's scope, minus the exclusions documented at the top. -->
     <Compile
       Include="$(RepoRoot)/Runtime/**/*.cs"

--- a/PLAN.md
+++ b/PLAN.md
@@ -151,6 +151,27 @@ only open work.
   nested drawer that leaked one of its own; and **`using` declarations**, which let a nineteen-site
   sweep land without re-indenting a single existing block.
 
+- **#284 — a constant whose only effect was the bug, session 188.** A `SerializableDictionary`'s
+  pending "Add entry" section draws Key and Value as one column stacked twice — same origin, same
+  width, same label width, and for `<string,string>` literally the same `EditorGUI.TextField` call.
+  It then shifted the Value rect left by `Min(8.5f, valueRect.x - sectionPadding)`, and that clamp
+  measures its headroom from the **indent**: 0 at indent 0, 8.5 everywhere else. So
+  `PendingValueContentLeftShift` was inert exactly where it looked deliberate and misaligned
+  everywhere else — *its entire observable effect anywhere in the drawer was to produce the defect*.
+  For a foldout value it and `PendingFoldoutValueRightShift` cancel at every indent, so deleting
+  both left that path unchanged.
+
+  *Three lessons, two of them repeats.* **A suite can assert the bug as the contract** (#358 said
+  this; third session running) — four assertions across three tests pinned the 8.5px gap, one of
+  them named `PendingEntryKeyAndValueAlignedWithWGroupPaddingAndIndent`, which is the reporter's
+  exact configuration asserting a misalignment while calling itself *Aligned*. **A loose tolerance
+  is how a re-baseline hides**: those assertions used `Within(1f)` on an 8.5px quantity, wide enough
+  to accept either answer, so the re-baseline had to *tighten* to `0.01f` rather than just flip the
+  number. And **"in some scenarios" in a bug report is a hypothesis to resolve, not a caveat to
+  accept**: it meant "whenever a WGroup is anywhere above it", because `WGroup` renders any member
+  with visible children at indent 1 while outdenting leaves, and `WGroupAutoIncludeMode` defaults to
+  `Infinite` — so the reporter's un-annotated dictionary was swallowed into the group above it.
+
 - **CI Failure Remediation: Standalone IL2CPP + PlayMode** — closed as a gate. Every Unity leg has been
   green since PR `272`. Its one still-open thread, the protobuf-net AOT failure under IL2CPP, is the
   subject of the WallstopProto design item below; the rest was root-cause history for fixes that have
@@ -192,6 +213,34 @@ Sibling contention was ruled out for that window: no Ambiguous-Interactive repo 
 DoxReloaded, IshoBoy, qora-redux) touched the self-hosted runners while ours sat idle.
 
 ### Done
+
+- **#347 — the Odin branch was compiled by nothing, session 188.** Not the 16 files the issue
+  records: **192**, once the ~176 test files behind the same define are counted. The define comes
+  from a `versionDefines` entry keyed on the `odininspector` package, which no CI project declares —
+  and the MCP editor does not have Odin either, so there was no local fallback. The part that makes
+  it a shipping risk rather than a coverage statistic: **Odin changes the base class** of
+  `RuntimeSingleton<T>`, `ScriptableObjectSingleton<T>` and `AttributeEffect` through a `using`
+  alias, so three public types had an entirely uncompiled second form. #275 is that shipping to
+  consumers.
+
+  The surface was measured before anything was built, and it is two types
+  (`SerializedMonoBehaviour`, `SerializedScriptableObject`) for the whole runtime assembly. A shim
+  declaring exactly those, plus a third configuration on `TypeCheck`/`TestCheck`, closes the runtime
+  half for ~15 s of the `typecheck:unity` chain, which `Local Gates` already runs.
+
+  *Proven discriminating, which is the only thing that makes a new gate worth having.* Retyping the
+  alias to a nonexistent Sirenix type leaves the **default** configuration green and fails the
+  **Odin** one — a defect that lives only in the branch nothing compiled, caught by the thing built
+  to compile it.
+
+  **Still open on #347: the editor-side half** (nine drawers, three inspectors). It cannot be
+  reached from a `Generator~` project, because `WButtonOdinInspectorHelper` pulls in
+  `Editor/Utils/WButton/**` and therefore the whole Editor assembly, which needs a `UnityEditor`
+  reference the community assemblies do not carry. Shimming `UnityEditor` would be a large fake
+  surface guarding a small real one. The vehicle is a Unity leg with a stub `odininspector` UPM
+  package injected into the generated project — the `versionDefines` entry then sets the define with
+  no asmdef change at all — modelled on `unitypackage-smoke` (hosted runner, org lock, no
+  self-hosted slot). Compile-only: the ~176 Odin fixtures would *run* against a no-op stub and fail.
 
 - **#428 — one red check on a green pull request is not ours, session 186.** The automatic
   `copilot-pull-request-reviewer` fails with HTTP 402 (`exceeded your monthly quota`) before reading
@@ -1529,7 +1578,31 @@ byte-diff oracle has to expect that asymmetry rather than flag it.
   **What is left on #399**, each independent of the above:
   - **Rectangular arrays (`int[,]`)** are still `WPROTO003`, and they are a different question rather
     than the same one unfinished: there is no per-row structure to wrap, so reconstructing one needs
-    its dimensions carried in the payload. Tracked separately.
+    its dimensions carried in the payload. Tracked on **#434**, and scoped in session 188:
+
+    *There is no oracle, confirmed rather than assumed.* protobuf-net refuses `int[,]` at **write**
+    on both majors -- 2.4.9 with a dedicated multi-dimensional message, 3.2.56 through its generic
+    repeated refusal -- so no payload with this shape exists for either side to read. The encoding
+    is ours to define, under the owner's 2026-08-13 condition that it map to a concrete proto3 type.
+    A `TheOracleRefusesEveryRectangularShape` fixture must assert **both** oracle legs, because the
+    two majors throw different messages and the existing `Contains("Nested or jagged")` assertion
+    would not survive.
+
+    *The blocking question is not code.* A `dims` header is a **capacity claim**, not a length
+    prefix, which is critical rule 17 exactly: six bytes can state `[46341, 46341]` and ask for 8 GB.
+    It must be refused with `SerializationCapacityLimits.TryAccept` unless the product of `dims`,
+    computed in `long` so it cannot overflow into something plausible, equals the delivered element
+    count. Two more decisions before anything is written: a zero-length dimension (`new int[0,5]`)
+    has real shape and no elements, so `dims` must be written even when `values` is empty -- the
+    opposite of the omit-empty rule everywhere else -- and rank is a **compile-time** property of
+    the member's declared type, so the generator can emit `new T[a, b]` directly and never needs
+    `Array.CreateInstance` or a runtime rank at all.
+
+    *The insertion points are small and known*: `RepeatedMember.cs:111` (the `array.Rank == 1`
+    gate), `Shape.cs:374` (the last-resort hook that already routes an unwrappable collection to a
+    generated message), `NestedCollections.TryShape` (which currently drops anything that is not a
+    `RepeatedMember`/`MapMember`), and the `WPROTO003` message text. Three `DiagnosticTests` cases
+    pin the refusal today and must invert; there is no `int[,,]` or `T[,]`-in-a-generic case yet.
   - **The contract surveys** of the wallstop and Ambiguous-Interactive repositories, and the
     remaining stdlib types, which the wrapper encoding does not change either way.
 - **#398 — the read path's own allocation is closed, session 186.** The issue asked for a benchmark

--- a/Tests/Editor/CustomDrawers/SerializableDictionaryPropertyDrawerTests.cs
+++ b/Tests/Editor/CustomDrawers/SerializableDictionaryPropertyDrawerTests.cs
@@ -3175,10 +3175,7 @@ namespace WallstopStudios.UnityHelpers.Tests.CustomDrawers
             Rect keyRect = SerializableDictionaryPropertyDrawer.LastPendingKeyFieldRect;
             Rect valueRect = SerializableDictionaryPropertyDrawer.LastPendingValueFieldRect;
 
-            // At indent level 0, there's no room to shift the value field left because
-            // valueRect.x is already at the minimum position (PendingSectionPadding).
-            // The shift is calculated as Min(PendingValueContentLeftShift, valueRect.x - resolvedSectionPadding),
-            // which equals 0 at indent level 0. Both fields should start at the same xMin.
+            // Both fields start at the same xMin, at this and every other indent level.
             float actualShift = keyRect.xMin - valueRect.xMin;
 
             TestContext.WriteLine(
@@ -3414,27 +3411,25 @@ namespace WallstopStudios.UnityHelpers.Tests.CustomDrawers
                 Rect keyRect = SerializableDictionaryPropertyDrawer.LastPendingKeyFieldRect;
                 Rect valueRect = SerializableDictionaryPropertyDrawer.LastPendingValueFieldRect;
 
-                float expectedShift =
-                    SerializableDictionaryPropertyDrawer.PendingValueContentLeftShift;
                 float actualShift = keyRect.xMin - valueRect.xMin;
 
                 TestContext.WriteLine(
                     $"[PendingEntryKeyAndValueAlignedAtIndentLevel{indentLevel}] "
                         + $"keyRect.xMin={keyRect.xMin:F3}, valueRect.xMin={valueRect.xMin:F3}, "
                         + $"keyRect.width={keyRect.width:F3}, valueRect.width={valueRect.width:F3}, "
-                        + $"expectedShift={expectedShift:F3}, actualShift={actualShift:F3}"
+                        + $"actualShift={actualShift:F3}"
                 );
 
                 Assert.That(
                     actualShift,
-                    Is.EqualTo(expectedShift).Within(1f),
-                    $"Value field should be shifted left by PendingValueContentLeftShift ({expectedShift}px) at indent level {indentLevel}."
+                    Is.EqualTo(0f).Within(0.01f),
+                    $"Key and Value are one column stacked twice, so they must share an origin at indent level {indentLevel} (#284)."
                 );
 
                 Assert.That(
                     valueRect.width - keyRect.width,
-                    Is.EqualTo(expectedShift).Within(1f),
-                    $"Value field should be wider than key field by PendingValueContentLeftShift ({expectedShift}px) at indent level {indentLevel}."
+                    Is.EqualTo(0f).Within(0.01f),
+                    $"Key and Value must share a width at indent level {indentLevel} (#284)."
                 );
             }
         }
@@ -3503,29 +3498,23 @@ namespace WallstopStudios.UnityHelpers.Tests.CustomDrawers
                 {
                     Rect keyRect = SerializableDictionaryPropertyDrawer.LastPendingKeyFieldRect;
                     Rect valueRect = SerializableDictionaryPropertyDrawer.LastPendingValueFieldRect;
-                    float pendingShift =
-                        SerializableDictionaryPropertyDrawer.PendingValueContentLeftShift;
                     float sectionPadding =
                         SerializableDictionaryPropertyDrawer.GetPendingSectionPaddingForTests();
                     float actualShift = keyRect.xMin - valueRect.xMin;
 
                     TestContext.WriteLine($"  keyRect           = {keyRect}");
                     TestContext.WriteLine($"  valueRect         = {valueRect}");
-                    TestContext.WriteLine($"  PendingValueContentLeftShift = {pendingShift:F3}px");
                     TestContext.WriteLine($"  SectionPadding    = {sectionPadding:F3}px");
                     TestContext.WriteLine($"  actualShift       = {actualShift:F3}px");
 
-                    // At indent level 0, expect no shift (fields aligned at same xMin)
-                    // At indent level 1+, expect shift of PendingValueContentLeftShift
-                    float expectedShift = indentLevel == 0 ? 0f : pendingShift;
-                    TestContext.WriteLine(
-                        $"  expectedShift     = {expectedShift:F3}px (indent={indentLevel})"
-                    );
-
+                    // The columns share an origin at every indent level. This used to expect
+                    // 8.5px at indent 1+, which was the defect in #284 written down as the
+                    // contract: the shift's clamp measured its headroom from the indent, so it
+                    // was inert at indent 0 and moved only the Value column everywhere else.
                     Assert.That(
                         actualShift,
-                        Is.EqualTo(expectedShift).Within(1f),
-                        $"At indent level {indentLevel}, expected shift of {expectedShift:F3}px but got {actualShift:F3}px."
+                        Is.EqualTo(0f).Within(0.01f),
+                        $"At indent level {indentLevel}, Key and Value must share an origin but differed by {actualShift:F3}px."
                     );
                 }
                 else
@@ -3713,7 +3702,6 @@ namespace WallstopStudios.UnityHelpers.Tests.CustomDrawers
             Rect keyRect = SerializableDictionaryPropertyDrawer.LastPendingKeyFieldRect;
             Rect valueRect = SerializableDictionaryPropertyDrawer.LastPendingValueFieldRect;
 
-            float expectedShift = SerializableDictionaryPropertyDrawer.PendingValueContentLeftShift;
             float actualShift = keyRect.xMin - valueRect.xMin;
 
             TestContext.WriteLine(
@@ -3721,19 +3709,22 @@ namespace WallstopStudios.UnityHelpers.Tests.CustomDrawers
                     + $"keyRect.xMin={keyRect.xMin:F3}, valueRect.xMin={valueRect.xMin:F3}, "
                     + $"keyRect.width={keyRect.width:F3}, valueRect.width={valueRect.width:F3}, "
                     + $"LeftPadding={LeftPadding}, IndentLevel={IndentLevel}, "
-                    + $"expectedShift={expectedShift:F3}, actualShift={actualShift:F3}"
+                    + $"actualShift={actualShift:F3}"
             );
 
+            // This is the reporter's configuration in #284 -- a dictionary inside a WGroup, which
+            // draws its members at indent 1 -- and it is the case this fixture asserted an 8.5px
+            // offset for while calling itself "Aligned".
             Assert.That(
                 actualShift,
-                Is.EqualTo(expectedShift).Within(1f),
-                $"Value field should be shifted left by PendingValueContentLeftShift ({expectedShift}px) with WGroup padding and indent."
+                Is.EqualTo(0f).Within(0.01f),
+                "Key and Value must share an origin with WGroup padding and indent (#284)."
             );
 
             Assert.That(
                 valueRect.width - keyRect.width,
-                Is.EqualTo(expectedShift).Within(1f),
-                $"Value field should be wider than key field by PendingValueContentLeftShift ({expectedShift}px) with WGroup padding and indent."
+                Is.EqualTo(0f).Within(0.01f),
+                "Key and Value must share a width with WGroup padding and indent (#284)."
             );
         }
 
@@ -3985,20 +3976,18 @@ namespace WallstopStudios.UnityHelpers.Tests.CustomDrawers
             Rect keyRect = SerializableDictionaryPropertyDrawer.LastPendingKeyFieldRect;
             Rect valueRect = SerializableDictionaryPropertyDrawer.LastPendingValueFieldRect;
 
-            float expectedShift = SerializableDictionaryPropertyDrawer.PendingValueContentLeftShift;
             float actualShift = keyRect.xMin - valueRect.xMin;
 
             TestContext.WriteLine(
                 $"[PendingEntryKeyAndValueAlignedWithSortedDictionary] "
                     + $"keyRect.xMin={keyRect.xMin:F3}, valueRect.xMin={valueRect.xMin:F3}, "
-                    + $"IndentLevel={IndentLevel}, "
-                    + $"expectedShift={expectedShift:F3}, actualShift={actualShift:F3}"
+                    + $"IndentLevel={IndentLevel}, actualShift={actualShift:F3}"
             );
 
             Assert.That(
                 actualShift,
-                Is.EqualTo(expectedShift).Within(1f),
-                $"Value field should be shifted left by PendingValueContentLeftShift ({expectedShift}px) for sorted dictionary."
+                Is.EqualTo(0f).Within(0.01f),
+                "Key and Value must share an origin for a sorted dictionary (#284)."
             );
         }
 

--- a/package.json
+++ b/package.json
@@ -46,52 +46,52 @@
   "licensesUrl": "https://ambiguous-interactive.github.io/unity-helpers/project/license/",
   "samples": [
     {
-      "displayName": "DI \u2013 VContainer",
+      "displayName": "DI – VContainer",
       "description": "LifetimeScope registration, scene-wide assignment, and runtime BuildUpWithRelations.",
       "path": "Samples~/DI - VContainer"
     },
     {
-      "displayName": "DI \u2013 Zenject",
+      "displayName": "DI – Zenject",
       "description": "SceneContext installer, scene-wide assignment, and prefab instantiation with relations.",
       "path": "Samples~/DI - Zenject"
     },
     {
-      "displayName": "DI \u2013 Reflex",
+      "displayName": "DI – Reflex",
       "description": "SceneScope installer, scene scan, and runtime Container helpers.",
       "path": "Samples~/DI - Reflex"
     },
     {
-      "displayName": "Relational Components \u2013 Basic",
+      "displayName": "Relational Components – Basic",
       "description": "Attribute-based auto-wiring without DI; parent/sibling/child examples.",
       "path": "Samples~/Relational Components - Basic"
     },
     {
-      "displayName": "Serialization \u2013 JSON",
+      "displayName": "Serialization – JSON",
       "description": "System.Text.Json with Unity converters; pretty and fast options.",
       "path": "Samples~/Serialization - JSON"
     },
     {
-      "displayName": "Random \u2013 PRNG",
+      "displayName": "Random – PRNG",
       "description": "PCG seeds, floats, Gaussian, and list sampling.",
       "path": "Samples~/Random - PRNG"
     },
     {
-      "displayName": "Logging \u2013 Tag Formatter",
+      "displayName": "Logging – Tag Formatter",
       "description": "UnityLogTagFormatter decorators, runtime toggles, and logging extension demos.",
       "path": "Samples~/Logging - Tag Formatter"
     },
     {
-      "displayName": "Spatial Structures \u2013 2D and 3D",
+      "displayName": "Spatial Structures – 2D and 3D",
       "description": "QuadTree2D, KdTree2D nearest neighbors, SpatialHash2D queries.",
       "path": "Samples~/Spatial Structures - 2D and 3D"
     },
     {
-      "displayName": "UI Toolkit \u2013 MultiFile Selector (Editor)",
+      "displayName": "UI Toolkit – MultiFile Selector (Editor)",
       "description": "EditorWindow using MultiFileSelectorElement for multi-file picking.",
       "path": "Samples~/UI Toolkit - MultiFile Selector (Editor)"
     },
     {
-      "displayName": "UGUI \u2013 EnhancedImage",
+      "displayName": "UGUI – EnhancedImage",
       "description": "Programmatic Canvas setup and HDR-tinted EnhancedImage.",
       "path": "Samples~/UGUI - EnhancedImage"
     }
@@ -194,12 +194,14 @@
     "test:analyzer-placement": "node scripts/tests/test-analyzer-placement.js",
     "test:wproto-annotations": "node scripts/tests/test-wproto-annotations.js",
     "test:out-parameters": "node scripts/tests/test-out-parameter-discipline.js",
-    "typecheck:unity": "npm run typecheck:unity:default && npm run typecheck:unity:legacy && npm run typecheck:tests",
+    "typecheck:unity": "npm run typecheck:unity:default && npm run typecheck:unity:legacy && npm run typecheck:unity:odin && npm run typecheck:tests",
     "typecheck:unity:default": "dotnet build \"Generator~/WallstopStudios.UnityHelpers.TypeCheck/WallstopStudios.UnityHelpers.TypeCheck.csproj\" --nologo -v quiet",
     "typecheck:unity:legacy": "dotnet build \"Generator~/WallstopStudios.UnityHelpers.TypeCheck/WallstopStudios.UnityHelpers.TypeCheck.csproj\" --nologo -v quiet -p:WallstopProto=false",
-    "typecheck:tests": "npm run typecheck:tests:default && npm run typecheck:tests:legacy",
+    "typecheck:unity:odin": "dotnet build \"Generator~/WallstopStudios.UnityHelpers.TypeCheck/WallstopStudios.UnityHelpers.TypeCheck.csproj\" --nologo -v quiet -p:WallstopOdin=true",
+    "typecheck:tests": "npm run typecheck:tests:default && npm run typecheck:tests:legacy && npm run typecheck:tests:odin",
     "typecheck:tests:default": "dotnet build \"Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj\" --nologo -v quiet",
     "typecheck:tests:legacy": "dotnet build \"Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj\" --nologo -v quiet -p:WallstopProto=false",
+    "typecheck:tests:odin": "dotnet build \"Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj\" --nologo -v quiet -p:WallstopOdin=true",
     "test:validate-git-push-config": "pwsh -NoProfile -File scripts/tests/test-validate-git-push-config.ps1 -VerboseOutput",
     "test:validate-lint-error-codes": "pwsh -NoProfile -File scripts/tests/test-validate-lint-error-codes.ps1 -VerboseOutput",
     "test:precommit-integration": "bash scripts/tests/test-precommit-integration.sh",


### PR DESCRIPTION
Two independent fixes, both of the same shape: something that looked covered was not.

## 1. The Odin branch was compiled by nothing (#347, #275)

`WALLSTOP_UNITY_HELPERS_ODIN_INSPECTOR` comes from a `versionDefines` entry keyed on the
`odininspector` package. No CI project declares that package, so **192 files behind the define were
compiled by no automation at all** — not the typecheck projects, not any Unity leg, and not the MCP
editor, which does not have Odin installed either. The issue records "16 files"; that is the
production subset, before the ~176 test files.

The urgent part is not the count. **Odin changes the base class** of `RuntimeSingleton<T>`,
`ScriptableObjectSingleton<T>` and `AttributeEffect` through a `using` alias, so three public types
had an entirely uncompiled second form. [#275](https://github.com/Ambiguous-Interactive/unity-helpers/issues/275)
is that blind spot shipping a compile break to consumers.

Measured before building: the whole Sirenix surface the **runtime** assembly touches is two types.
So the shim declares those two and nothing else — declaring a member the real type lacks would let a
genuine error through. `TypeCheck` and `TestCheck` each gain a third configuration behind a
`WallstopOdin` property; `typecheck:unity` now builds six, and `Local Gates` already runs it.
**~15s** added to a 3m38s chain.

**Proven discriminating, which is the only thing that makes a new gate worth having.** Retyping the
alias to a nonexistent Sirenix type:

| configuration | result |
| --- | --- |
| default | green |
| Odin | **red (CS0234)** |

A defect living only in the branch nothing compiled, caught by the thing built to compile it.

**The editor-side half is still open, and option (2) as written on #347 cannot work** —
`WButtonOdinInspectorHelper` pulls in the whole Editor assembly, which needs a `UnityEditor`
reference the community assemblies do not carry. The working vehicle (stub `odininspector` UPM
package + a compile-only hosted leg modelled on `unitypackage-smoke`) is recorded on the issue and
in PLAN.md rather than left implied.

## 2. A dictionary's pending Key and Value columns were misaligned (#284)

The "Add entry" section draws Key and Value as one column stacked twice — same origin, same width,
same 72px label width, and for `<string,string>` literally the same `EditorGUI.TextField` call. It
then shifted the Value rect left by `Min(8.5f, valueRect.x - sectionPadding)`.

That clamp measures its headroom from the **indent**:

| indent | `keyRect.x` | `valueRect.x` | gap |
| ---: | ---: | ---: | ---: |
| 0 | 6.0 | 6.0 | **0** |
| 1 | 21.0 | 12.5 | **8.5** |

So `PendingValueContentLeftShift` was inert exactly where it looked deliberate and misaligned
everywhere else — **its entire observable effect anywhere in the drawer was to produce the defect**.
For a foldout value it and `PendingFoldoutValueRightShift` cancel at every indent, so removing both
leaves that path unchanged. All three constants are gone.

The reporter never annotated their dictionary: `WGroup` renders any member with visible children at
indent 1 (leaves get indent compensation; dictionaries have `_keys`/`_values`, so they do not), and
`WGroupAutoIncludeMode` defaults to `Infinite`, so it was swallowed into the group above it. "In
some scenarios" meant "whenever a WGroup is anywhere above it".

**Four assertions across three tests pinned the offset as the contract** — one of them named
`PendingEntryKeyAndValueAlignedWithWGroupPaddingAndIndent`, the reporter's exact configuration,
asserting an 8.5px gap while calling itself *Aligned*. Re-baselined to `0` within **0.01px**, not the
original `Within(1f)`, which was loose enough on an 8.5px quantity to accept either answer.

## Investigated, deliberately not changed

Both root-caused; neither shipped, for the same reason — the fix that closes the class needs
evidence this container cannot produce. Full findings posted to the issues.

- **[#280](https://github.com/Ambiguous-Interactive/unity-helpers/issues/280)** — the deferral is
  not the bug and cannot be; Unity guards *every* `OnValidate`. `HasMatchingSubAsset` loads every
  object at a path and throws them all away to answer a pure `Type` question, once per
  (watcher × path). `FindAssets("t:X")` answers it from the index, but matches on **short type
  name** and needs post-import freshness measured on all four matrix editors — shipping it unverified
  would trade warning spam for watchers that silently stop firing. Also found:
  `SubAssetLoadDoesNotEmitSendMessageWarnings` **cannot fail** (its fixture is a solid-colour PNG
  with no `OnValidate` anywhere).
- **[#434](https://github.com/Ambiguous-Interactive/unity-helpers/issues/434)** — confirmed **no
  oracle exists**: protobuf-net refuses `int[,]` at *write* on both majors. Rank is compile-time, so
  the generator can emit `new T[a, b]` and never needs `Array.CreateInstance`. The `dims` header is
  a **capacity claim**, not a length prefix — critical rule 17, `TryAccept`, product computed in
  `long`. Four insertion points named.

## Filed

- **[#439](https://github.com/Ambiguous-Interactive/unity-helpers/issues/439)** — the
  `AssetPostprocessor` forbidden-API contract is a textual scan of the callback body, and two frames
  of indirection defeat it. `DetectAssetChangeProcessor` already has such a path.

## Verification

| Gate | Result |
| --- | --- |
| `npm run typecheck:unity` (6 configurations) | green, 3m38s |
| Odin gate mutation | default green / Odin **red**, as designed |
| `npm run agent:preflight` | green on every commit |
| `scripts/lint-tests.ps1` | green |
| Unity MCP 6000.x recompile | **zero console errors** |

The drawer change is geometry and its assertions are EditMode tests this devcontainer has no license
to run — the four editmode legs are what confirm them. The tolerance was tightened to 0.01px
specifically so a wrong answer cannot pass them.

Closes #284
Refs #347, #275, #280, #434, #439

---

## Adversarial review round (post-first-run)

The first push settled at **54 green repository-owned checks, 0 failures** — all eight
editmode/playmode legs, all four IL2CPP standalone legs, `SINGLE_THREADED`, export smoke and
`Unity CI Success`. So the #284 re-baselining is adjudicated by four real editors, not asserted.

A critical review of the diff then found three real defects, all fixed in `e2b0ebf6`:

1. **The new gate had a hole that defeated its own purpose.** `TestCheck.csproj` pulled the shared
   shims in with an unconditional glob, so the Odin base classes compiled into **every**
   configuration. An **unguarded** `Sirenix.OdinInspector` reference in a PlayMode fixture therefore
   bound and passed with the define off — `CS0246` in a real no-Odin project. #275 one level down,
   inside the thing built to catch #275. Proven fixed: an ungated probe now fails
   `typecheck:tests:default` with CS0246 and passes `typecheck:tests:odin`. Before the fix it passed
   both.
2. **Two comments described a CI leg and a stub directory that do not exist** (`odin-compile`,
   `scripts/unity/stubs/`) and contradicted `.llm/context.md` from the same commit. A reader trusting
   them would believe the nine drawers were gated and ship the next #275.
3. **The sweep was incomplete.** `SerializableSetPropertyDrawer` carries the same idiom without the
   same bug — no key column, no indent term feeding the clamp — but
   `ManualEntryValueContentLeftShift` is **provably dead** (non-foldout headroom is exactly zero).
   Dead path deleted; foldout arithmetic preserved exactly, degenerate-width clamps included, so
   nothing moves on screen.

The review also **refuted** three suspicions, recorded as settled: `abstract` on the shim types is
correct and moot either way; the foldout shifts really do cancel bit-for-bit at every indent; and the
shared `obj/` across configurations costs a recompile per flip but **cannot** produce a false pass,
because MSBuild captures `DefineConstants` in `CoreCompileInputs.cache`.

## On the one red check

`copilot-pull-request-reviewer` fails with the #428 signature: `event: dynamic`, no workflow in
`.github/workflows/`, ~45s, **zero** inline comments. It is not a repository-owned check and nothing
here can turn it green. Recorded rather than chased, per
[ship-changes Step 10](./.llm/skills/ship-changes.md); the bot is not re-requested by hand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are editor IMGUI layout, local typecheck gates, and test expectations; runtime serialization behavior is unchanged and Odin editor code is still not compiled in CI.
> 
> **Overview**
> **Odin runtime branch in CI** — Adds a third `typecheck:unity` / `typecheck:tests` build with `WALLSTOP_UNITY_HELPERS_ODIN_INSPECTOR`, using `OdinInspectorShim.cs` for `SerializedMonoBehaviour` and `SerializedScriptableObject` so types that switch base class under Odin compile in automation. The Odin shim is included only when `WallstopOdin=true`; TestCheck avoids compiling the shim in define-off configs so fixtures cannot bind fake Odin types incorrectly. Docs and `package.json` scripts document the six-configuration gate; editor Odin drawers remain uncovered (#347).
> 
> **SerializableDictionary / SerializableSet inspector alignment (#284)** — Removes the pending-entry Value rect left-shift (`PendingValueContentLeftShift` and related foldout nudges) so Key and Value share the same origin and width at every indent, including inside `WGroup`. SerializableSet manual-entry foldout nudging is limited to foldout-capable values with clearer constants. EditMode tests re-baseline from asserting an 8.5px offset to **0** within **0.01px**.
> 
> **Housekeeping** — CHANGELOG entry for #284; `package.json` sample display names use en-dash; PLAN.md notes on #284, #347, and #434 scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b0ebf68738ebff0d50f5891e18a12c07de4c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->