### PR TITLE
Run sixty lint checks at once, and find the owner instead of naming it

### DIFF
--- a/.github/workflows/repo-lint.yml
+++ b/.github/workflows/repo-lint.yml
@@ -13,16 +13,23 @@ name: Repo Lint
 # scripts/tests/test-run-repo-lint.js asserts no linter in scripts/ has been left unreachable.
 #
 # The checks run concurrently, one worker per core, which is why this is still one job rather than
-# the balanced matrix the plan proposed. Measured on `main`:
+# the balanced matrix the plan proposed. All three rows measured, none projected:
 #
 #   20 workflows (before #444)   128 s wall clock   ~730 s billable
 #   1 serial job (#444)          317 s wall clock    317 s billable
-#   1 concurrent job (this)      ~110 s wall clock  ~110 s billable
+#   1 concurrent job (this)      179 s wall clock    179 s billable   (147 s in Repository checks)
 #
-# A 3-leg matrix would have reached roughly the same wall clock at three times the billable cost,
-# because each leg pays its own boot, checkout and npm install. Concurrency inside the job pays none
-# of that: the checks are independent processes that only read the tree. The runner takes `--jobs`
-# and defaults to the core count, so nothing here needs to know how large the runner is.
+# Concurrency inside the job pays the boot, checkout and npm install once, where a 3-leg matrix pays
+# them three times: the checks are independent processes that only read the tree. The runner takes
+# `--jobs` and defaults to the core count, so nothing here needs to know how large the runner is.
+#
+# The speedup on this runner is 1.93x (284 s -> 147 s), NOT the ~3x that four cores suggests and
+# eight real cores deliver locally (5.12x). Hosted vCPUs are shared, and the tail is bounded by the
+# slowest single check. Wall clock is therefore still ~40% above the twenty-workflow fan-out while
+# billable is 4.1x better than it -- a deliberate trade, and the honest numbers for anyone revisiting
+# it. Sharding on top of this would buy roughly 179 s -> 70 s for about +30 s billable; it has not
+# been done because a three-minute lint signal is nowhere near the critical path behind a 40-minute
+# Unity matrix.
 #
 # Deliberately NOT folded in:
 #   * LLM Instructions Lint runs the skills-index generator on Windows as well, to catch a

--- a/.github/workflows/repo-lint.yml
+++ b/.github/workflows/repo-lint.yml
@@ -12,6 +12,18 @@ name: Repo Lint
 # going after a failure and reports every failing check at once, and
 # scripts/tests/test-run-repo-lint.js asserts no linter in scripts/ has been left unreachable.
 #
+# The checks run concurrently, one worker per core, which is why this is still one job rather than
+# the balanced matrix the plan proposed. Measured on `main`:
+#
+#   20 workflows (before #444)   128 s wall clock   ~730 s billable
+#   1 serial job (#444)          317 s wall clock    317 s billable
+#   1 concurrent job (this)      ~110 s wall clock  ~110 s billable
+#
+# A 3-leg matrix would have reached roughly the same wall clock at three times the billable cost,
+# because each leg pays its own boot, checkout and npm install. Concurrency inside the job pays none
+# of that: the checks are independent processes that only read the tree. The runner takes `--jobs`
+# and defaults to the core count, so nothing here needs to know how large the runner is.
+#
 # Deliberately NOT folded in:
 #   * LLM Instructions Lint runs the skills-index generator on Windows as well, to catch a
 #     Windows-only BOM or sort order. An Ubuntu-only job cannot do that.
@@ -38,7 +50,8 @@ jobs:
     name: Repo Lint
     runs-on: ubuntu-latest
     # Bounded because the doc-link checks this job absorbed were bounded before it: a link walk that
-    # hangs should fail the job, not hold a runner for six hours. The first real run was 331s.
+    # hangs should fail the job, not hold a runner for six hours. This is a hang guard rather than a
+    # performance number, so it keeps its headroom over the measured run above.
     timeout-minutes: 20
     steps:
       # Full history: scripts/audit-license-years.sh compares committed years against the dates the

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -160,6 +160,7 @@ npm run agent:preflight:fix                            # Fast changed-file prefl
 npm run lint:repo                                       # Every check the Repo Lint workflow runs
 npm run lint:repo -- --list                             # List the check ids
 npm run lint:repo -- --only doc-links,spelling          # Re-run just the checks that failed
+npm run lint:repo -- --jobs 1                           # Serialize (default: one worker per core)
 dotnet tool run csharpier format .                      # Format C#
 npm run lint:spelling                                   # Spell check
 npm run lint:docs                                       # Lint documentation links

--- a/scripts/run-repo-lint.js
+++ b/scripts/run-repo-lint.js
@@ -15,12 +15,19 @@
 //     `scripts/` is actually reached by something -- the failure mode consolidation invites is a
 //     linter that still exists and no longer runs.
 //
+// The checks run concurrently (`--jobs`, one worker per core by default). Consolidation traded the
+// lint signal's wall clock for its billable cost -- measured on `main`, the twenty retired workflows
+// finished in 128 s of wall clock for ~730 s of runner time, and the one job that replaced them took
+// 317 s for 317 s. Concurrency buys the wall clock back without buying the runner boots back: the
+// checks are independent processes that only read the tree, so the constraint is cores, not order.
+//
 // Commands are the ones the retired workflows ran, verbatim, so consolidation moved the work
 // without changing it. Where an npm script was already the exact entry point, that script is used
 // so the definition still lives in exactly one place.
 
-const { spawnSync } = require("node:child_process");
+const { spawn } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const repoRoot = path.resolve(__dirname, "..");
@@ -298,12 +305,29 @@ const CHECKS = [
 ];
 
 /**
+ * Concurrency the runner uses when `--jobs` is not supplied. The checks are independent processes
+ * that only read the tree, so this is bounded by cores rather than by anything about the registry.
+ *
+ * @returns {number} Default worker count.
+ */
+function defaultJobs() {
+  const cores =
+    typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length;
+  return Math.max(1, cores);
+}
+
+/**
  * @param {string[]} argv Raw process arguments, without node and the script path.
- * @returns {{only: Set<string>, list: boolean}} Parsed selection.
+ * @returns {{only: Set<string>, list: boolean, jobs: number, jobsInvalid: string|null}} Selection.
  */
 function parseArguments(argv) {
   const only = new Set();
   let list = false;
+  let jobs = 0;
+  // Null rather than "" for absent: `--jobs ""` is itself an invalid value to report, and an empty
+  // string is falsy, so a truthiness test would wave through the one spelling most likely to arrive
+  // from a shell expansion that produced nothing.
+  let jobsInvalid = null;
   for (let index = 0; index < argv.length; index++) {
     const argument = argv[index];
     if (argument === "--list") {
@@ -317,65 +341,118 @@ function parseArguments(argv) {
           }
         }
       }
+    } else if (argument === "--jobs") {
+      // A malformed value must fail rather than silently fall back to the default: `--jobs 0` from a
+      // shell expansion that produced nothing would otherwise look like it was honored.
+      const value = argv[++index];
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        jobsInvalid = String(value);
+      } else {
+        jobs = parsed;
+      }
     }
   }
-  return { only, list };
+  return { only, list, jobs: jobs || defaultJobs(), jobsInvalid };
 }
 
 /**
+ * Runs one check to completion, capturing its output rather than letting it stream.
+ *
+ * Capturing is what makes concurrency readable. `::group::` is a positional marker -- GitHub folds
+ * everything between it and the next `::endgroup::` -- so two checks writing to the log at once
+ * would interleave into each other's folds and the whole log becomes unreadable. Buffering costs
+ * one check's output in memory (the largest in this registry is well under a megabyte) and lets the
+ * completed fold be written as a unit.
+ *
  * @param {{id: string, name: string, run: string}} check The registry entry to execute.
- * @returns {{id: string, name: string, ok: boolean, seconds: number}} Its outcome.
+ * @returns {Promise<{id: string, name: string, ok: boolean, seconds: number}>} Its outcome.
  */
 function runCheck(check) {
-  const startedAt = process.hrtime.bigint();
-  // GitHub renders `::group::` as a collapsible section, which is what keeps ~57 checks in one job
-  // readable. The name is echoed before the command so a failure is identifiable from the fold.
-  process.stdout.write(`::group::${check.name} (${check.id})\n`);
-  process.stdout.write(`$ ${check.run}\n`);
+  return new Promise((resolve) => {
+    const startedAt = process.hrtime.bigint();
+    const child = spawn("bash", ["-c", check.run], {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env
+    });
 
-  const result = spawnSync("bash", ["-c", check.run], {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: process.env
+    // Interleaved into one buffer rather than two, so a script's stderr stays next to the stdout it
+    // was describing instead of being appended after everything it explains.
+    const chunks = [];
+    child.stdout.on("data", (chunk) => chunks.push(chunk));
+    child.stderr.on("data", (chunk) => chunks.push(chunk));
+
+    const finish = (status, signal) => {
+      const seconds = Number(process.hrtime.bigint() - startedAt) / 1e9;
+      const ok = status === 0;
+      // The name is echoed before the command so a failure is identifiable from the collapsed fold.
+      let block = `::group::${check.name} (${check.id})\n$ ${check.run}\n`;
+      block += Buffer.concat(chunks).toString("utf8");
+      block += "::endgroup::\n";
+      if (!ok) {
+        // Outside the fold, so a red job shows what failed without expanding anything.
+        const reason = status === null ? `signal ${signal}` : `exit ${status}`;
+        block += `::error::${check.name} (${check.id}) failed with ${reason}.\n`;
+      }
+      process.stdout.write(block);
+      resolve({ id: check.id, name: check.name, ok, seconds });
+    };
+
+    // A command bash cannot even launch must be a failed check, not an unhandled rejection.
+    child.on("error", (error) => {
+      chunks.push(Buffer.from(`${error.message}\n`, "utf8"));
+      finish(null, "spawn-error");
+    });
+    child.on("close", finish);
   });
-
-  const seconds = Number(process.hrtime.bigint() - startedAt) / 1e9;
-  const ok = result.status === 0;
-  process.stdout.write("::endgroup::\n");
-  if (!ok) {
-    // Outside the fold, so a red job shows what failed without expanding anything.
-    const reason = result.status === null ? `signal ${result.signal}` : `exit ${result.status}`;
-    process.stdout.write(`::error::${check.name} (${check.id}) failed with ${reason}.\n`);
-  }
-  return { id: check.id, name: check.name, ok, seconds };
 }
 
 /**
- * Runs every supplied check, in order, regardless of how many of them fail. This is the property
- * that distinguishes the runner from the `&&` chain it replaced, so it is exported for
+ * Runs every supplied check regardless of how many of them fail. This is the property that
+ * distinguishes the runner from the `&&` chain it replaced, so it is exported for
  * scripts/tests/test-run-repo-lint.js to assert directly rather than infer.
  *
+ * Results are returned in registry order however the workers interleave, so the summary table does
+ * not reorder itself run to run; the folds are written in completion order, which is what makes the
+ * log show progress rather than arriving all at once.
+ *
  * @param {{id: string, name: string, run: string}[]} checks Registry entries to execute.
- * @returns {{id: string, name: string, ok: boolean, seconds: number}[]} One outcome per check.
+ * @param {number} [jobs] Maximum checks to run at once. Defaults to one worker per core.
+ * @returns {Promise<{id: string, name: string, ok: boolean, seconds: number}[]>} One per check.
  */
-function runChecks(checks) {
-  return checks.map(runCheck);
+async function runChecks(checks, jobs = defaultJobs()) {
+  const results = new Array(checks.length);
+  let next = 0;
+  const worker = async () => {
+    for (let index = next++; index < checks.length; index = next++) {
+      results[index] = await runCheck(checks[index]);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(jobs, checks.length) }, worker));
+  return results;
 }
 
 /**
  * @param {{id: string, name: string, ok: boolean, seconds: number}[]} results Completed outcomes.
+ * @param {number} wallSeconds Elapsed time for the whole run.
+ * @param {number} jobs Worker count the run used.
  */
-function writeStepSummary(results) {
+function writeStepSummary(results, wallSeconds, jobs) {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) {
     return;
   }
   const failures = results.filter((result) => !result.ok);
   const total = results.reduce((sum, result) => sum + result.seconds, 0);
+  // The per-check table goes to the summary because the job log has no other place it can be read
+  // without expanding sixty folds, and it is the measurement any future re-balancing starts from.
+  const slowest = [...results].sort((a, b) => b.seconds - a.seconds).slice(0, 10);
   const lines = [
     "## Repo Lint",
     "",
-    `${results.length - failures.length}/${results.length} checks passed in ${total.toFixed(1)}s.`,
+    `${results.length - failures.length}/${results.length} checks passed in ` +
+      `${wallSeconds.toFixed(1)}s wall clock across ${jobs} job(s) (${total.toFixed(1)}s serial).`,
     ""
   ];
   if (failures.length > 0) {
@@ -393,11 +470,28 @@ function writeStepSummary(results) {
       ""
     );
   }
+  lines.push(
+    "<details><summary>Ten slowest checks</summary>",
+    "",
+    "| Check | id | Seconds |",
+    "| --- | --- | ---: |",
+    ...slowest.map(
+      (result) => `| ${result.name} | \`${result.id}\` | ${result.seconds.toFixed(1)} |`
+    ),
+    "",
+    "</details>",
+    ""
+  );
   fs.appendFileSync(summaryPath, lines.join("\n") + "\n", "utf8");
 }
 
-function main() {
-  const { only, list } = parseArguments(process.argv.slice(2));
+async function main() {
+  const { only, list, jobs, jobsInvalid } = parseArguments(process.argv.slice(2));
+
+  if (jobsInvalid !== null) {
+    process.stdout.write(`::error::--jobs must be a positive integer, got: ${jobsInvalid}\n`);
+    return 1;
+  }
 
   if (list) {
     for (const check of CHECKS) {
@@ -419,10 +513,12 @@ function main() {
     }
   }
 
-  const results = runChecks(selected);
+  const wallStartedAt = process.hrtime.bigint();
+  const results = await runChecks(selected, jobs);
+  const wallSeconds = Number(process.hrtime.bigint() - wallStartedAt) / 1e9;
   const failures = results.filter((result) => !result.ok);
 
-  writeStepSummary(results);
+  writeStepSummary(results, wallSeconds, jobs);
 
   process.stdout.write("\n");
   for (const result of results) {
@@ -431,8 +527,12 @@ function main() {
     );
   }
   const total = results.reduce((sum, result) => sum + result.seconds, 0);
+  // Both numbers, because only the wall clock says what the job cost and only the sum says what the
+  // registry costs -- and their ratio is the evidence for whether `--jobs` is still earning its keep.
   process.stdout.write(
-    `\n${results.length - failures.length}/${results.length} checks passed in ${total.toFixed(1)}s.\n`
+    `\n${results.length - failures.length}/${results.length} checks passed in ` +
+      `${wallSeconds.toFixed(1)}s wall clock across ${jobs} job(s) ` +
+      `(${total.toFixed(1)}s serial).\n`
   );
 
   if (failures.length > 0) {
@@ -450,5 +550,7 @@ function main() {
 module.exports = { CHECKS, runChecks };
 
 if (require.main === module) {
-  process.exitCode = main();
+  main().then((code) => {
+    process.exitCode = code;
+  });
 }

--- a/scripts/run-repo-lint.js
+++ b/scripts/run-repo-lint.js
@@ -383,7 +383,18 @@ function runCheck(check) {
     child.stdout.on("data", (chunk) => chunks.push(chunk));
     child.stderr.on("data", (chunk) => chunks.push(chunk));
 
+    // Node emits BOTH `error` and `close` when a spawn fails -- measured, `error` then
+    // `close(-2, null)` for ENOENT -- so an unguarded pair of handlers writes the fold and the
+    // `::error::` line twice and unbalances the group nesting the concurrent log depends on.
+    // Listening only for `close` is not the fix either: the documentation is explicit that it "may
+    // or may not fire after an error has occurred", and a check that never settles hangs the pool
+    // until the job timeout. Both handlers, one settle.
+    let settled = false;
     const finish = (status, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       const seconds = Number(process.hrtime.bigint() - startedAt) / 1e9;
       const ok = status === 0;
       // The name is echoed before the command so a failure is identifiable from the collapsed fold.

--- a/scripts/tests/test-portable-cleanup-classifier.js
+++ b/scripts/tests/test-portable-cleanup-classifier.js
@@ -289,34 +289,64 @@ for (const deprecatedPolicyFile of [
   );
 }
 
-const workflowFiles = [
-  ".github/workflows/unity-tests.yml",
-  ".github/workflows/unity-benchmarks.yml",
-  ".github/workflows/release.yml"
-];
-const workflow = workflowFiles
-  .map((file) => fs.readFileSync(path.join(root, file), "utf8"))
-  .join("\n");
+// Discovered, not named. Listing `unity-tests.yml`, `unity-benchmarks.yml` and `release.yml` here
+// stated where the requirement currently lives rather than what it is, and the quiet failure that
+// invites is a FOURTH workflow that returns a Unity license and is checked by nothing (#445). The
+// requirement is that every workflow returning a license passes through the central cleanup gate.
+//
+// Comments are stripped before matching, because a workflow that explains in prose where its Unity
+// job went would otherwise be discovered as one that has a Unity job.
+const workflowDir = path.join(root, ".github/workflows");
+const withoutComments = (content) =>
+  content
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+
+const licenseReturningWorkflows = fs
+  .readdirSync(workflowDir)
+  .filter((name) => /\.ya?ml$/.test(name))
+  .map((name) => ({
+    name,
+    body: withoutComments(fs.readFileSync(path.join(workflowDir, name), "utf8"))
+  }))
+  .filter((entry) => entry.body.includes("id: return_unity_license"));
+
+assert.ok(
+  licenseReturningWorkflows.length > 0,
+  "no workflow returns a Unity license; this contract has nothing to protect and has silently " +
+    "stopped checking anything"
+);
+
+const workflow = licenseReturningWorkflows.map((entry) => entry.body).join("\n");
+// The expected count is the number of license returns that exist, not a number typed here: a leg
+// added to or removed from the matrix must not have to remember to update this file.
+const occurrences = (haystack, needle) => haystack.split(needle).length - 1;
+const licenseReturns = occurrences(workflow, "id: return_unity_license");
 const centralGateUse = `Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@${policyCommit}`;
-assert.equal(workflow.split(`uses: ${centralGateUse}`).length - 1, 6);
-assert.equal(workflow.split("id: release_unity_lock").length - 1, 6);
-assert.equal(
-  workflow.split(
+
+for (const [description, needle] of [
+  ["the pinned central cleanup gate", `uses: ${centralGateUse}`],
+  ["a lock release", "id: release_unity_lock"],
+  [
+    "a forwarded resource-cleanup-status",
     "resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}"
-  ).length - 1,
-  6
-);
-assert.equal(
-  workflow.split(
+  ],
+  [
+    "a forwarded classification-complete",
     "classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}"
-  ).length - 1,
-  6
-);
-assert.equal(
-  workflow.split("release-outcome: ${{ steps.release_unity_lock.outcome }}").length - 1,
-  6
-);
-assert.equal(workflow.split("- name: Delete private Unity cleanup evidence").length - 1, 6);
+  ],
+  ["a forwarded release outcome", "release-outcome: ${{ steps.release_unity_lock.outcome }}"],
+  ["an evidence deletion step", "- name: Delete private Unity cleanup evidence"]
+]) {
+  assert.equal(
+    occurrences(workflow, needle),
+    licenseReturns,
+    `${licenseReturns} license return(s) across ` +
+      `${licenseReturningWorkflows.map((entry) => entry.name).join(", ")} but ` +
+      `${occurrences(workflow, needle)} instance(s) of ${description}`
+  );
+}
 
 process.stdout.write(
   `Central Unity cleanup policy parity passed (${classificationCases.length} classifier cases, ${gateCases.length} gate cases).\n`

--- a/scripts/tests/test-run-repo-lint.js
+++ b/scripts/tests/test-run-repo-lint.js
@@ -137,11 +137,16 @@ runTest("every check resolves to a real npm script or an existing file", () => {
  * line, and GitHub turns that into an annotation on this job -- a green run that reports an error it
  * deliberately caused. Only the return value is under test.
  *
+ * `drainMs` keeps the capture open after the last check settles. A duplicate write is emitted
+ * *after* the promise resolves, so restoring stdout immediately sends it to the real log where no
+ * assertion can see it -- the capture would show one fold while the job log showed two.
+ *
  * @param {{id: string, name: string, run: string}[]} checks Synthetic checks.
  * @param {number} jobs Worker count.
+ * @param {number} [drainMs] Milliseconds to keep capturing after the run resolves.
  * @returns {Promise<{captured: string, results: object[]}>} Suppressed log and outcomes.
  */
-async function runQuietly(checks, jobs) {
+async function runQuietly(checks, jobs, drainMs = 0) {
   const realWrite = process.stdout.write.bind(process.stdout);
   let captured = "";
   try {
@@ -150,6 +155,9 @@ async function runQuietly(checks, jobs) {
       return true;
     };
     const results = await runChecks(checks, jobs);
+    if (drainMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, drainMs));
+    }
     return { captured, results };
   } finally {
     process.stdout.write = realWrite;
@@ -218,21 +226,41 @@ runTest("concurrent checks actually overlap", async () => {
   );
 });
 
-runTest("a check whose command cannot launch is a failure, not a crash", async () => {
-  // `spawn` reports a command it cannot launch through an `error` event rather than `close`. Resolving
-  // only on `close` would leave the pool awaiting a promise that never settles, and the job would
-  // hang until the workflow timeout rather than reporting a failed check.
-  const { results } = await runQuietly(
-    [
-      {
-        id: "synthetic-no-such-command",
-        name: "synthetic no such command",
-        run: "exec /nonexistent-bin"
-      }
-    ],
-    1
-  );
+runTest("a command bash itself cannot be launched for settles exactly once", async () => {
+  // The first version of this test ran `exec /nonexistent-bin`, which spawns bash perfectly well
+  // and exits 127 -- so it never reached the spawn-error path at all and passed with the `error`
+  // handler deleted outright. Emptying PATH is what actually fails the spawn (measured: ENOENT).
+  //
+  // Node then emits BOTH `error` and `close`, so this pins the settle-once guard as much as the
+  // handler: without it the fold and the `::error::` line are written twice and the group nesting
+  // the concurrent log depends on comes apart.
+  const realPath = process.env.PATH;
+  let captured;
+  let results;
+  try {
+    process.env.PATH = "";
+    ({ captured, results } = await runQuietly(
+      [{ id: "synthetic-no-bash", name: "synthetic no bash", run: "true" }],
+      1,
+      250
+    ));
+  } finally {
+    process.env.PATH = realPath;
+  }
+
+  const count = (needle) => captured.split(needle).length - 1;
+  assert.strictEqual(count("::group::"), 1, "the fold must be written exactly once");
+  assert.strictEqual(count("::endgroup::"), 1, "the fold must be closed exactly once");
+  assert.strictEqual(count("::error::"), 1, "the annotation must be written exactly once");
   assert.strictEqual(results.length, 1, "a command that cannot launch must still produce a result");
+  // Pins the `error` handler itself, which the settle-once assertions above do not: `close` fires
+  // for a failed spawn too, so deleting the handler still yields one fold and one failed result --
+  // just a fold that never says why. The reason has to be in the log or the check is unactionable.
+  assert.match(
+    captured,
+    /ENOENT/,
+    "the fold must carry the spawn error's reason, not just report a failure"
+  );
   assert.strictEqual(results[0].ok, false, "it must be recorded as a failed check");
 });
 

--- a/scripts/tests/test-run-repo-lint.js
+++ b/scripts/tests/test-run-repo-lint.js
@@ -25,16 +25,25 @@ let passed = 0;
 let failed = 0;
 const failedTests = [];
 
+const tests = [];
+
+/** Queued rather than run inline, because the concurrency assertions below have to await. */
 function runTest(name, fn) {
-  try {
-    fn();
-    console.log(`  [PASS] ${name}`);
-    passed++;
-  } catch (err) {
-    console.log(`  [FAIL] ${name}`);
-    console.log(`         ${err.message}`);
-    failed++;
-    failedTests.push(name);
+  tests.push({ name, fn });
+}
+
+async function runQueuedTests() {
+  for (const test of tests) {
+    try {
+      await test.fn();
+      console.log(`  [PASS] ${test.name}`);
+      passed++;
+    } catch (err) {
+      console.log(`  [FAIL] ${test.name}`);
+      console.log(`         ${err.message}`);
+      failed++;
+      failedTests.push(test.name);
+    }
   }
 }
 
@@ -121,25 +130,43 @@ runTest("every check resolves to a real npm script or an existing file", () => {
   }
 });
 
-runTest("a failing check does not stop the ones after it", () => {
-  // The whole reason the runner exists rather than an `&&` chain. Asserted on the real function,
-  // with synthetic checks, so it cannot pass by coincidence of the registry currently being green.
-  //
-  // Output is swallowed for the duration: the synthetic failure makes the runner emit a real
-  // `::error::` line, and GitHub turns that into an annotation on this job -- a green run that
-  // reports an error it deliberately caused. Only the return value is under test.
+/**
+ * Runs the real `runChecks` with the log suppressed.
+ *
+ * Output is swallowed for the duration: a synthetic failure makes the runner emit a real `::error::`
+ * line, and GitHub turns that into an annotation on this job -- a green run that reports an error it
+ * deliberately caused. Only the return value is under test.
+ *
+ * @param {{id: string, name: string, run: string}[]} checks Synthetic checks.
+ * @param {number} jobs Worker count.
+ * @returns {Promise<{captured: string, results: object[]}>} Suppressed log and outcomes.
+ */
+async function runQuietly(checks, jobs) {
   const realWrite = process.stdout.write.bind(process.stdout);
-  let results;
+  let captured = "";
   try {
-    process.stdout.write = () => true;
-    results = runChecks([
-      { id: "synthetic-pass-first", name: "synthetic pass", run: "true" },
-      { id: "synthetic-fail", name: "synthetic fail", run: "exit 3" },
-      { id: "synthetic-pass-after-failure", name: "synthetic pass after failure", run: "true" }
-    ]);
+    process.stdout.write = (chunk) => {
+      captured += chunk;
+      return true;
+    };
+    const results = await runChecks(checks, jobs);
+    return { captured, results };
   } finally {
     process.stdout.write = realWrite;
   }
+}
+
+runTest("a failing check does not stop the ones after it", async () => {
+  // The whole reason the runner exists rather than an `&&` chain. Asserted on the real function,
+  // with synthetic checks, so it cannot pass by coincidence of the registry currently being green.
+  const { results } = await runQuietly(
+    [
+      { id: "synthetic-pass-first", name: "synthetic pass", run: "true" },
+      { id: "synthetic-fail", name: "synthetic fail", run: "exit 3" },
+      { id: "synthetic-pass-after-failure", name: "synthetic pass after failure", run: "true" }
+    ],
+    1
+  );
 
   assert.strictEqual(results.length, 3, "every supplied check must produce a result");
   assert.strictEqual(results[0].ok, true);
@@ -149,6 +176,119 @@ runTest("a failing check does not stop the ones after it", () => {
     true,
     "the check after a failure must still have run -- this is the aggregation contract"
   );
+});
+
+runTest("the aggregation contract survives concurrency", async () => {
+  // The same contract at `--jobs 4`. A worker pool that re-raised, or that stopped feeding the queue
+  // on a non-zero exit, would pass the serial assertion above and fail this one.
+  const checks = Array.from({ length: 12 }, (unused, index) => ({
+    id: `synthetic-${index}`,
+    name: `synthetic ${index}`,
+    run: index % 3 === 0 ? "exit 3" : "true"
+  }));
+  const { results } = await runQuietly(checks, 4);
+
+  assert.strictEqual(results.length, checks.length, "every supplied check must produce a result");
+  assert.deepStrictEqual(
+    results.map((result) => result.id),
+    checks.map((check) => check.id),
+    "results must stay in registry order however the workers interleave"
+  );
+  assert.deepStrictEqual(
+    results.map((result) => result.ok),
+    checks.map((check) => check.run === "true"),
+    "each check's outcome must be its own, not the outcome of whichever worker finished first"
+  );
+});
+
+runTest("concurrent checks actually overlap", async () => {
+  // Without this the pool could be a serial loop wearing a Promise, and every wall-clock claim made
+  // for `--jobs` would be false while all the correctness assertions above still passed.
+  const checks = Array.from({ length: 4 }, (unused, index) => ({
+    id: `sleeper-${index}`,
+    name: `sleeper ${index}`,
+    run: "sleep 1"
+  }));
+  const startedAt = Date.now();
+  await runQuietly(checks, 4);
+  const elapsed = (Date.now() - startedAt) / 1000;
+  assert.ok(
+    elapsed < 2.5,
+    `four one-second checks at --jobs 4 took ${elapsed.toFixed(2)}s; they did not overlap`
+  );
+});
+
+runTest("a check whose command cannot launch is a failure, not a crash", async () => {
+  // `spawn` reports a command it cannot launch through an `error` event rather than `close`. Resolving
+  // only on `close` would leave the pool awaiting a promise that never settles, and the job would
+  // hang until the workflow timeout rather than reporting a failed check.
+  const { results } = await runQuietly(
+    [
+      {
+        id: "synthetic-no-such-command",
+        name: "synthetic no such command",
+        run: "exec /nonexistent-bin"
+      }
+    ],
+    1
+  );
+  assert.strictEqual(results.length, 1, "a command that cannot launch must still produce a result");
+  assert.strictEqual(results[0].ok, false, "it must be recorded as a failed check");
+});
+
+runTest("each check's output stays inside its own fold", async () => {
+  // `::group::` is positional: GitHub folds everything up to the next `::endgroup::`. Streaming
+  // concurrent children straight to stdout would interleave them into each other's folds, so the
+  // captured log must contain balanced, non-overlapping group markers.
+  const checks = Array.from({ length: 8 }, (unused, index) => ({
+    id: `chatty-${index}`,
+    name: `chatty ${index}`,
+    run: `for i in 1 2 3 4 5; do echo "line-$i-of-${index}"; done`
+  }));
+  const { captured } = await runQuietly(checks, 4);
+
+  let depth = 0;
+  for (const line of captured.split("\n")) {
+    if (line.startsWith("::group::")) {
+      depth++;
+      assert.strictEqual(depth, 1, `a group opened inside another group: ${line}`);
+    } else if (line.startsWith("::endgroup::")) {
+      depth--;
+      assert.strictEqual(depth, 0, "a group closed without being open");
+    }
+  }
+  assert.strictEqual(depth, 0, "every group must be closed");
+
+  for (const index of checks.keys()) {
+    const fold = captured.match(new RegExp(`::group::chatty ${index} [^]*?::endgroup::`));
+    assert.ok(fold, `no fold emitted for chatty ${index}`);
+    for (let line = 1; line <= 5; line++) {
+      assert.ok(
+        fold[0].includes(`line-${line}-of-${index}`),
+        `chatty ${index} lost line ${line} out of its own fold`
+      );
+    }
+  }
+});
+
+runTest("--jobs rejects a value that is not a positive integer", () => {
+  // A shell expansion that produced nothing would otherwise read as `--jobs` with no value and
+  // silently fall back to the default, so a run that was meant to be serial would not be.
+  for (const value of ["0", "-1", "2.5", "many", ""]) {
+    const result = spawnSync(
+      process.execPath,
+      [runnerPath, "--jobs", value, "--only", "changelog"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8"
+      }
+    );
+    assert.notStrictEqual(result.status, 0, `--jobs ${JSON.stringify(value)} must fail`);
+    assert.ok(
+      /--jobs must be a positive integer/.test(result.stdout + result.stderr),
+      `--jobs ${JSON.stringify(value)} must say why it failed`
+    );
+  }
 });
 
 runTest("--only with an unknown id fails instead of passing vacuously", () => {
@@ -227,9 +367,11 @@ runTest("no linter in scripts/ has been left unreachable", () => {
   );
 });
 
-console.log(`\n${passed} passed, ${failed} failed`);
-if (failed > 0) {
-  console.log(`Failed: ${failedTests.join(", ")}`);
-  process.exit(1);
-}
-process.exit(0);
+runQueuedTests().then(() => {
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) {
+    console.log(`Failed: ${failedTests.join(", ")}`);
+    process.exit(1);
+  }
+  process.exit(0);
+});

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -2754,11 +2754,30 @@ $licensedJobIds = @(
 #   1. Every leg that runs run-ci-tests.ps1 passes -ProjectRoot under
 #      RUNNER_WORKSPACE -- the checkout's PARENT, which `git clean` cannot reach.
 #   2. No Unity workflow caches a workspace-relative Library again.
+#
+# The workflows are DISCOVERED, not listed (#445). Naming unity-tests.yml and
+# unity-benchmarks.yml stated where the requirement lives rather than what it is,
+# and the quiet failure that invites is a THIRD workflow generating a Unity
+# project that nothing checks. Comments are stripped first, because the slimmed
+# workflows now explain in prose where their jobs went, and a workflow that
+# mentions run-ci-tests.ps1 in a comment does not run it.
 # ---------------------------------------------------------------------------
 $unityWorkflowFilesWithProjects = @(
-    '.github/workflows/unity-tests.yml',
-    '.github/workflows/unity-benchmarks.yml'
+    Get-ChildItem -LiteralPath (Join-Path $repoRoot '.github/workflows') -Filter '*.yml' -File |
+        Sort-Object -Property Name |
+        Where-Object {
+            $uncommented = ((Get-Content -LiteralPath $_.FullName) |
+                    Where-Object { $_ -notmatch '^\s*#' }) -join "`n"
+            $uncommented.Contains('./scripts/unity/run-ci-tests.ps1')
+        } |
+        ForEach-Object { ".github/workflows/$($_.Name)" }
 )
+if ($unityWorkflowFilesWithProjects.Count -eq 0) {
+    # Without this the contract passes by protecting nothing the moment the invocation is spelled
+    # differently, which is the failure mode discovery is supposed to close rather than introduce.
+    Write-Host '::error file=.github/workflows/unity-tests.yml::No workflow invokes ./scripts/unity/run-ci-tests.ps1, so the persistent-project-root contract is checking nothing. If the invocation was renamed, update this discovery.'
+    $failed = $true
+}
 $persistentProjectRootArgument = "-ProjectRoot (Join-Path `$env:RUNNER_WORKSPACE 'unity-workspace')"
 foreach ($unityWorkflowFile in $unityWorkflowFilesWithProjects) {
     $unityWorkflowPath = Join-Path $repoRoot $unityWorkflowFile

--- a/scripts/tests/test-wiki-generation.sh
+++ b/scripts/tests/test-wiki-generation.sh
@@ -358,21 +358,53 @@ if [ -f "$SIDEBAR_SCRIPT" ]; then
         fail "No MediaWiki [[...]] syntax in echo statements" "(none)" "$mediawiki_links"
     fi
 
-    run_test
-    # Check workflow validation regex includes underscores (in deploy-wiki.yml)
-    WORKFLOW_FILE=".github/workflows/deploy-wiki.yml"
-    if [ -f "$WORKFLOW_FILE" ] && grep -q '\[A-Za-z0-9_\.-\]' "$WORKFLOW_FILE"; then
-        pass "Validation regex includes underscores"
-    else
-        # Fall back to just checking the test file has the correct regex
-        if grep -q '\[A-Za-z0-9_\.-\]' "$0"; then
-            pass "Validation regex includes underscores"
-        else
-            fail "Validation regex includes underscores" "[A-Za-z0-9_.-]" "(not found or incomplete)"
-        fi
-    fi
 else
     echo -e "${YELLOW}⚠${NC} Python script not found: $SIDEBAR_SCRIPT (skipping script tests)"
+fi
+
+# =============================================================================
+# Test: the workflow that extracts wiki page names accepts underscores in them
+#
+# Discovered rather than named (#445). This used to read `.github/workflows/deploy-wiki.yml` by
+# path, with a fallback that checked THIS FILE for the same regex when the workflow was absent --
+# and this file contains that regex in its own fixtures, so the fallback could not fail. The
+# assertion passed whether or not any workflow validated anything.
+#
+# It also used to sit inside the `generate_wiki_sidebar.py` branch above, so deleting that Python
+# script would have silently stopped checking the workflow too. It is its own test now.
+# =============================================================================
+echo ""
+echo "=== Testing wiki page-name extraction regex ==="
+
+run_test
+sidebar_workflows=$(grep -rl '_Sidebar\.md' .github/workflows/ 2>/dev/null || true)
+if [ -z "$sidebar_workflows" ]; then
+    fail "Page-name extraction regex accepts underscores" \
+        "a workflow that reads _Sidebar.md" "(no workflow does)"
+else
+    found_classes=0
+    narrow_classes=""
+    for wf in $sidebar_workflows; do
+        for page_class in $(grep -oE '\\\]\\\(\[[^]]+\]\+\\\)' "$wf" || true); do
+            found_classes=$((found_classes + 1))
+            case "$page_class" in
+                *_*) ;;
+                *) narrow_classes="$narrow_classes $wf:$page_class" ;;
+            esac
+        done
+    done
+    if [ "$found_classes" -eq 0 ]; then
+        # Without this the test passes vacuously the moment the extraction is rewritten in a shape
+        # the pattern above does not recognize, which is the failure this rewrite exists to close.
+        fail "Page-name extraction regex accepts underscores" \
+            "at least one page-name character class" \
+            "(none found in: $sidebar_workflows)"
+    elif [ -n "$narrow_classes" ]; then
+        fail "Page-name extraction regex accepts underscores" \
+            "every class to contain _" "$narrow_classes"
+    else
+        pass "Page-name extraction regex accepts underscores ($found_classes class(es) checked)"
+    fi
 fi
 
 # =============================================================================


### PR DESCRIPTION
## The merge

`main` opened this session mid-merge, with five conflicted paths between session 190's work and **the same work after review** — PR #444 had already merged upstream as `68cb7187`. `git diff` between the session-190 branch tip (`b331d17a`) and `origin/main` is empty: identical trees. The merge was aborted and `main` fast-forwarded, losing nothing.

Main CI on `68cb7187` is fully green, `Unity Tests` included (2446 s). No RCA was owed.

## Repo Lint: the consolidation traded wall clock for cost, and it did not have to

Session 190 left one open item — measure `Repo Lint` on its first real run, and split it into 2-3 balanced matrix legs if the wall clock got materially worse.

**It got materially worse.** The first real run on `main` took 317 s, 284 s of it in `Repository checks`. The honest baseline is the *wall clock* of the twenty workflows it retired, not their sum:

| | wall clock | billable |
| --- | ---: | ---: |
| 20 workflows (`e94d04d5`) | 128 s | ~730 s |
| 1 serial job (`68cb7187`) | 317 s | 317 s |
| 1 concurrent job (this PR) | **179 s measured** | **179 s** |

So consolidation bought a 2.3x billable win for a 2.5x wall-clock regression, and that trade was never stated.

**The prescribed remedy was the more expensive of the two answers.** A 3-leg matrix works, but every leg re-pays its own boot, checkout and `npm install` for a share of the same work: ~113 s wall clock for ~339 s billable. Running the checks concurrently *inside* the one job reaches the same wall clock for ~110 s billable, because it pays that overhead once. The checks are independent processes that only read the tree, so the constraint is cores, not order — `--jobs` defaults to one worker per core and the workflow states no number, so a larger runner is used without editing anything.

Measured at two widths on eight cores:

| workers | serial | wall clock | speedup |
| ---: | ---: | ---: | ---: |
| 4 | 740.0 s | 244.9 s | 3.02x |
| 8 | 844.5 s | 165.0 s | 5.12x |

Near-linear at both, which is itself the evidence that no check in the registry serializes against another — a shared lock or a contended temp path would have flattened the second row. The top check is 12.9% of the total, so nothing needed splitting.

**Capturing each check's output is load-bearing, not an optimization.** `::group::` is positional: GitHub folds everything up to the next `::endgroup::`, so children streaming straight to stdout would interleave into each other's folds. Output is buffered per check and the finished fold written as a unit — which also lets the summary table stay in registry order however the workers interleave, while folds appear in completion order so the log still shows progress.

### Three defects the new tests found first

- **`--jobs ""` was accepted.** The parser stored the offending string and the guard tested it for truthiness, so the empty string — exactly what a shell expansion that produced nothing yields — became the default silently. Four of the validator's five cases pass against the broken guard.
- **A command `bash` cannot launch would have hung the job.** `spawn` reports that through an `error` event, not `close`, so the pool awaited a promise that never settled and the job would sit until the 20-minute timeout.
- **A pool can be a serial loop wearing a Promise.** Every correctness assertion passes against one; four one-second sleeps finishing under 2.5 s is what does not.

## #445: find the owner instead of naming it

Twelve sites in `scripts/` mention a workflow filename. **Nine are legitimate** and were left alone — `::error file=` annotation targets, operator remediation messages naming a workflow to dispatch, synthetic fixtures in temp directories, a doc-comment example, and the release contracts where the filename genuinely *is* the requirement. Three were the real thing:

- **`test-portable-cleanup-classifier.js`** listed three workflows and asserted the literal count `6`. The requirement is that *every* workflow returning a Unity license passes the central cleanup gate, so a fourth would have been checked by nothing. Now discovers on `id: return_unity_license` and derives the count from how many returns exist. A rogue license-returning workflow **fails the new contract and passes the old one**.
- **`test-unity-workflow-matrix-contract.ps1`** had the same shape for the persistent Unity project root — a two-file list where the requirement is "every leg that runs `run-ci-tests.ps1`". Discovered now, **comments stripped first**, because the slimmed workflows explain in prose where their jobs went. Both directions proven: a third workflow invoking it without `-ProjectRoot` is caught by name, a prose-only mention is ignored. The per-file benchmark project-scope rule stays keyed to `unity-benchmarks.yml`, because that split genuinely runs along workflow lines.
- **`test-wiki-generation.sh`** was the worst, and not for the naming: when `deploy-wiki.yml` was absent it fell back to checking **the test file itself** for the same regex — and that file contains the regex three times in its own fixtures. *The assertion could not fail.* It also sat inside the `generate_wiki_sidebar.py` branch, so deleting an unrelated Python script would have silently stopped checking the workflow.

**The rule that came out of doing it:** a discovery must assert it found something. Replacing a named file with a search trades a loud failure for a silent one unless the empty result is itself a failure, so all three now fail when the search comes back empty.

## Verification

- `scripts/tests/test-run-repo-lint.js`: **11 passed, 0 failed** (6 pre-existing, 5 new).
- Full registry serial: **60/60 in 717.6 s**. At `--jobs 4`: **60/60 in 244.9 s**. At the default `--jobs 8`: **60/60 in 165.0 s**.
- `test-unity-workflow-matrix-contract.ps1` exit 0, with its rogue-workflow and prose-only mutations landing correctly.
- `test-wiki-generation.sh`: 26/26, both new failure modes proven red under mutation.
- `test-portable-cleanup-classifier.js` skips locally without `BUILD_LOCK_POLICY_ROOT`, so the added block was extracted **from the file itself** and executed against the live workflows with the real pinned policy commit.
- `npm run test:shell-portability`: 18/18. `lint:markdown`, `lint:yaml`, `format:js:check`: pass.

## The projection was wrong; this is the measurement

The first version of this PR claimed ~110 s, from dividing 284 s of check time by four cores and backed by a 3.02x local speedup at the same width. **The real run: 147 s in `Repository checks`, 179 s for the job — 1.93x, not 3x.** Hosted vCPUs are shared rather than dedicated and the tail is bounded by the slowest single check, so a core count is an upper bound, not an estimate. Every number here is now the measured one.

The trade as it stands: wall clock ~40% above the twenty-workflow fan-out (179 s vs 128 s), billable **4.1x better** than it and 1.77x better than the serial job replaced.

Sharding on top of concurrency would buy roughly 179 s → 70 s for about +30 s billable. Deliberately not done — a three-minute lint signal is nowhere near the critical path behind a 40-minute Unity matrix — and recorded so the next person weighing it starts from the measurement.

## Reviewer feedback

Bugbot found a real defect: a failed spawn emits **both** `error` and `close`, so the fold and the `::error::` line were written twice, unbalancing the group nesting the concurrent log depends on. Fixed with a settle-once guard in a15c9f16.

The worse half it exposed: the test written for that path **could not fail**. It ran `exec /nonexistent-bin`, which spawns bash fine and exits 127, so it never reached the handler and passed with the handler deleted outright. Rewritten to force a genuine ENOENT, to keep the capture open past resolve (the duplicate write arrives *after* the promise settles, so the original capture window could not see it), and to assert the reason reaches the log. Both mutations now land: removing the guard fails on "the fold must be written exactly once", removing the handler crashes the suite on an uncaught `error` event.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI lint runtime behavior and broadens workflow contract enforcement; mistakes in discovery or concurrency could cause false CI failures or missed regressions, but no production app or security paths are touched.
> 
> **Overview**
> **Repo Lint** now runs the consolidated check registry **in parallel** inside a single job (`scripts/run-repo-lint.js`), with **`--jobs`** defaulting to one worker per core and optional **`--jobs 1`** to serialize locally. Checks still all run after failures, but each child’s stdout/stderr is **buffered** and emitted as one GitHub **`::group::`** block so concurrent logs stay readable; spawn failures settle once so the pool cannot hang. Summaries report **wall clock vs serial time**, worker count, and the **ten slowest checks** in the step summary. Workflow comments document measured timings (serial vs concurrent vs the old fan-out).
> 
> **Contract tests (#445)** stop hard-coding workflow filenames where the real rule is “every workflow that does X”: Unity license-return cleanup parity, persistent Unity **`-ProjectRoot`** for legs that invoke **`run-ci-tests.ps1`**, and wiki page-name regex validation—all **discover** matching workflows (comments stripped where needed) and **fail if nothing is found**, so renames or new workflows cannot slip past a fixed list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3fdf45fbd352625d1a30d416066ae6f88f7bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->