### PR TITLE
Keep the binding a walk threw away, and make three excuses executable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,12 @@
   // credential helper remains the fallback (see the GitHub access notes in .llm/context.md).
   "remoteEnv": {
     "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
-    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    // Credentials resolve from a 0600 cache; an EMPTY cache used to fall through to the editor's
+    // askpass, which raises a dialog on the owner's desktop that no credential helper can suppress
+    // (#450). This makes the fallback an error naming the fix instead. The Git extension sets its
+    // own GIT_ASKPASS for the git processes it launches, so the editor's UI is unaffected.
+    "GIT_ASKPASS": "${containerWorkspaceFolder}/scripts/git-askpass-refuse.sh"
   },
   // Run any post-create commands (see post-create.sh for details)
   // 1. Fix volume mount permissions (Docker named volumes are root-owned)

--- a/.github/workflows/stuck-job-watchdog.yml
+++ b/.github/workflows/stuck-job-watchdog.yml
@@ -12,9 +12,12 @@ name: Stuck Job Watchdog
 #   * The workflow run is `status: queued` AND its CURRENT ATTEMPT (`run_started_at`,
 #     which resets on re-run, falling back to `created_at`) is older than
 #     MIN_QUEUE_AGE_SECONDS
-#     (default 300s / 5 min; round-2 false-positive guards below -- zero
+#     (default 300s; round-2 false-positive guards below -- zero
 #     in-progress jobs, self-run exclusion, excluded-workflow list -- make
 #     the previous conservative 600s buffer unnecessary).
+#     300s is a floor on how long a run must have been WAITING to be a
+#     candidate. It is not the detection latency, which is set by how often
+#     GitHub actually delivers this schedule -- see the note on `on: schedule`.
 #   * No job in the run is `status: in_progress` - a run with even one
 #     in-progress job is by definition holding/using a runner, not
 #     dispatcher-stuck. This is what prevents false positives for matrix cells
@@ -52,7 +55,8 @@ name: Stuck Job Watchdog
 #   * The run is completed with `conclusion: cancelled`, and finished within
 #     MAX_RERUN_AGE_SECONDS.
 #   * Its `run_attempt` is at most MAX_RERUN_ATTEMPT, so a re-run that lands in
-#     the same state is escalated to a human instead of looping every 5 min.
+#     the same state is escalated to a human instead of looping on every
+#     delivered tick.
 #   * At least one of its jobs has `conclusion: cancelled` with a non-empty
 #     step list whose every step is `conclusion: success`. A deliberate cancel
 #     never matches: its in-flight step is itself cancelled, not successful.
@@ -71,6 +75,28 @@ name: Stuck Job Watchdog
 # newer schedules must not cancel an in-flight audit after it has cancelled a
 # stuck run but before it persists the state-branch counter.
 
+# WHAT THIS SCHEDULE ACTUALLY DELIVERS, measured over 300 runs (2026-08-11 to
+# 08-15, #448). GitHub drops most scheduled triggers on a busy shard, so the
+# cron below is a REQUEST rather than a cadence, and every latency budget
+# written in terms of it is 3-4x optimistic:
+#
+#   Cron requests            288/day
+#   Runs actually delivered  65.5/day (23%)
+#   Median gap               21.3 min (p25 14.6, p75 26.1, p90 34.0, max 58.5)
+#   Job duration             p50 13 s, p95 49 s
+#   Cost                     $0.00 -- the repository is public
+#
+# Two consequences worth keeping. Making this cheaper is not available: billing
+# rounds every job up to a whole minute and the job takes thirteen seconds, so
+# deleting a step saves exactly nothing. And making it slower buys nothing
+# either, because delivery is already throttled below the request rate.
+#
+# DO NOT raise the interval towards MAX_RERUN_AGE_SECONDS. A run cancelled with
+# every step green (#342) is only recoverable inside that window, and the gap
+# GitHub delivers is several times the gap requested -- so a cron of 15 minutes
+# is already an hour of real latency, which is the whole window. The contract in
+# scripts/tests/test-unity-workflow-matrix-contract.ps1 pins that relationship
+# against the measured throttle factor rather than leaving it to this comment.
 on:
   schedule:
     - cron: "*/5 * * * *"
@@ -124,6 +150,9 @@ jobs:
           MAX_RERUNS_PER_DAY: "1"
           MAX_RERUN_AGE_SECONDS: "3600"
           MAX_RERUN_ATTEMPT: "1"
+          # How long a run must have been QUEUED to be a candidate, not how
+          # quickly one is noticed: this workflow is delivered every ~21 min
+          # (see the note on `on: schedule`), so anything under that is free.
           MIN_QUEUE_AGE_SECONDS: "300"
           DEFAULT_EXCLUDED_WORKFLOWS: "release.yml"
           EXTRA_EXCLUDED_WORKFLOWS: ${{ vars.WATCHDOG_EXCLUDED_WORKFLOWS }}

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -270,9 +270,11 @@ Lint-error-code prefixes (`^[A-Z]{2,}\d{3}$` tokens like `UNH001`, `PWS002`) mus
   dialog at all. If the script exits 3, report that and ask — do not go looking for another way to
   ask the desktop.
 
-  With the cache populated nothing prompts at all. With it **empty**, git falls back to the editor's
-  own `GIT_ASKPASS` dialog, which a helper cannot suppress — so an exit 3 is a request for a human,
-  not an invitation to retry the operation until something answers.
+  With the cache populated nothing prompts at all. With it **empty**, git falls back to
+  `GIT_ASKPASS`, which no credential helper can override — so the container **is** the askpass:
+  `remoteEnv` points it at `scripts/git-askpass-refuse.sh`, which prints the fix to stderr and exits
+  non-zero. An exit 3 is therefore a request for a human, not an invitation to retry the operation
+  until something answers.
 
   When it does prompt: **hang versus immediate answer is the only discriminator**, never empty
   output. A blocked helper is a dialog nobody has answered yet, and reading its truncated empty read

--- a/.llm/skills/validate-before-commit.md
+++ b/.llm/skills/validate-before-commit.md
@@ -195,6 +195,18 @@ npm run lint:docs         # Validates links
 npm run lint:markdown     # Structural rules
 ```
 
+**A link from `docs/` to a file OUTSIDE `docs/` needs the MkDocs build, not `lint:docs`.**
+`lint:docs` walks markdown-to-markdown links and passes a link to a `.sh`, `.ps1` or any other repo
+file — while `Validate Documentation` fails the whole run on it, because `mkdocs build --strict`
+turns "target not found among documentation files" into an error. Reference such a file in
+backticks, or link the GitHub blob URL the way `docs/project/llms-txt.md` does. The strict build is
+runnable in this devcontainer and takes about 40 seconds, which is far cheaper than finding out on a
+pull request:
+
+```bash
+.venv/bin/mkdocs build --strict    # writes to the gitignored site/
+```
+
 ### CHANGELOG or Project JSON Changes
 
 ```bash

--- a/.llm/skills/validate-before-commit.md
+++ b/.llm/skills/validate-before-commit.md
@@ -199,9 +199,9 @@ npm run lint:markdown     # Structural rules
 `lint:docs` walks markdown-to-markdown links and passes a link to a `.sh`, `.ps1` or any other repo
 file — while `Validate Documentation` fails the whole run on it, because `mkdocs build --strict`
 turns "target not found among documentation files" into an error. Reference such a file in
-backticks, or link the GitHub blob URL the way `docs/project/llms-txt.md` does. The strict build is
-runnable in this devcontainer and takes about 40 seconds, which is far cheaper than finding out on a
-pull request:
+backticks, or link the GitHub blob URL the way
+[the llms.txt page](../../docs/project/llms-txt.md) does. The strict build is runnable in this
+devcontainer and takes about 40 seconds, which is far cheaper than finding out on a pull request:
 
 ```bash
 .venv/bin/mkdocs build --strict    # writes to the gitignored site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`AnimationClip.GetSpriteFramesFromClip()`**: every sprite a clip references, paired with the curve binding that supplies it, so a caller can tell which object each sprite is animated onto. `GetSpritesFromClip(path, propertyName, type)` filters on that binding, and `UnityExtensions.SpriteBindingProperty` names the property a sprite is normally bound to. Editor-only, like the existing `GetSpritesFromClip()`. See [Sprites from an AnimationClip](./docs/features/utilities/math-and-extensions.md#sprites-from-an-animationclip) ([#451](https://github.com/Ambiguous-Interactive/unity-helpers/issues/451)).
+
 - **`AssetChangeDetectionUtility.Enabled`**: turn the `[DetectAssetChanged]` watcher on or off, with `ResetEnabledToDefault()` and `EnabledScope(bool)` ([#327](https://github.com/Ambiguous-Interactive/unity-helpers/issues/327)).
 - **`AssetChangeDetectionEnabledScope`**: an `IDisposable` that restores the watcher's previous enablement on dispose.
 - **`SingleThreadedThreadPool.DrainAsync()`**: closes the pool and waits for already-queued work to finish, for queues you cannot afford to drop. Disposal still cancels. `IsAcceptingWork` reports whether `Enqueue` still does anything ([#318](https://github.com/Ambiguous-Interactive/unity-helpers/issues/318)).

--- a/Editor/AnimationEventEditorViewModel.cs
+++ b/Editor/AnimationEventEditorViewModel.cs
@@ -8,6 +8,7 @@ namespace WallstopStudios.UnityHelpers.Editor
     using System.Collections.Generic;
     using UnityEditor;
     using UnityEngine;
+    using WallstopStudios.UnityHelpers.Core.Extension;
     using WallstopStudios.UnityHelpers.Utils;
 
     /// <summary>
@@ -60,7 +61,11 @@ namespace WallstopStudios.UnityHelpers.Editor
 
             ObjectReferenceKeyframe[] curve = AnimationUtility.GetObjectReferenceCurve(
                 clip,
-                EditorCurveBinding.PPtrCurve(string.Empty, typeof(SpriteRenderer), "m_Sprite")
+                EditorCurveBinding.PPtrCurve(
+                    string.Empty,
+                    typeof(SpriteRenderer),
+                    UnityExtensions.SpriteBindingProperty
+                )
             );
             if (curve != null)
             {

--- a/Editor/Sprites/AnimationCreatorWindow.cs
+++ b/Editor/Sprites/AnimationCreatorWindow.cs
@@ -1821,7 +1821,11 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
 
             AnimationUtility.SetObjectReferenceCurve(
                 clip,
-                EditorCurveBinding.PPtrCurve("", typeof(SpriteRenderer), "m_Sprite"),
+                EditorCurveBinding.PPtrCurve(
+                    "",
+                    typeof(SpriteRenderer),
+                    UnityExtensions.SpriteBindingProperty
+                ),
                 keyframes
             );
 
@@ -2529,7 +2533,11 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
 
             AnimationUtility.SetObjectReferenceCurve(
                 clip,
-                EditorCurveBinding.PPtrCurve("", typeof(SpriteRenderer), "m_Sprite"),
+                EditorCurveBinding.PPtrCurve(
+                    "",
+                    typeof(SpriteRenderer),
+                    UnityExtensions.SpriteBindingProperty
+                ),
                 keyframes
             );
 

--- a/Editor/Sprites/AnimationViewerWindow.cs
+++ b/Editor/Sprites/AnimationViewerWindow.cs
@@ -95,7 +95,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                             binding.type == typeof(SpriteRenderer)
                             && string.Equals(
                                 binding.propertyName,
-                                "m_Sprite",
+                                UnityExtensions.SpriteBindingProperty,
                                 StringComparison.Ordinal
                             )
                         )
@@ -1498,7 +1498,11 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             {
                 if (
                     b.type == typeof(SpriteRenderer)
-                    && string.Equals(b.propertyName, "m_Sprite", StringComparison.Ordinal)
+                    && string.Equals(
+                        b.propertyName,
+                        UnityExtensions.SpriteBindingProperty,
+                        StringComparison.Ordinal
+                    )
                     && (
                         string.IsNullOrWhiteSpace(bindingPath)
                         || string.Equals(b.path, bindingPath, StringComparison.Ordinal)
@@ -1517,7 +1521,11 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 {
                     if (
                         b.type == typeof(SpriteRenderer)
-                        && string.Equals(b.propertyName, "m_Sprite", StringComparison.Ordinal)
+                        && string.Equals(
+                            b.propertyName,
+                            UnityExtensions.SpriteBindingProperty,
+                            StringComparison.Ordinal
+                        )
                     )
                     {
                         spriteBinding = b;

--- a/Editor/Sprites/SpriteSheetAnimationCreator.cs
+++ b/Editor/Sprites/SpriteSheetAnimationCreator.cs
@@ -1474,7 +1474,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 {
                     type = typeof(SpriteRenderer),
                     path = "",
-                    propertyName = "m_Sprite",
+                    propertyName = UnityExtensions.SpriteBindingProperty,
                 };
 
                 ObjectReferenceKeyframe[] keyframes = new ObjectReferenceKeyframe[

--- a/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/FuzzTests.cs
+++ b/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/FuzzTests.cs
@@ -187,9 +187,10 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
             internal IReadOnlyList<byte[]> Seeds { get; }
 
             /// <summary>
-            /// The field numbers this contract's members occupy, read out of the seeds rather than
-            /// declared here. A member added to a contract and set in its sample is covered by the
-            /// gate automatically; a list written down beside it would have to be remembered.
+            /// The wire keys this contract's members occupy -- <c>(field &lt;&lt; 3) | wireType</c>
+            /// -- read out of the seeds rather than declared here. A member added to a contract and
+            /// set in its sample is covered by the gate automatically; a list written down beside it
+            /// would have to be remembered.
             /// </summary>
             internal IReadOnlyList<int> Members { get; }
 
@@ -322,11 +323,20 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
         /// How far the reader got. A key that ends at or before this offset is one the reader
         /// dispatched on, which is the question a per-member coverage claim is really asking.
         /// </param>
-        /// <param name="fields">Receives the field numbers found.</param>
+        /// <param name="fields">Receives the keys found, as <c>(field &lt;&lt; 3) | wireType</c>.</param>
         /// <remarks>
+        /// <para>
         /// A deliberately independent walk rather than a hook inside the reader: instrumenting the
         /// thing under test to report on itself would let a reader that silently skipped a member
         /// look covered.
+        /// </para>
+        /// <para>
+        /// The <b>whole key</b> is recorded, not the field number. A generated reader dispatches on
+        /// field and wire type together and skips a field whose wire type it does not expect -- and
+        /// the bit-flip mutator changes a wire type on roughly three keys in eight. Recording the
+        /// field alone would count those skips as "this member's reader ran", which is exactly what
+        /// the gate's failure message denies.
+        /// </para>
         /// </remarks>
         private static void ScanTopLevelFields(byte[] payload, int limit, ISet<int> fields)
         {
@@ -347,7 +357,7 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
 
                 if (offset <= limit)
                 {
-                    fields.Add(field);
+                    fields.Add((field << 3) | wireType);
                 }
 
                 switch (wireType)
@@ -991,10 +1001,15 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
             internal string DescribeMembers(string target, IReadOnlyList<int> members)
             {
                 StringBuilder text = new StringBuilder(Describe(target));
-                text.Append("; per member:");
+                text.Append("; per member (field/wire=hits):");
                 foreach (int member in members)
                 {
-                    text.Append(' ').Append(member).Append('=').Append(HitsFor(member));
+                    text.Append(' ')
+                        .Append(member >> 3)
+                        .Append('/')
+                        .Append(member & 7)
+                        .Append('=')
+                        .Append(HitsFor(member));
                 }
 
                 return text.ToString();
@@ -1181,6 +1196,16 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
         /// the formatter also refused.
         /// </para>
         /// <para>
+        /// <b>What is and is not incremental, stated rather than implied.</b> The facade reaches the
+        /// same formatter with the same bytes, so it decodes nothing this suite has not already
+        /// decoded -- against the shipped code every assertion below except the
+        /// unexpected-exception arm is unreachable, and saying otherwise would oversell it. They are
+        /// <i>regression</i> assertions, and the mutations prove they fire: making
+        /// <c>TryDeserializeAs</c> decline instead of throwing reddens eight tests here. What the
+        /// facade adds over the formatter is the SHAPE OF A REFUSAL, and that is the thing a corrupt
+        /// save file meets and the thing nothing pinned.
+        /// </para>
+        /// <para>
         /// Allocation is measured on the formatter's own read rather than here, because a throw
         /// allocates an exception and a stack trace -- charging that to the payload would say a
         /// refusal is more expensive than an acceptance, which is true and irrelevant.
@@ -1321,8 +1346,9 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                         coverage.HitsFor(member),
                         minimumHits,
                         coverage.DescribeMembers(target.Name, target.Members)
-                            + $" -- field {member} was dispatched on fewer than {minimumHits} "
-                            + "times, so this suite does not fuzz that member's reader."
+                            + $" -- field {member >> 3} at wire type {member & 7} was dispatched "
+                            + $"on fewer than {minimumHits} times, so this suite does not fuzz that "
+                            + "member's reader."
                     );
                 }
             }
@@ -1717,15 +1743,18 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
         /// </summary>
         /// <param name="hex">The payload.</param>
         /// <param name="limit">How far the reader is claimed to have got.</param>
-        /// <returns>The field numbers found, comma separated.</returns>
-        [TestCase("0801", 2, ExpectedResult = "1")]
-        [TestCase("08011002", 4, ExpectedResult = "1,2")]
-        [TestCase("08011002", 1, ExpectedResult = "1")]
+        /// <returns>The keys found, as <c>field/wireType</c>, comma separated.</returns>
+        [TestCase("0801", 2, ExpectedResult = "1/0")]
+        [TestCase("08011002", 4, ExpectedResult = "1/0,2/0")]
+        [TestCase("08011002", 1, ExpectedResult = "1/0")]
         [TestCase("08011002", 0, ExpectedResult = "")]
-        [TestCase("0A026162 1003", 6, ExpectedResult = "1,2")]
-        [TestCase("0A05", 2, ExpectedResult = "1")]
-        [TestCase("0D0000803F 1103000000000000 00", 14, ExpectedResult = "1,2")]
-        [TestCase("1B 0801", 3, ExpectedResult = "3")]
+        [TestCase("0A026162 1003", 6, ExpectedResult = "1/2,2/0")]
+        [TestCase("0A05", 2, ExpectedResult = "1/2")]
+        [TestCase("0D0000803F 1103000000000000 00", 14, ExpectedResult = "1/5,2/1")]
+        [TestCase("1B 0801", 3, ExpectedResult = "3/3")]
+        // One field at two wire types is two keys, because it is two dispatch outcomes: the reader
+        // serves the one its member declares and skips the other as unknown.
+        [TestCase("0801 0A0161", 5, ExpectedResult = "1/0,1/2")]
         [TestCase("00", 1, ExpectedResult = "")]
         [TestCase("FFFFFFFFFFFFFFFFFFFF7F", 11, ExpectedResult = "")]
         [TestCase("", 0, ExpectedResult = "")]
@@ -1734,9 +1763,15 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
             int limit
         )
         {
-            SortedSet<int> fields = new SortedSet<int>();
-            ScanTopLevelFields(FromHex(hex.Replace(" ", string.Empty)), limit, fields);
-            return string.Join(",", fields);
+            SortedSet<int> keys = new SortedSet<int>();
+            ScanTopLevelFields(FromHex(hex.Replace(" ", string.Empty)), limit, keys);
+            List<string> rendered = new List<string>(keys.Count);
+            foreach (int key in keys)
+            {
+                rendered.Add($"{key >> 3}/{key & 7}");
+            }
+
+            return string.Join(",", rendered);
         }
 
         [Test]

--- a/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/FuzzTests.cs
+++ b/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/FuzzTests.cs
@@ -38,32 +38,85 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
         /// Iterations per target per strategy. Raise it locally with <c>WPROTO_FUZZ_ITERATIONS</c>;
         /// CI pays a fixed, small cost every run rather than an occasional large one.
         /// </summary>
-        private static readonly int Iterations = ResolveIterations();
+        private static readonly int Iterations = ResolveIterations(
+            Environment.GetEnvironmentVariable("WPROTO_FUZZ_ITERATIONS")
+        );
+
+        private const int DefaultIterations = 1500;
 
         /// <summary>
-        /// A decode may allocate the graph it returns and nothing else of consequence. The multiple
-        /// is deliberately loose -- a dictionary slot costs many times the bytes that describe it --
-        /// because the failure this catches is not overhead, it is a payload that names a size
-        /// nothing in it pays for. The header that wrapped to zero asked for 8 GB from sixteen
-        /// bytes, which is five hundred million times its own length.
+        /// The smallest corpus the coverage gates below can be asked about. Under it they report a
+        /// defect that does not exist -- a member unreached because nothing has generated a payload
+        /// for it yet is a statement about the sample size, not about the fuzzer.
         /// </summary>
-        private const long AllocationSlackBytes = 128 * 1024;
+        /// <remarks>
+        /// The environment variable exists to <b>raise</b> the count, so flooring it costs nothing a
+        /// caller asked for. Measured on the mutation corpus, which is the gated one: at three
+        /// iterations not one mutated payload survived and the suite reported that as a defect.
+        /// </remarks>
+        private const int MinimumIterations = 200;
+
+        /// <summary>
+        /// A decode may allocate the graph it returns and nothing else of consequence.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Both numbers are measured</b>, and the teardown below prints the measurement every run
+        /// so the next person to tighten them does not have to trust this sentence. Across every
+        /// strategy here, with the readers warmed: the worst allocation is <b>160 KB</b>, by the
+        /// 20,000-level nesting bomb on its own 74 KB payload, which is 2.2x its length; and the
+        /// worst <b>per-byte</b> cost is <b>152x</b> -- 304 bytes from two, which is one contract
+        /// object and nothing else. The fixed term covers the second and the multiple covers the
+        /// first, with roughly an order of magnitude over each.
+        /// </para>
+        /// <para>
+        /// The previous 128 KB + 256x was inert: it accepted a 1,300x amplification on a 96-byte
+        /// payload, so the only defect it could catch is one that asks for gigabytes. Both that have
+        /// actually happened here did -- but a bug that tops out at a megabyte is a denial of
+        /// service on a console all the same.
+        /// <see cref="TheAllocationCeilingCatchesABoundedAmplification"/> is the proof that the
+        /// replacement is not inert either, and it is an assertion rather than an argument.
+        /// </para>
+        /// </remarks>
+        private const long AllocationSlackBytes = 4 * 1024;
 
         private const long AllocationMultiple = 256;
 
-        private static int ResolveIterations()
+        /// <summary>
+        /// Resolves the iteration count from the environment, never below
+        /// <see cref="MinimumIterations"/>.
+        /// </summary>
+        /// <param name="configured">The raw environment value, which may be absent or nonsense.</param>
+        /// <returns>The iteration count every strategy runs.</returns>
+        internal static int ResolveIterations(string configured)
         {
-            string configured = Environment.GetEnvironmentVariable("WPROTO_FUZZ_ITERATIONS");
             if (
                 !string.IsNullOrEmpty(configured)
                 && int.TryParse(configured, out int parsed)
                 && parsed > 0
             )
             {
-                return parsed;
+                return parsed < MinimumIterations ? MinimumIterations : parsed;
             }
 
-            return 1500;
+            return DefaultIterations;
+        }
+
+        [TestCase(null, ExpectedResult = DefaultIterations)]
+        [TestCase("", ExpectedResult = DefaultIterations)]
+        [TestCase("0", ExpectedResult = DefaultIterations)]
+        [TestCase("-1", ExpectedResult = DefaultIterations)]
+        [TestCase("2.5", ExpectedResult = DefaultIterations)]
+        [TestCase("many", ExpectedResult = DefaultIterations)]
+        [TestCase("3", ExpectedResult = MinimumIterations)]
+        [TestCase("200", ExpectedResult = MinimumIterations)]
+        [TestCase("5000", ExpectedResult = 5000)]
+        public int TheIterationCountNeverFallsBelowWhatTheGatesCanBeAskedAbout(string configured)
+        {
+            // A count of 3 turned this suite red on a coverage gate, naming a defect that does not
+            // exist -- the corpus had not had a chance to reach the member, and the assertion said
+            // the fuzzer had stopped covering it.
+            return ResolveIterations(configured);
         }
 
         /// <summary>
@@ -79,6 +132,33 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
         private delegate bool ReEncodePayload(byte[] payload, out byte[] first, out byte[] second);
 
         /// <summary>
+        /// Decodes through <see cref="WProtoFacade"/> -- the entry point a shipped game reaches
+        /// through <c>Serializer.ProtoDeserialize</c>. Unlike <see cref="ReadPayload"/> this one is
+        /// expected to <b>throw</b> on a payload it refuses, deliberately, so what it throws is the
+        /// contract under test.
+        /// </summary>
+        private delegate bool FacadeReadPayload(byte[] payload);
+
+        /// <summary>
+        /// Builds a random value of the contract's type. The counterpart to a mutator: the read
+        /// strategies cover payloads an attacker constructs, this covers values a <b>game</b>
+        /// constructs, which is the only way a <c>Measure</c>/<c>Write</c> disagreement on a shape
+        /// no decode produces can be seen.
+        /// </summary>
+        private delegate T ValueFactory<out T>(ref FuzzRandom random);
+
+        /// <summary>
+        /// Builds a random value, measures it, and writes it into a buffer of exactly that many
+        /// bytes. Reports what <c>Measure</c> promised, what <c>Write</c> consumed, and the bytes.
+        /// </summary>
+        private delegate bool WriteGeneratedValue(
+            ref FuzzRandom random,
+            out int measured,
+            out int written,
+            out byte[] encoded
+        );
+
+        /// <summary>
         /// A decode target: the seeds a mutator starts from, and the reads under test.
         /// </summary>
         private sealed class Target
@@ -86,23 +166,40 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
             internal Target(
                 string name,
                 IReadOnlyList<byte[]> seeds,
+                IReadOnlyList<int> members,
                 ReadPayload read,
-                ReEncodePayload reEncode
+                ReEncodePayload reEncode,
+                FacadeReadPayload facadeRead,
+                WriteGeneratedValue writeGenerated
             )
             {
                 Name = name;
                 Seeds = seeds;
+                Members = members;
                 Read = read;
                 ReEncode = reEncode;
+                FacadeRead = facadeRead;
+                WriteGenerated = writeGenerated;
             }
 
             internal string Name { get; }
 
             internal IReadOnlyList<byte[]> Seeds { get; }
 
+            /// <summary>
+            /// The field numbers this contract's members occupy, read out of the seeds rather than
+            /// declared here. A member added to a contract and set in its sample is covered by the
+            /// gate automatically; a list written down beside it would have to be remembered.
+            /// </summary>
+            internal IReadOnlyList<int> Members { get; }
+
             internal ReadPayload Read { get; }
 
             internal ReEncodePayload ReEncode { get; }
+
+            internal FacadeReadPayload FacadeRead { get; }
+
+            internal WriteGeneratedValue WriteGenerated { get; }
         }
 
         private static byte[] Encode<T>(IWProtoFormatter<T> formatter, T value)
@@ -119,7 +216,7 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
             return encoded;
         }
 
-        private static Target For<T>(string name, params T[] samples)
+        private static Target For<T>(string name, ValueFactory<T> factory, params T[] samples)
         {
             // An all-default contract encodes to ZERO bytes, because every member equals its
             // default and protobuf omits those. Such a seed is not a mutation seed at all -- there
@@ -142,10 +239,34 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                 $"{name}: every sample encoded to nothing, so this target has no mutation corpus."
             );
 
+            SortedSet<int> members = new SortedSet<int>();
+            foreach (byte[] seed in seeds)
+            {
+                ScanTopLevelFields(seed, seed.Length, members);
+            }
+
+            Assert.IsNotEmpty(
+                members,
+                $"{name}: no member field was found in any seed, so the per-member coverage gate "
+                    + "would be vacuous."
+            );
+
             IWProtoFormatter<T> formatter = WProtoFormatterProvider.Get<T>();
+
+            // The facade answers only for a type it has a formatter for, and that is a property of
+            // the target rather than of a payload -- so it is asked once, here, where "the facade
+            // does not serve this contract at all" reads as itself instead of as every hostile
+            // payload mysteriously declining.
+            Assert.IsTrue(
+                WProtoFacade.TryDeserialize(new ReadOnlySpan<byte>(seeds[0]), out T _),
+                $"{name}: the facade does not serve this contract, so driving hostile bytes through "
+                    + "it would prove nothing."
+            );
+
             return new Target(
                 name,
                 seeds,
+                new List<int>(members),
                 (byte[] payload, out int consumed) =>
                 {
                     WProtoReader reader = new WProtoReader(payload);
@@ -177,8 +298,116 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
 
                     second = Encode(formatter, reDecoded);
                     return second != null;
+                },
+                payload => WProtoFacade.TryDeserialize(new ReadOnlySpan<byte>(payload), out T _),
+                (ref FuzzRandom random, out int measured, out int written, out byte[] encoded) =>
+                {
+                    T value = factory(ref random);
+                    measured = formatter.Measure(value);
+                    encoded = new byte[measured];
+                    WProtoWriter writer = new WProtoWriter(encoded);
+                    bool wrote = formatter.Write(ref writer, value);
+                    written = writer.Position;
+                    return wrote && !writer.Faulted;
                 }
             );
+        }
+
+        /// <summary>
+        /// Records the field numbers a payload presents at its top level, up to
+        /// <paramref name="limit"/> bytes in.
+        /// </summary>
+        /// <param name="payload">The bytes to walk.</param>
+        /// <param name="limit">
+        /// How far the reader got. A key that ends at or before this offset is one the reader
+        /// dispatched on, which is the question a per-member coverage claim is really asking.
+        /// </param>
+        /// <param name="fields">Receives the field numbers found.</param>
+        /// <remarks>
+        /// A deliberately independent walk rather than a hook inside the reader: instrumenting the
+        /// thing under test to report on itself would let a reader that silently skipped a member
+        /// look covered.
+        /// </remarks>
+        private static void ScanTopLevelFields(byte[] payload, int limit, ISet<int> fields)
+        {
+            int offset = 0;
+            while (offset < payload.Length)
+            {
+                if (!TryScanVarint(payload, ref offset, out ulong key))
+                {
+                    return;
+                }
+
+                int field = (int)(key >> 3);
+                int wireType = (int)(key & 7);
+                if (field <= 0)
+                {
+                    return;
+                }
+
+                if (offset <= limit)
+                {
+                    fields.Add(field);
+                }
+
+                switch (wireType)
+                {
+                    case 0:
+                        if (!TryScanVarint(payload, ref offset, out ulong _))
+                        {
+                            return;
+                        }
+
+                        break;
+                    case 1:
+                        offset += 8;
+                        break;
+                    case 5:
+                        offset += 4;
+                        break;
+                    case 2:
+                        if (!TryScanVarint(payload, ref offset, out ulong length))
+                        {
+                            return;
+                        }
+
+                        if (length > (ulong)(payload.Length - offset))
+                        {
+                            return;
+                        }
+
+                        offset += (int)length;
+                        break;
+                    default:
+                        return;
+                }
+
+                if (offset > payload.Length)
+                {
+                    return;
+                }
+            }
+        }
+
+        private static bool TryScanVarint(byte[] payload, ref int offset, out ulong value)
+        {
+            value = 0;
+            for (int shift = 0; shift < 64; shift += 7)
+            {
+                if (offset >= payload.Length)
+                {
+                    return false;
+                }
+
+                byte current = payload[offset++];
+                value |= (ulong)(current & 0x7F) << shift;
+                if ((current & 0x80) == 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -192,24 +421,33 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
             {
                 For(
                     "scalars",
+                    RandomScalar,
                     new ScalarContract(),
+                    // Every member is set, because the seeds are what the per-member coverage gate
+                    // reads its expectations out of: a member left at its default is omitted from
+                    // the wire, so leaving one unset here quietly excuses the corpus from covering
+                    // it.
                     new ScalarContract
                     {
                         Int32 = -1,
                         Int64 = long.MinValue,
+                        UInt32 = 11,
                         UInt64 = ulong.MaxValue,
                         Flag = true,
                         Single = 1.5f,
                         Double = -2.5,
                         Text = "seed",
                         Bytes = new byte[] { 1, 2, 3 },
+                        Enum = Mode.Careful,
                         MaybeDouble = 0.25,
                         Int16 = -300,
+                        Hidden = 5,
                         Counted = 7,
                     }
                 ),
                 For(
                     "nested",
+                    RandomNesting,
                     new NestingContract(),
                     new NestingContract
                     {
@@ -221,6 +459,7 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                 ),
                 For(
                     "repeated",
+                    RandomRepeated,
                     new RepeatedContract(),
                     new RepeatedContract
                     {
@@ -230,6 +469,7 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                         Doubles = new[] { 0.5, -1.5 },
                         Longs = new ulong[] { 1, ulong.MaxValue },
                         Flags = new[] { true, false },
+                        Modes = new[] { Mode.Fast, Mode.Careful },
                         Points = new[]
                         {
                             new Outer.Point { X = 1, Y = 2 },
@@ -245,6 +485,7 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                 ),
                 For(
                     "polymorphic",
+                    RandomInclude,
                     new IncludeHolder(),
                     new IncludeHolder
                     {
@@ -254,6 +495,7 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                 ),
                 For(
                     "rectangular",
+                    RandomRectangular,
                     new RectangularArrayContract(),
                     new RectangularArrayContract
                     {
@@ -273,6 +515,13 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                                 new Outer.Point { X = 1, Y = 1 },
                             },
                         },
+                        Layers = new[]
+                        {
+                            new[,]
+                            {
+                                { 1, 2 },
+                            },
+                        },
                         Frames = new List<int[,]>
                         {
                             new[,]
@@ -280,9 +529,347 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                                 { 5 },
                             },
                         },
+                        Named = new Dictionary<string, int[,]>
+                        {
+                            {
+                                "k",
+                                new[,]
+                                {
+                                    { 7 },
+                                }
+                            },
+                        },
+                        Rows = new int[,][]
+                        {
+                            { new[] { 1, 2 } },
+                        },
+                        Blobs = new byte[,]
+                        {
+                            { 1, 2 },
+                        },
                     }
                 ),
             };
+        }
+
+        /// <summary>
+        /// A string with every UTF-8 width in it, plus the one shape an encoder can disagree with
+        /// itself about: a <b>lone surrogate</b>, which has no encoding and is replaced. That is the
+        /// case where <c>Measure</c> (<c>GetByteCount</c>) and <c>Write</c> (<c>GetBytes</c>) could
+        /// promise different lengths, which is half the reason to fuzz the writer at all.
+        /// </summary>
+        private static string RandomText(ref FuzzRandom random)
+        {
+            switch (random.Next(6))
+            {
+                case 0:
+                    return null;
+                case 1:
+                    return string.Empty;
+                default:
+                    int length = random.Next(12);
+                    char[] text = new char[length];
+                    for (int index = 0; index < length; ++index)
+                    {
+                        switch (random.Next(4))
+                        {
+                            case 0:
+                                text[index] = (char)(0x20 + random.Next(0x5F));
+                                break;
+                            case 1:
+                                text[index] = (char)(0x80 + random.Next(0x700));
+                                break;
+                            case 2:
+                                text[index] = (char)(0x0800 + random.Next(0x800));
+                                break;
+                            default:
+                                text[index] = (char)(0xD800 + random.Next(0x800));
+                                break;
+                        }
+                    }
+
+                    return new string(text);
+            }
+        }
+
+        private static byte[] RandomBytes(ref FuzzRandom random)
+        {
+            switch (random.Next(6))
+            {
+                case 0:
+                    return null;
+                case 1:
+                    return Array.Empty<byte>();
+                default:
+                    byte[] value = new byte[random.Next(16)];
+                    for (int index = 0; index < value.Length; ++index)
+                    {
+                        value[index] = random.NextByte();
+                    }
+
+                    return value;
+            }
+        }
+
+        /// <summary>
+        /// Null, empty, or one to four elements -- but never a <b>null element</b>, which has no
+        /// encoding at all and is a documented throw rather than a decode failure.
+        /// </summary>
+        private static T[] RandomArray<T>(ref FuzzRandom random, ValueFactory<T> element)
+        {
+            switch (random.Next(6))
+            {
+                case 0:
+                    return null;
+                case 1:
+                    return Array.Empty<T>();
+                default:
+                    T[] values = new T[1 + random.Next(4)];
+                    for (int index = 0; index < values.Length; ++index)
+                    {
+                        values[index] = element(ref random);
+                    }
+
+                    return values;
+            }
+        }
+
+        private static List<T> RandomList<T>(ref FuzzRandom random, ValueFactory<T> element)
+        {
+            T[] values = RandomArray(ref random, element);
+            return values == null ? null : new List<T>(values);
+        }
+
+        private static int RandomInt32(ref FuzzRandom random)
+        {
+            return (int)random.Next();
+        }
+
+        private static double RandomDouble(ref FuzzRandom random)
+        {
+            return BitConverter.Int64BitsToDouble((long)random.Next());
+        }
+
+        private static Mode RandomMode(ref FuzzRandom random)
+        {
+            switch (random.Next(3))
+            {
+                case 0:
+                    return Mode.None;
+                case 1:
+                    return Mode.Fast;
+                default:
+                    return Mode.Careful;
+            }
+        }
+
+        private static Outer.Point RandomPoint(ref FuzzRandom random)
+        {
+            return new Outer.Point { X = (int)random.Next(), Y = (int)random.Next() };
+        }
+
+        private static string RandomNonNullText(ref FuzzRandom random)
+        {
+            return RandomText(ref random) ?? string.Empty;
+        }
+
+        private static byte[] RandomNonNullBytes(ref FuzzRandom random)
+        {
+            return RandomBytes(ref random) ?? Array.Empty<byte>();
+        }
+
+        private static EmptyContract RandomEmpty(ref FuzzRandom random)
+        {
+            _ = random.Next();
+            return new EmptyContract();
+        }
+
+        private static ulong RandomUInt64(ref FuzzRandom random)
+        {
+            return random.Next();
+        }
+
+        private static bool RandomBool(ref FuzzRandom random)
+        {
+            return random.Next(2) == 0;
+        }
+
+        private static short RandomInt16(ref FuzzRandom random)
+        {
+            return (short)random.Next();
+        }
+
+        private static ScalarContract RandomScalar(ref FuzzRandom random)
+        {
+            return new ScalarContract
+            {
+                Int32 = (int)random.Next(),
+                Int64 = (long)random.Next(),
+                UInt32 = (uint)random.Next(),
+                UInt64 = random.Next(),
+                Flag = random.Next(2) == 0,
+                // Reconstituted from bits rather than sampled from a range, so NaN, the infinities
+                // and every subnormal are in the corpus.
+                Single = BitConverter.Int32BitsToSingle((int)random.Next()),
+                Double = RandomDouble(ref random),
+                Text = RandomText(ref random),
+                Bytes = RandomBytes(ref random),
+                Enum = RandomMode(ref random),
+                MaybeDouble = random.Next(4) == 0 ? (double?)null : RandomDouble(ref random),
+                Int16 = (short)random.Next(),
+                Hidden = (int)random.Next(),
+                Counted = (int)random.Next(),
+            };
+        }
+
+        private static NestingContract RandomNesting(ref FuzzRandom random)
+        {
+            return new NestingContract
+            {
+                Id = (int)random.Next(),
+                Child =
+                    random.Next(4) == 0 ? null : new HookedContract { Value = (int)random.Next() },
+                Where = RandomPoint(ref random),
+                MaybeWhere = random.Next(4) == 0 ? (Outer.Point?)null : RandomPoint(ref random),
+            };
+        }
+
+        private static RepeatedContract RandomRepeated(ref FuzzRandom random)
+        {
+            return new RepeatedContract
+            {
+                Ints = RandomArray<int>(ref random, RandomInt32),
+                IntList = RandomList<int>(ref random, RandomInt32),
+                Texts = RandomArray<string>(ref random, RandomNonNullText),
+                Doubles = RandomArray<double>(ref random, RandomDouble),
+                Longs = RandomArray<ulong>(ref random, RandomUInt64),
+                Flags = RandomArray<bool>(ref random, RandomBool),
+                Modes = RandomArray<Mode>(ref random, RandomMode),
+                Points = RandomArray<Outer.Point>(ref random, RandomPoint),
+                Messages = RandomArray<EmptyContract>(ref random, RandomEmpty),
+                Blobs = RandomArray<byte[]>(ref random, RandomNonNullBytes),
+                PointList = RandomList<Outer.Point>(ref random, RandomPoint),
+                Shorts = RandomArray<short>(ref random, RandomInt16),
+            };
+        }
+
+        private static IncludeHolder RandomInclude(ref FuzzRandom random)
+        {
+            IncludeBase value;
+            switch (random.Next(5))
+            {
+                case 0:
+                    value = null;
+                    break;
+                case 1:
+                    value = new IncludeBase();
+                    break;
+                case 2:
+                    value = new IncludeAlpha { AlphaOnly = (int)random.Next() };
+                    break;
+                case 3:
+                    value = new IncludeBeta { BetaOnly = RandomDouble(ref random) };
+                    break;
+                default:
+                    value = new IncludeGamma { GammaOnly = random.Next(2) == 0 };
+                    break;
+            }
+
+            if (value != null)
+            {
+                value.Id = (int)random.Next();
+                value.Label = RandomText(ref random);
+            }
+
+            return new IncludeHolder { Value = value, Trailer = (int)random.Next() };
+        }
+
+        /// <summary>
+        /// Axes are kept to 0-2 deliberately: a zero axis is the shape whose product annihilates
+        /// every other axis, and it is legal to <b>write</b>, so it belongs in the generated corpus
+        /// that has to survive its own encoding.
+        /// </summary>
+        private static int[,] RandomGrid(ref FuzzRandom random)
+        {
+            if (random.Next(5) == 0)
+            {
+                return null;
+            }
+
+            int[,] grid = new int[random.Next(3), random.Next(3)];
+            for (int row = 0; row < grid.GetLength(0); ++row)
+            {
+                for (int column = 0; column < grid.GetLength(1); ++column)
+                {
+                    grid[row, column] = (int)random.Next();
+                }
+            }
+
+            return grid;
+        }
+
+        private static int[,] RandomNonNullGrid(ref FuzzRandom random)
+        {
+            return RandomGrid(ref random) ?? new int[0, 0];
+        }
+
+        private static RectangularArrayContract RandomRectangular(ref FuzzRandom random)
+        {
+            RectangularArrayContract value = new RectangularArrayContract
+            {
+                Grid = RandomGrid(ref random),
+                Labels = random.Next(4) == 0 ? null : new string[random.Next(3), random.Next(3)],
+                Layers = RandomArray<int[,]>(ref random, RandomNonNullGrid),
+                Frames = RandomList<int[,]>(ref random, RandomNonNullGrid),
+            };
+
+            if (random.Next(4) != 0)
+            {
+                value.Volume = new int[random.Next(3), random.Next(3), random.Next(3)];
+            }
+
+            if (random.Next(4) != 0)
+            {
+                value.Points = new Outer.Point[random.Next(3), random.Next(3)];
+            }
+
+            if (random.Next(4) != 0)
+            {
+                value.Blobs = new byte[random.Next(3), random.Next(3)];
+            }
+
+            if (random.Next(4) != 0)
+            {
+                value.Rows = new int[random.Next(2), random.Next(2)][];
+                for (int row = 0; row < value.Rows.GetLength(0); ++row)
+                {
+                    for (int column = 0; column < value.Rows.GetLength(1); ++column)
+                    {
+                        value.Rows[row, column] = new int[random.Next(3)];
+                    }
+                }
+            }
+
+            if (random.Next(4) != 0)
+            {
+                value.Named = new Dictionary<string, int[,]>
+                {
+                    { "k", RandomNonNullGrid(ref random) },
+                };
+            }
+
+            if (value.Labels != null)
+            {
+                for (int row = 0; row < value.Labels.GetLength(0); ++row)
+                {
+                    for (int column = 0; column < value.Labels.GetLength(1); ++column)
+                    {
+                        value.Labels[row, column] = RandomNonNullText(ref random);
+                    }
+                }
+            }
+
+            return value;
         }
 
         private static string Hex(byte[] payload)
@@ -363,11 +950,32 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
 
             internal int Reached;
 
-            internal void Record(bool accepted, int consumed)
+            /// <summary>
+            /// How many payloads got as far as dispatching on each field number. The corpus-wide
+            /// reach rate cannot answer this: a strategy that reaches the tag reader on every
+            /// payload and then always dies on field 1 scores 100% while nine members are untouched.
+            /// </summary>
+            private readonly Dictionary<int, int> _byMember = new Dictionary<int, int>();
+
+            internal void Record(bool accepted, int consumed, byte[] payload)
             {
                 Payloads += 1;
                 Accepted += accepted ? 1 : 0;
                 Reached += accepted || consumed >= PastTheFirstKey ? 1 : 0;
+
+                SortedSet<int> fields = new SortedSet<int>();
+                ScanTopLevelFields(payload, accepted ? payload.Length : consumed, fields);
+                foreach (int field in fields)
+                {
+                    _byMember.TryGetValue(field, out int hits);
+                    _byMember[field] = hits + 1;
+                }
+            }
+
+            internal int HitsFor(int member)
+            {
+                _byMember.TryGetValue(member, out int hits);
+                return hits;
             }
 
             internal double AcceptanceRate => Payloads == 0 ? 0 : (double)Accepted / Payloads;
@@ -379,6 +987,72 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                 return $"{target}: {Payloads} payloads, {Accepted} accepted, {Reached} reaching a "
                     + "member reader";
             }
+
+            internal string DescribeMembers(string target, IReadOnlyList<int> members)
+            {
+                StringBuilder text = new StringBuilder(Describe(target));
+                text.Append("; per member:");
+                foreach (int member in members)
+                {
+                    text.Append(' ').Append(member).Append('=').Append(HitsFor(member));
+                }
+
+                return text.ToString();
+            }
+        }
+
+        /// <summary>
+        /// The largest allocation any decode in this run charged, and the payload that charged it.
+        /// Printed once at the end so the next person to tighten <see cref="AllocationSlackBytes"/>
+        /// starts from a measurement rather than from a sentence.
+        /// </summary>
+        private static long _worstAllocation;
+
+        private static int _worstAllocationPayloadLength;
+
+        private static string _worstAllocationTarget = "none";
+
+        private static double _worstAllocationRatio;
+
+        private static long _worstRatioAllocation;
+
+        private static int _worstRatioPayloadLength;
+
+        private static string _worstRatioTarget = "none";
+
+        [OneTimeSetUp]
+        public void WarmEveryReaderBeforeAnythingIsMeasured()
+        {
+            // A first decode pays for type initialization, cached lookups and whatever else the
+            // runtime builds on the way -- none of which is the amplification this suite exists to
+            // catch, and all of which lands on iteration zero. Warming here is what lets the ceiling
+            // above be tight enough to mean something instead of loose enough to swallow the first
+            // call.
+            foreach (Target target in Targets())
+            {
+                foreach (byte[] seed in target.Seeds)
+                {
+                    target.Read(seed, out int _);
+                    target.ReEncode(seed, out byte[] _, out byte[] _);
+                    target.FacadeRead(seed);
+                }
+
+                target.Read(Array.Empty<byte>(), out int _);
+                FuzzRandom random = new FuzzRandom(1);
+                target.WriteGenerated(ref random, out int _, out int _, out byte[] _);
+            }
+        }
+
+        [OneTimeTearDown]
+        public void ReportTheWorstAllocationObserved()
+        {
+            TestContext.Progress.WriteLine(
+                $"WallstopProto fuzz: worst decode allocation {_worstAllocation} B on a "
+                    + $"{_worstAllocationPayloadLength} byte {_worstAllocationTarget} payload; "
+                    + $"worst ratio {_worstAllocationRatio:F1}x ({_worstRatioAllocation} B on "
+                    + $"{_worstRatioPayloadLength} bytes, {_worstRatioTarget}). Ceiling is "
+                    + $"{AllocationSlackBytes} + {AllocationMultiple} x length."
+            );
         }
 
         /// <summary>
@@ -420,7 +1094,28 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                     + $"{Environment.NewLine}payload: {Hex(payload)}"
             );
 
-            coverage?.Record(accepted, consumed);
+            // Recorded AFTER the ceiling, so the figure the teardown prints is the worst cost the
+            // ceiling ACCEPTED. Recording first would let the deliberate amplifier in
+            // TheAllocationCeilingCatchesABoundedAmplification set the high-water mark, and the next
+            // person to tune the constants would be reading this suite's own counter-example.
+            if (allocated > _worstAllocation)
+            {
+                _worstAllocation = allocated;
+                _worstAllocationPayloadLength = payload.Length;
+                _worstAllocationTarget = target.Name;
+            }
+
+            if (payload.Length > 0 && (double)allocated / payload.Length > _worstAllocationRatio)
+            {
+                _worstAllocationRatio = (double)allocated / payload.Length;
+                _worstRatioAllocation = allocated;
+                _worstRatioPayloadLength = payload.Length;
+                _worstRatioTarget = target.Name;
+            }
+
+            coverage?.Record(accepted, consumed, payload);
+
+            AssertTheFacadeAnswersTheSameWay(target, payload, accepted, origin);
 
             if (!accepted)
             {
@@ -463,6 +1158,78 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                 $"{target.Name}: encoding is not a fixed point -- the value decoded from an "
                     + $"accepted payload does not survive its own encoding.{Environment.NewLine}"
                     + $"{origin}{Environment.NewLine}payload: {Hex(payload)}"
+            );
+        }
+
+        /// <summary>
+        /// Drives the same payload through <see cref="WProtoFacade"/> -- the entry point
+        /// <c>Serializer.ProtoDeserialize</c> reaches, and the one a corrupt save file actually
+        /// meets -- and pins what a refusal looks like from there.
+        /// </summary>
+        /// <param name="target">The contract under test.</param>
+        /// <param name="payload">The hostile bytes.</param>
+        /// <param name="accepted">What the formatter itself answered.</param>
+        /// <param name="origin">The strategy, seed and iteration, for a reproducible failure.</param>
+        /// <remarks>
+        /// <para>
+        /// The facade deliberately <b>throws</b> where the formatter returns <c>false</c>: "no
+        /// formatter for this type" and "this type's formatter refused the payload" are different
+        /// answers, and reporting both as <c>false</c> sent a rejected payload on to protobuf-net,
+        /// which is the path IL2CPP cannot run. That decision is in tension with the
+        /// <c>TryXxx</c>-never-throws rule, so what may escape is asserted here rather than left to
+        /// the reader of the source: exactly <see cref="InvalidOperationException"/>, and only where
+        /// the formatter also refused.
+        /// </para>
+        /// <para>
+        /// Allocation is measured on the formatter's own read rather than here, because a throw
+        /// allocates an exception and a stack trace -- charging that to the payload would say a
+        /// refusal is more expensive than an acceptance, which is true and irrelevant.
+        /// </para>
+        /// </remarks>
+        private static void AssertTheFacadeAnswersTheSameWay(
+            Target target,
+            byte[] payload,
+            bool accepted,
+            string origin
+        )
+        {
+            bool served;
+            try
+            {
+                served = target.FacadeRead(payload);
+            }
+            catch (InvalidOperationException)
+            {
+                Assert.IsFalse(
+                    accepted,
+                    $"{target.Name}: the facade threw for a payload its own formatter ACCEPTED, so "
+                        + $"a legitimate save would fail to load.{Environment.NewLine}{origin}"
+                        + $"{Environment.NewLine}payload: {Hex(payload)}"
+                );
+                return;
+            }
+            catch (Exception failure)
+            {
+                Assert.Fail(
+                    $"{target.Name}: the facade raised {failure.GetType().Name}. The only exception "
+                        + "it may raise on a refusal is InvalidOperationException -- anything else "
+                        + "reaches a game as an unhandled crash rather than as a corrupt save."
+                        + $"{Environment.NewLine}{origin}{Environment.NewLine}"
+                        + $"payload: {Hex(payload)}{Environment.NewLine}{failure}"
+                );
+                return;
+            }
+
+            Assert.IsTrue(
+                served,
+                $"{target.Name}: the facade declined a contract it is registered for, which sends "
+                    + $"the payload on to protobuf-net.{Environment.NewLine}{origin}"
+                    + $"{Environment.NewLine}payload: {Hex(payload)}"
+            );
+            Assert.IsTrue(
+                accepted,
+                $"{target.Name}: the facade accepted a payload its own formatter refused."
+                    + $"{Environment.NewLine}{origin}{Environment.NewLine}payload: {Hex(payload)}"
             );
         }
 
@@ -540,6 +1307,24 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                     coverage.Describe(target.Name)
                         + " -- the mutations are barely changing anything."
                 );
+
+                // The claim "every member shape is fuzzed", made checkable. The corpus-wide reach
+                // rate above cannot support it: a strategy that dies on field 1 every time scores
+                // 100% reach while every other member is untouched, which is exactly how the
+                // capacity-claim strategy shipped covering one field of seven. The expected members
+                // are read out of the seeds, so adding a member to a contract and setting it in the
+                // sample extends this gate with no second list to remember.
+                int minimumHits = Math.Max(1, Iterations / 100);
+                foreach (int member in target.Members)
+                {
+                    Assert.GreaterOrEqual(
+                        coverage.HitsFor(member),
+                        minimumHits,
+                        coverage.DescribeMembers(target.Name, target.Members)
+                            + $" -- field {member} was dispatched on fewer than {minimumHits} "
+                            + "times, so this suite does not fuzz that member's reader."
+                    );
+                }
             }
         }
 
@@ -862,6 +1647,141 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
                     );
                 }
             }
+        }
+
+        [Test]
+        public void AGeneratedValueWritesExactlyWhatItMeasures()
+        {
+            // The write path's whole failure class, and one the read strategies cannot see. The
+            // fixed-point check above only compares encodings of values a DECODE produced, so a
+            // shape no payload decodes to -- a lone surrogate in a string, a rectangular array with
+            // a zero axis, a NaN -- could have Measure and Write disagreeing and nothing would say
+            // so until a game saved one. Measure sizes the buffer and Write gets exactly that many
+            // bytes, so a disagreement is a failed write or a short one rather than a silent
+            // overrun: the buffer is the assertion.
+            foreach (Target target in Targets())
+            {
+                FuzzRandom random = new FuzzRandom(0x217E5);
+                for (int iteration = 0; iteration < Iterations; ++iteration)
+                {
+                    string origin = $"strategy=generated-value seed=0x217E5 iteration={iteration}";
+                    int measured;
+                    int written;
+                    byte[] encoded;
+                    bool wrote;
+                    try
+                    {
+                        wrote = target.WriteGenerated(
+                            ref random,
+                            out measured,
+                            out written,
+                            out encoded
+                        );
+                    }
+                    catch (Exception failure)
+                    {
+                        Assert.Fail(
+                            $"{target.Name}: measuring or writing a generated value threw "
+                                + $"{failure.GetType().Name}.{Environment.NewLine}{origin}"
+                                + $"{Environment.NewLine}{failure}"
+                        );
+                        return;
+                    }
+
+                    Assert.IsTrue(
+                        wrote,
+                        $"{target.Name}: Write failed into a buffer of exactly the {measured} bytes "
+                            + $"Measure asked for.{Environment.NewLine}{origin}"
+                    );
+                    Assert.AreEqual(
+                        measured,
+                        written,
+                        $"{target.Name}: Measure promised {measured} bytes and Write produced "
+                            + $"{written}. A value serialized into a pooled buffer would carry the "
+                            + $"previous message's tail.{Environment.NewLine}{origin}"
+                    );
+
+                    // Its own encoding is a payload like any other, so it has to survive every
+                    // property the hostile corpus is held to -- including reading back into
+                    // something that re-encodes to the same bytes.
+                    AssertDecodeIsSafe(target, encoded, origin);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The per-member coverage gate reads both what it expects and what it observed through
+        /// <see cref="ScanTopLevelFields"/>, so a scanner that quietly stopped early would shrink
+        /// both sides and stay green. That makes the scanner the one thing in this file that has to
+        /// be pinned on its own rather than through the property it serves.
+        /// </summary>
+        /// <param name="hex">The payload.</param>
+        /// <param name="limit">How far the reader is claimed to have got.</param>
+        /// <returns>The field numbers found, comma separated.</returns>
+        [TestCase("0801", 2, ExpectedResult = "1")]
+        [TestCase("08011002", 4, ExpectedResult = "1,2")]
+        [TestCase("08011002", 1, ExpectedResult = "1")]
+        [TestCase("08011002", 0, ExpectedResult = "")]
+        [TestCase("0A026162 1003", 6, ExpectedResult = "1,2")]
+        [TestCase("0A05", 2, ExpectedResult = "1")]
+        [TestCase("0D0000803F 1103000000000000 00", 14, ExpectedResult = "1,2")]
+        [TestCase("1B 0801", 3, ExpectedResult = "3")]
+        [TestCase("00", 1, ExpectedResult = "")]
+        [TestCase("FFFFFFFFFFFFFFFFFFFF7F", 11, ExpectedResult = "")]
+        [TestCase("", 0, ExpectedResult = "")]
+        public string TheFieldScannerReportsWhatTheReaderWouldHaveDispatchedOn(
+            string hex,
+            int limit
+        )
+        {
+            SortedSet<int> fields = new SortedSet<int>();
+            ScanTopLevelFields(FromHex(hex.Replace(" ", string.Empty)), limit, fields);
+            return string.Join(",", fields);
+        }
+
+        [Test]
+        public void TheAllocationCeilingCatchesABoundedAmplification()
+        {
+            // The proof that tightening the ceiling bought something. The old 128 KB + 256x accepted
+            // a decode that allocated 32 KB from ten bytes -- 3,300x -- which is every amplification
+            // bug that happens to top out below a megabyte. This is that bug, synthesized: a reader
+            // that allocates a fixed 32 KB whatever it was handed.
+            Target amplifier = new Target(
+                "synthetic-amplifier",
+                new List<byte[]> { new byte[] { 0x08, 0x01 } },
+                new List<int> { 1 },
+                (byte[] payload, out int consumed) =>
+                {
+                    consumed = payload.Length;
+                    GC.KeepAlive(new byte[32 * 1024]);
+                    return false;
+                },
+                (byte[] payload, out byte[] first, out byte[] second) =>
+                {
+                    first = null;
+                    second = null;
+                    return false;
+                },
+                payload => throw new InvalidOperationException("refused"),
+                (ref FuzzRandom random, out int measured, out int written, out byte[] encoded) =>
+                {
+                    measured = 0;
+                    written = 0;
+                    encoded = Array.Empty<byte>();
+                    return true;
+                }
+            );
+
+            Assert.Throws<AssertionException>(
+                () =>
+                    AssertDecodeIsSafe(
+                        amplifier,
+                        new byte[] { 0x08, 0x01, 0x10, 0x02, 0x18, 0x03, 0x20, 0x04, 0x28, 0x05 },
+                        "strategy=ceiling-discrimination"
+                    ),
+                "the allocation ceiling accepted 32 KB from a ten-byte payload, so it is inert "
+                    + "against every amplification that stops short of it."
+            );
         }
 
         /// <summary>

--- a/Runtime/Core/Extension/Partials/Animation.cs
+++ b/Runtime/Core/Extension/Partials/Animation.cs
@@ -4,6 +4,7 @@
 // ReSharper disable once CheckNamespace
 namespace WallstopStudios.UnityHelpers.Core.Extension
 {
+    using System;
     using System.Collections.Generic;
     using UnityEngine;
 #if UNITY_EDITOR
@@ -13,6 +14,12 @@ namespace WallstopStudios.UnityHelpers.Core.Extension
     public static partial class UnityExtensions
     {
 #if UNITY_EDITOR
+        /// <summary>
+        /// The serialized property name an animated sprite is bound to, on both
+        /// <see cref="SpriteRenderer"/> and Unity UI's Image.
+        /// </summary>
+        public const string SpriteBindingProperty = "m_Sprite";
+
         /// <summary>
         /// Extracts all Sprite objects referenced in an AnimationClip.
         /// </summary>
@@ -24,9 +31,98 @@ namespace WallstopStudios.UnityHelpers.Core.Extension
         /// Performance: O(n*m) where n is number of bindings and m is keyframes per binding.
         /// Allocations: Allocates arrays for bindings and keyframes.
         /// Unity Behavior: Only available in Unity Editor. Uses AnimationUtility.
-        /// Edge Cases: Only returns Sprite object references, ignores other object types.
+        /// Edge Cases: Only returns Sprite object references, ignores other object types. Sprites
+        /// bound to a child object are indistinguishable from the root's -- use
+        /// <see cref="GetSpriteFramesFromClip"/> or the filtering overload when the owning renderer
+        /// matters.
         /// </remarks>
         public static IEnumerable<Sprite> GetSpritesFromClip(this AnimationClip clip)
+        {
+            foreach ((EditorCurveBinding _, Sprite sprite) in clip.GetSpriteFramesFromClip())
+            {
+                yield return sprite;
+            }
+        }
+
+        /// <summary>
+        /// Extracts the Sprite objects an AnimationClip binds to one particular animated property.
+        /// </summary>
+        /// <param name="clip">The AnimationClip to extract sprites from.</param>
+        /// <param name="path">
+        /// Transform path the binding must target, relative to the animated root --
+        /// <see cref="string.Empty"/> for the root itself. Null matches any path.
+        /// </param>
+        /// <param name="propertyName">
+        /// Serialized property the binding must animate, defaulting to
+        /// <see cref="SpriteBindingProperty"/>. Null matches any property.
+        /// </param>
+        /// <param name="type">
+        /// Exact component type the binding must target, such as <see cref="SpriteRenderer"/>. Null
+        /// matches any type; subclasses of a named type do not match.
+        /// </param>
+        /// <returns>Sprites bound to matching curves, in binding then keyframe order.</returns>
+        /// <remarks>
+        /// Thread Safety: Must be called from Unity main thread. Editor-only.
+        /// Null Handling: Returns empty enumerable if clip is null. Null filters match anything.
+        /// Performance: O(n*m) where n is number of bindings and m is keyframes per binding.
+        /// Allocations: Allocates arrays for bindings and keyframes.
+        /// Unity Behavior: Only available in Unity Editor. Uses AnimationUtility.
+        /// Edge Cases: A clip animating a child's renderer yields nothing for the root's path,
+        /// rather than the child's sprites.
+        /// </remarks>
+        public static IEnumerable<Sprite> GetSpritesFromClip(
+            this AnimationClip clip,
+            string path,
+            string propertyName = SpriteBindingProperty,
+            Type type = null
+        )
+        {
+            foreach ((EditorCurveBinding binding, Sprite sprite) in clip.GetSpriteFramesFromClip())
+            {
+                if (path != null && !string.Equals(binding.path, path, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (
+                    propertyName != null
+                    && !string.Equals(binding.propertyName, propertyName, StringComparison.Ordinal)
+                )
+                {
+                    continue;
+                }
+
+                if (type != null && binding.type != type)
+                {
+                    continue;
+                }
+
+                yield return sprite;
+            }
+        }
+
+        /// <summary>
+        /// Extracts every Sprite an AnimationClip references along with the curve binding that
+        /// supplies it, so a caller can tell which object each sprite is animated onto.
+        /// </summary>
+        /// <param name="clip">The AnimationClip to extract sprite frames from.</param>
+        /// <returns>
+        /// Each referenced sprite paired with its <see cref="EditorCurveBinding"/>, in binding then
+        /// keyframe order.
+        /// </returns>
+        /// <remarks>
+        /// Thread Safety: Must be called from Unity main thread. Editor-only.
+        /// Null Handling: Returns empty enumerable if clip is null.
+        /// Performance: O(n*m) where n is number of bindings and m is keyframes per binding.
+        /// Allocations: Allocates arrays for bindings and keyframes.
+        /// Unity Behavior: Only available in Unity Editor. Uses AnimationUtility.
+        /// Edge Cases: Only returns Sprite object references, ignores other object types. The same
+        /// sprite is yielded once per keyframe that references it.
+        /// </remarks>
+        public static IEnumerable<(
+            EditorCurveBinding binding,
+            Sprite sprite
+        )> GetSpriteFramesFromClip(this AnimationClip clip)
         {
             if (clip == null)
             {
@@ -45,7 +141,7 @@ namespace WallstopStudios.UnityHelpers.Core.Extension
                 {
                     if (frame.value is Sprite sprite)
                     {
-                        yield return sprite;
+                        yield return (binding, sprite);
                     }
                 }
             }

--- a/Runtime/Core/Serialization/WallstopProto/WProtoFacade.cs
+++ b/Runtime/Core/Serialization/WallstopProto/WProtoFacade.cs
@@ -149,6 +149,14 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// <param name="data">The payload.</param>
         /// <param name="value">Receives the value, or <c>default</c> when unhandled.</param>
         /// <returns><c>true</c> when WallstopProto served the request.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// <typeparamref name="T"/> has a formatter and that formatter refused
+        /// <paramref name="data"/>. This is the <b>only</b> exception this method raises for a
+        /// malformed, truncated or hostile payload, and the fuzz suite asserts it: a corrupt save
+        /// file has to arrive as one catchable error rather than as whatever the byte that broke
+        /// happened to break. See <see cref="TryDeserializeAs{T}"/> for why it is not reported as
+        /// <c>false</c>.
+        /// </exception>
         public static bool TryDeserialize<T>(ReadOnlySpan<byte> data, out T value)
         {
             return TryDeserializeAs(data, typeof(T), out value);
@@ -163,6 +171,10 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// <param name="concrete">The type the caller named explicitly.</param>
         /// <param name="value">Receives the value, or <c>default</c> when unhandled.</param>
         /// <returns><c>true</c> when WallstopProto served the request.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// A formatter answers for this type and refused the payload. The only exception this method
+        /// raises for malformed input, asserted against every strategy in the fuzz suite.
+        /// </exception>
         /// <remarks>
         /// The read side of the entry point that lets a caller override the declared type. The
         /// concrete type is not passed on to the formatter, because it does not need it -- the

--- a/Tests/Runtime/Extensions/UnityExtensionsComprehensiveTests.cs
+++ b/Tests/Runtime/Extensions/UnityExtensionsComprehensiveTests.cs
@@ -2831,6 +2831,152 @@ namespace WallstopStudios.UnityHelpers.Tests.Extensions
 
             yield return null;
         }
+
+        /// <summary>
+        /// Builds a clip whose four curves differ in exactly one binding field each, so a filter
+        /// that ignores one of the three is visible as a wrong answer rather than a missing one.
+        /// Every sprite is named for what selects it.
+        /// </summary>
+        private AnimationClip BuildBoundSpriteClip()
+        {
+            Texture2D texture = Track(new Texture2D(8, 8));
+            AnimationClip clip = Track(new AnimationClip());
+
+            void Bind(string path, Type type, string propertyName, params string[] spriteNames)
+            {
+                UnityEditor.ObjectReferenceKeyframe[] frames =
+                    new UnityEditor.ObjectReferenceKeyframe[spriteNames.Length];
+                for (int index = 0; index < spriteNames.Length; ++index)
+                {
+                    Sprite sprite = Track(
+                        Sprite.Create(texture, new Rect(0f, 0f, 4f, 4f), new Vector2(0.5f, 0.5f))
+                    );
+                    sprite.name = spriteNames[index];
+                    frames[index] = new UnityEditor.ObjectReferenceKeyframe
+                    {
+                        time = index,
+                        value = sprite,
+                    };
+                }
+
+                UnityEditor.AnimationUtility.SetObjectReferenceCurve(
+                    clip,
+                    UnityEditor.EditorCurveBinding.PPtrCurve(path, type, propertyName),
+                    frames
+                );
+            }
+
+            Bind(string.Empty, typeof(SpriteRenderer), "m_Sprite", "root0", "root1");
+            Bind("Child", typeof(SpriteRenderer), "m_Sprite", "child0");
+            Bind(string.Empty, typeof(Image), "m_Sprite", "image0");
+            Bind(string.Empty, typeof(SpriteRenderer), "m_Decoration", "deco0");
+
+            // Every assertion below reads as a filtering bug if the editor declined to store one of
+            // these curves, so the fixture states what it built.
+            Assert.AreEqual(
+                4,
+                UnityEditor.AnimationUtility.GetObjectReferenceCurveBindings(clip).Length,
+                "the editor did not store every object-reference curve this fixture set"
+            );
+            return clip;
+        }
+
+        private static string NamesOf(IEnumerable<Sprite> sprites)
+        {
+            List<string> names = sprites.Select(sprite => sprite.name).ToList();
+            names.Sort(StringComparer.Ordinal);
+            return string.Join(",", names);
+        }
+
+        [Test]
+        public void GetSpriteFramesFromClipKeepsTheBindingThatSuppliesEachSprite()
+        {
+            AnimationClip clip = BuildBoundSpriteClip();
+
+            Dictionary<string, UnityEditor.EditorCurveBinding> bindingsBySprite =
+                clip.GetSpriteFramesFromClip()
+                    .ToDictionary(frame => frame.sprite.name, frame => frame.binding);
+
+            Assert.AreEqual(5, bindingsBySprite.Count);
+            Assert.AreEqual(string.Empty, bindingsBySprite["root0"].path);
+            Assert.AreEqual(string.Empty, bindingsBySprite["root1"].path);
+            Assert.AreEqual("Child", bindingsBySprite["child0"].path);
+            Assert.AreEqual(typeof(SpriteRenderer), bindingsBySprite["root0"].type);
+            Assert.AreEqual(typeof(Image), bindingsBySprite["image0"].type);
+            Assert.AreEqual("m_Decoration", bindingsBySprite["deco0"].propertyName);
+        }
+
+        [Test]
+        public void GetSpriteFramesFromClipYieldsKeyframesInTimeOrder()
+        {
+            AnimationClip clip = BuildBoundSpriteClip();
+
+            List<string> rootFrames = clip.GetSpritesFromClip(
+                    string.Empty,
+                    "m_Sprite",
+                    typeof(SpriteRenderer)
+                )
+                .Select(sprite => sprite.name)
+                .ToList();
+
+            CollectionAssert.AreEqual(new[] { "root0", "root1" }, rootFrames);
+        }
+
+        [TestCase("", "m_Sprite", typeof(SpriteRenderer), "root0,root1")]
+        [TestCase("Child", "m_Sprite", typeof(SpriteRenderer), "child0")]
+        [TestCase(null, "m_Sprite", typeof(SpriteRenderer), "child0,root0,root1")]
+        [TestCase("", "m_Sprite", null, "image0,root0,root1")]
+        [TestCase("", null, typeof(SpriteRenderer), "deco0,root0,root1")]
+        [TestCase(null, null, null, "child0,deco0,image0,root0,root1")]
+        [TestCase("", "m_Sprite", typeof(Image), "image0")]
+        [TestCase("Missing", "m_Sprite", typeof(SpriteRenderer), "")]
+        [TestCase("", "m_Missing", typeof(SpriteRenderer), "")]
+        public void GetSpritesFromClipFiltersOnEveryBindingField(
+            string path,
+            string propertyName,
+            Type type,
+            string expected
+        )
+        {
+            AnimationClip clip = BuildBoundSpriteClip();
+
+            Assert.AreEqual(expected, NamesOf(clip.GetSpritesFromClip(path, propertyName, type)));
+        }
+
+        [Test]
+        public void GetSpritesFromClipDefaultsToTheSpriteProperty()
+        {
+            AnimationClip clip = BuildBoundSpriteClip();
+
+            // The default exists so the common call is `clip.GetSpritesFromClip(path)`; a default
+            // that matched anything would hand back the decoration curve too.
+            Assert.AreEqual("root0,root1", NamesOf(clip.GetSpritesFromClip(string.Empty)));
+            Assert.AreEqual(
+                "m_Sprite",
+                WallstopStudios.UnityHelpers.Core.Extension.UnityExtensions.SpriteBindingProperty
+            );
+        }
+
+        [Test]
+        public void GetSpriteFramesFromClipHandlesNullClip()
+        {
+            AnimationClip clip = null;
+
+            Assert.IsEmpty(clip.GetSpriteFramesFromClip().ToList());
+            Assert.IsEmpty(clip.GetSpritesFromClip().ToList());
+            Assert.IsEmpty(clip.GetSpritesFromClip(string.Empty).ToList());
+        }
+
+        [Test]
+        public void GetSpritesFromClipIsTheUnfilteredProjectionOfItsFrames()
+        {
+            AnimationClip clip = BuildBoundSpriteClip();
+
+            CollectionAssert.AreEqual(
+                clip.GetSpriteFramesFromClip().Select(frame => frame.sprite).ToList(),
+                clip.GetSpritesFromClip().ToList()
+            );
+        }
 #endif
     }
 }

--- a/Tests/Runtime/Extensions/UnityExtensionsComprehensiveTests.cs
+++ b/Tests/Runtime/Extensions/UnityExtensionsComprehensiveTests.cs
@@ -2907,16 +2907,50 @@ namespace WallstopStudios.UnityHelpers.Tests.Extensions
         }
 
         [Test]
-        public void GetSpriteFramesFromClipYieldsKeyframesInTimeOrder()
+        public void GetSpriteFramesFromClipWalksOneBindingAtATimeInKeyframeOrder()
         {
             AnimationClip clip = BuildBoundSpriteClip();
 
-            List<string> rootFrames = clip.GetSpritesFromClip(
-                    string.Empty,
-                    "m_Sprite",
-                    typeof(SpriteRenderer)
+            List<(UnityEditor.EditorCurveBinding binding, Sprite sprite)> frames =
+                clip.GetSpriteFramesFromClip().ToList();
+
+            Assert.AreEqual(5, frames.Count);
+            Assert.AreEqual(5, clip.GetSpritesFromClip().Count());
+
+            // "Binding then keyframe order" is the documented contract, and a comparison over a
+            // sorted projection cannot see it -- an implementation that interleaved bindings would
+            // hold the same five sprites. Contiguity is what says the walk is per binding.
+            List<string> runs = new();
+            foreach ((UnityEditor.EditorCurveBinding binding, Sprite _) in frames)
+            {
+                string key = $"{binding.path}|{binding.propertyName}|{binding.type}";
+                if (
+                    runs.Count == 0
+                    || !string.Equals(runs[runs.Count - 1], key, StringComparison.Ordinal)
                 )
-                .Select(sprite => sprite.name)
+                {
+                    runs.Add(key);
+                }
+            }
+
+            Assert.AreEqual(4, runs.Count);
+            Assert.AreEqual(
+                runs.Count,
+                runs.Distinct().Count(),
+                "one binding's frames are not contiguous, so the walk is not per binding"
+            );
+
+            List<string> rootFrames = frames
+                .Where(frame =>
+                    frame.binding.type == typeof(SpriteRenderer)
+                    && string.Equals(frame.binding.path, string.Empty, StringComparison.Ordinal)
+                    && string.Equals(
+                        frame.binding.propertyName,
+                        "m_Sprite",
+                        StringComparison.Ordinal
+                    )
+                )
+                .Select(frame => frame.sprite.name)
                 .ToList();
 
             CollectionAssert.AreEqual(new[] { "root0", "root1" }, rootFrames);
@@ -2931,6 +2965,12 @@ namespace WallstopStudios.UnityHelpers.Tests.Extensions
         [TestCase("", "m_Sprite", typeof(Image), "image0")]
         [TestCase("Missing", "m_Sprite", typeof(SpriteRenderer), "")]
         [TestCase("", "m_Missing", typeof(SpriteRenderer), "")]
+        // A base of the binding's type matches NOTHING. Without these two rows an implementation
+        // written as `type.IsAssignableFrom(binding.type)` passes every row above, and the
+        // documented rule -- which exists so "which renderer" cannot be answered approximately --
+        // would be enforced nowhere.
+        [TestCase("", "m_Sprite", typeof(Renderer), "")]
+        [TestCase("", "m_Sprite", typeof(Graphic), "")]
         public void GetSpritesFromClipFiltersOnEveryBindingField(
             string path,
             string propertyName,
@@ -2948,13 +2988,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Extensions
         {
             AnimationClip clip = BuildBoundSpriteClip();
 
-            // The default exists so the common call is `clip.GetSpritesFromClip(path)`; a default
-            // that matched anything would hand back the decoration curve too.
-            Assert.AreEqual("root0,root1", NamesOf(clip.GetSpritesFromClip(string.Empty)));
-            Assert.AreEqual(
-                "m_Sprite",
-                WallstopStudios.UnityHelpers.Core.Extension.UnityExtensions.SpriteBindingProperty
-            );
+            // The default exists so the common call is `clip.GetSpritesFromClip(path)`. It narrows
+            // the property and nothing else: the decoration curve on the same object is excluded,
+            // the Image's m_Sprite is not, because `type` defaults to "any".
+            Assert.AreEqual("image0,root0,root1", NamesOf(clip.GetSpritesFromClip(string.Empty)));
+            Assert.AreEqual("m_Sprite", UnityExtensions.SpriteBindingProperty);
         }
 
         [Test]
@@ -2965,17 +3003,6 @@ namespace WallstopStudios.UnityHelpers.Tests.Extensions
             Assert.IsEmpty(clip.GetSpriteFramesFromClip().ToList());
             Assert.IsEmpty(clip.GetSpritesFromClip().ToList());
             Assert.IsEmpty(clip.GetSpritesFromClip(string.Empty).ToList());
-        }
-
-        [Test]
-        public void GetSpritesFromClipIsTheUnfilteredProjectionOfItsFrames()
-        {
-            AnimationClip clip = BuildBoundSpriteClip();
-
-            CollectionAssert.AreEqual(
-                clip.GetSpriteFramesFromClip().Select(frame => frame.sprite).ToList(),
-                clip.GetSpritesFromClip().ToList()
-            );
         }
 #endif
     }

--- a/docs/features/utilities/math-and-extensions.md
+++ b/docs/features/utilities/math-and-extensions.md
@@ -492,6 +492,7 @@ Edge Cases Gallery
 - Rect/Bounds conversions, RectTransform world bounds
 - Camera `OrthographicBounds`
 - Bounds aggregation from collections
+- Sprites referenced by an `AnimationClip`, with or without their curve bindings (editor-only)
 
 Example:
 
@@ -499,6 +500,42 @@ Example:
 Rect r = rectTransform.GetWorldRect();
 Bounds view = Camera.main.OrthographicBounds();
 ```
+
+<a id="sprites-from-an-animationclip"></a>
+
+### Sprites from an AnimationClip
+
+Editor-only. `GetSpritesFromClip()` yields every sprite a clip references, in binding then keyframe
+order. That is the right answer when a clip drives one renderer, and the wrong one when it drives
+several: a clip animating a **child's** `SpriteRenderer` is indistinguishable from one animating the
+root's, so measuring the returned sprites in the root's local space produces a plausible, wrong
+result rather than an empty one.
+
+`GetSpriteFramesFromClip()` keeps the binding, so the caller can tell them apart:
+
+```csharp
+foreach ((EditorCurveBinding binding, Sprite sprite) in clip.GetSpriteFramesFromClip())
+{
+    Debug.Log($"{binding.path}/{binding.propertyName} -> {sprite.name}");
+}
+```
+
+When you only want one object's frames, filter at the call instead:
+
+```csharp
+// The root's SpriteRenderer, which is what UnityExtensions.SpriteBindingProperty names.
+IEnumerable<Sprite> frames = clip.GetSpritesFromClip(
+    string.Empty,
+    UnityExtensions.SpriteBindingProperty,
+    typeof(SpriteRenderer)
+);
+
+// A child, by its transform path relative to the animated root.
+IEnumerable<Sprite> childFrames = clip.GetSpritesFromClip("Shadow");
+```
+
+A `null` filter matches anything, so `GetSpritesFromClip(null, null, null)` is the unfiltered walk.
+`type` is matched exactly — a subclass of the type you name does not match.
 
 Diagrams:
 

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -16,8 +16,12 @@ The container resolves github.com credentials from a cached token. The Dev Conta
 helper is out of the path entirely — that helper raises a dialog on the host desktop on **every**
 invocation, and `git push`, `git fetch` and every API call invoke it.
 
-With a token cached, nothing prompts. With an **empty** cache, git falls back to the editor's own
-askpass dialog, which is the signal to run one of the commands below rather than to answer it.
+With a token cached, nothing prompts. With an **empty** cache, git used to fall back to the editor's
+own askpass dialog — another window on the host desktop, from a different mechanism. The container
+points `GIT_ASKPASS` at [`scripts/git-askpass-refuse.sh`](../../scripts/git-askpass-refuse.sh)
+instead, so that path now ends in an error naming the commands below rather than in a dialog.
+(The editor's own Git UI is unaffected: the Git extension sets `GIT_ASKPASS` explicitly for the
+processes it launches.)
 
 Supply the token once per container, either way:
 

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -18,10 +18,9 @@ invocation, and `git push`, `git fetch` and every API call invoke it.
 
 With a token cached, nothing prompts. With an **empty** cache, git used to fall back to the editor's
 own askpass dialog — another window on the host desktop, from a different mechanism. The container
-points `GIT_ASKPASS` at [`scripts/git-askpass-refuse.sh`](../../scripts/git-askpass-refuse.sh)
-instead, so that path now ends in an error naming the commands below rather than in a dialog.
-(The editor's own Git UI is unaffected: the Git extension sets `GIT_ASKPASS` explicitly for the
-processes it launches.)
+points `GIT_ASKPASS` at `scripts/git-askpass-refuse.sh` instead, so that path now ends in an error
+naming the commands below rather than in a dialog. (The editor's own Git UI is unaffected: the Git
+extension sets `GIT_ASKPASS` explicitly for the processes it launches.)
 
 Supply the token once per container, either way:
 

--- a/scripts/git-askpass-refuse.sh
+++ b/scripts/git-askpass-refuse.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# GIT_ASKPASS for this devcontainer: refuse, legibly, instead of opening a window.
+#
+# Why it exists (#450). Credentials here resolve from a 0600 cache through
+# scripts/github-token.sh, installed as the only credential helper for github.com. When that cache
+# is EMPTY git does not fail -- it falls back to GIT_ASKPASS, which the editor sets to its own
+# askpass.sh, and that raises a dialog ON THE OWNER'S DESKTOP. A credential helper cannot suppress
+# it: git's precedence is GIT_ASKPASS -> core.askPass -> SSH_ASKPASS, and the environment variable
+# wins over anything git config can say. GIT_TERMINAL_PROMPT=0 does not cover askpass either.
+#
+# So the only lever is to BE the askpass. An unattended `git push` now ends in a one-line error
+# naming the command that fixes it, rather than in a window nobody is watching.
+#
+# The editor's own Git UI is unaffected: the Git extension sets GIT_ASKPASS explicitly for the git
+# processes it launches, because the value carries a per-session IPC handle it has to route back to.
+# What this replaces is the copy inherited by terminals and by anything an agent runs there.
+set -uo pipefail
+
+# stderr ONLY. git reads this program's STDOUT as the answer, so a single stray character would be
+# handed to the remote as a username or a password.
+{
+    printf 'git-askpass-refuse: refusing to prompt for "%s".\n' "${1:-a credential}"
+    printf '\n'
+    printf 'This container answers github.com from a 0600 credential cache, never from a dialog --\n'
+    printf 'a dialog here opens on the owner'"'"'s desktop, and nothing is watching it. The cache is\n'
+    printf 'empty, or this host is not github.com and has no cached credential.\n'
+    printf '\n'
+    printf 'From a terminal a human is watching:\n'
+    printf '  npm run github:token:bootstrap   # one deliberate dialog, once per container\n'
+    printf '  npm run github:token:store       # paste a token on stdin, no dialog at all\n'
+} >&2
+
+exit 1

--- a/scripts/git-askpass-refuse.sh.meta
+++ b/scripts/git-askpass-refuse.sh.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d62ff84f0ee647fbb1a756f49b25c539
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/tests/test-github-token.sh
+++ b/scripts/tests/test-github-token.sh
@@ -386,6 +386,55 @@ for entry in github:token github:token:bootstrap github:token:store; do
     fi
 done
 
+# ── The empty-cache path does not reach a dialog either (#450) ──────────────
+#
+# The helper covers "a credential exists". With the cache EMPTY git falls through to GIT_ASKPASS,
+# which the editor sets to its own dialog and which no credential helper can override -- so the only
+# way to close that path is to be the askpass.
+ASKPASS="$REPO_ROOT/scripts/git-askpass-refuse.sh"
+
+# STDOUT is the answer git uses. A single character here is handed to the remote as a credential,
+# so "prints nothing on stdout" is the security property, not a tidiness one.
+askpass_stdout="$(bash "$ASKPASS" "Password for 'https://github.com': " 2>/dev/null)"
+askpass_status=$?
+if [ -z "$askpass_stdout" ]; then
+    pass "the askpass refusal answers git with nothing on stdout"
+else
+    fail "the askpass refusal answers git with nothing on stdout" \
+        "it printed: $askpass_stdout"
+fi
+
+if [ "$askpass_status" -ne 0 ]; then
+    pass "the askpass refusal exits non-zero so git reports failure"
+else
+    fail "the askpass refusal exits non-zero so git reports failure" \
+        "it exited 0, which git reads as a successful empty answer"
+fi
+
+askpass_stderr="$(bash "$ASKPASS" "Username for 'https://github.com': " 2>&1 >/dev/null)"
+if printf '%s' "$askpass_stderr" | grep -q 'github:token:bootstrap' \
+    && printf '%s' "$askpass_stderr" | grep -q 'github:token:store'; then
+    pass "the askpass refusal names both commands that fix it"
+else
+    fail "the askpass refusal names both commands that fix it" \
+        "stderr was: $askpass_stderr"
+fi
+
+# Wiring, not just the script: an askpass nothing points at closes nothing.
+if node -e "
+const fs = require('fs');
+const raw = fs.readFileSync('$REPO_ROOT/.devcontainer/devcontainer.json', 'utf8');
+const stripped = raw.replace(/^\s*\/\/.*$/gm, '');
+const config = JSON.parse(stripped);
+const value = (config.remoteEnv || {}).GIT_ASKPASS || '';
+process.exit(value.includes('scripts/git-askpass-refuse.sh') ? 0 : 1);
+"; then
+    pass "devcontainer.json points GIT_ASKPASS at the refusal"
+else
+    fail "devcontainer.json points GIT_ASKPASS at the refusal" \
+        "remoteEnv.GIT_ASKPASS does not name scripts/git-askpass-refuse.sh"
+fi
+
 printf '\n%d passed, %d failed\n' "$passed" "$failed"
 if [ "$failed" -gt 0 ]; then
     printf 'Failed: %s\n' "${failed_names[*]}"

--- a/scripts/tests/test-github-token.sh
+++ b/scripts/tests/test-github-token.sh
@@ -393,6 +393,25 @@ done
 # way to close that path is to be the askpass.
 ASKPASS="$REPO_ROOT/scripts/git-askpass-refuse.sh"
 
+# git EXECUTES GIT_ASKPASS as a program, so the exec bit is the wiring. Every assertion below runs
+# it through `bash`, which succeeds on a 644 file -- so without this the suite stays green while git
+# reports "cannot exec" and falls back to... nothing, which is safe, but the refusal message the
+# whole file exists to deliver never reaches anyone. `.git` is bind-mounted from a Windows host with
+# `filemode = false`, which is exactly how a mode regression gets committed unnoticed.
+if [ -x "$ASKPASS" ]; then
+    pass "the askpass refusal is executable"
+else
+    fail "the askpass refusal is executable" \
+        "git runs GIT_ASKPASS as a program; $ASKPASS is not executable"
+fi
+
+if [ "$(git -C "$REPO_ROOT" ls-files -s scripts/git-askpass-refuse.sh | cut -d' ' -f1)" = "100755" ]; then
+    pass "the askpass refusal is executable in the index"
+else
+    fail "the askpass refusal is executable in the index" \
+        "run: git update-index --chmod=+x scripts/git-askpass-refuse.sh"
+fi
+
 # STDOUT is the answer git uses. A single character here is handed to the remote as a credential,
 # so "prints nothing on stdout" is the security property, not a tidiness one.
 askpass_stdout="$(bash "$ASKPASS" "Password for 'https://github.com': " 2>/dev/null)"

--- a/scripts/tests/test-run-repo-lint.js
+++ b/scripts/tests/test-run-repo-lint.js
@@ -98,6 +98,67 @@ function registryLeafCommands() {
   });
 }
 
+/**
+ * A file's text with comments and bare YAML list entries removed.
+ *
+ * Both removals are load-bearing. `llm-instructions-lint.yml` names
+ * `scripts/lint-llm-instructions.ps1` twice in `paths:` filters before it ever runs it, so a plain
+ * substring search cannot tell "this workflow re-runs when the linter changes" from "this workflow
+ * runs the linter" -- and the first is true of workflows that do not run it at all.
+ *
+ * @param {string} relativePath Repo-relative file.
+ * @returns {string} Text with comments and path-filter entries dropped.
+ */
+function invocationText(relativePath) {
+  const full = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(full) || !fs.statSync(full).isFile()) {
+    return "";
+  }
+  return fs
+    .readFileSync(full, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*#/.test(line))
+    .filter((line) => !/^\s*-\s*["']?!?[^:\s"']+["']?\s*$/.test(line))
+    .join("\n");
+}
+
+/**
+ * @param {string} containerRelativePath The file that might run it.
+ * @param {string} file Repo-relative script path.
+ * @returns {boolean} True when the container invokes it, directly or via an npm script.
+ */
+function fileInvokes(containerRelativePath, file) {
+  const text = invocationText(containerRelativePath);
+  if (!text) {
+    return false;
+  }
+  if (text.includes(file)) {
+    return true;
+  }
+  for (const match of text.matchAll(/npm run ([\w:.-]+)/g)) {
+    if (scriptPathsIn(expandNpmScript(match[1])).has(file)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @param {string} dir Repo-relative directory to scan, one level deep.
+ * @param {string} file Repo-relative script path.
+ * @returns {string[]} The files in `dir` that invoke it.
+ */
+function filesInvoking(dir, file) {
+  const full = path.join(repoRoot, dir);
+  if (!fs.existsSync(full)) {
+    return [];
+  }
+  return fs
+    .readdirSync(full)
+    .map((name) => `${dir}/${name}`)
+    .filter((candidate) => fileInvokes(candidate, file));
+}
+
 console.log("Testing scripts/run-repo-lint.js...\n");
 
 runTest("every check has a unique, non-empty id and name", () => {
@@ -351,16 +412,31 @@ runTest("--list prints every registered id", () => {
 });
 
 runTest("no linter in scripts/ has been left unreachable", () => {
-  // Linters that legitimately do not belong in Repo Lint, each with the thing that does run it.
-  // An entry here is a claim that must stay true; anything else new in scripts/ has to be wired up.
+  // Linters that legitimately do not belong in Repo Lint. The value is the KIND of owner that runs
+  // it, and every kind is a PREDICATE evaluated below.
+  //
+  // It used to be free text naming a workflow, and nothing ever read it (#445). Three of the seven
+  // claims were false when that was checked: one named a workflow that runs CSharpier directly and
+  // never touches the linter, one named pre-push for a script only an npm aggregate runs, and two
+  // said "git hooks" when the hook that runs them is the pre-commit FRAMEWORK's config rather than
+  // anything in .githooks/. An allowlist whose entries are prose excuses whatever is put in it --
+  // the quiet half of #445, one level up: the thing named still exists, so nothing goes red.
   const runElsewhere = new Map([
-    ["scripts/lint-llm-instructions.ps1", ".github/workflows/llm-instructions-lint.yml (cross-OS)"],
-    ["scripts/lint-skill-sizes.ps1", ".github/workflows/llm-instructions-lint.yml (cross-OS)"],
-    ["scripts/lint-unity-test-modules.ps1", ".github/workflows/unity-tests.yml"],
-    ["scripts/lint-csharp-format.ps1", ".github/workflows/csharpier-autofix.yml gates C# format"],
-    ["scripts/lint-staged-links.ps1", "git hooks: staged files only, nothing to check in CI"],
-    ["scripts/lint-staged-markdown.ps1", "git hooks: staged files only, nothing to check in CI"],
-    ["scripts/validate-git-push-config.ps1", "pre-push: inspects local git config, not the tree"]
+    ["scripts/lint-llm-instructions.ps1", "workflow"],
+    ["scripts/lint-skill-sizes.ps1", "workflow"],
+    ["scripts/lint-unity-test-modules.ps1", "workflow"],
+    ["scripts/lint-csharp-format.ps1", "preflight"],
+    ["scripts/lint-staged-links.ps1", "precommit-config"],
+    ["scripts/lint-staged-markdown.ps1", "precommit-config"],
+    ["scripts/validate-git-push-config.ps1", "prepush"]
+  ]);
+
+  const owners = new Map([
+    ["workflow", (file) => filesInvoking(".github/workflows", file).length > 0],
+    ["hook", (file) => filesInvoking(".githooks", file).length > 0],
+    ["preflight", (file) => fileInvokes("scripts/agent-preflight.ps1", file)],
+    ["prepush", (file) => scriptPathsIn(expandNpmScript("validate:prepush")).has(file)],
+    ["precommit-config", (file) => fileInvokes(".pre-commit-config.yaml", file)]
   ]);
 
   const reachable = new Set([
@@ -381,7 +457,7 @@ runTest("no linter in scripts/ has been left unreachable", () => {
     orphans,
     [],
     `these linters exist but nothing runs them -- add them to CHECKS in scripts/run-repo-lint.js, ` +
-      `or to runElsewhere here with the workflow that does: ${orphans.join(", ")}`
+      `or to runElsewhere here with the kind of owner that does: ${orphans.join(", ")}`
   );
 
   // The allowlist must not outlive the files it names, or it silently excuses nothing.
@@ -392,6 +468,20 @@ runTest("no linter in scripts/ has been left unreachable", () => {
     stale,
     [],
     `allowlist names files that no longer exist: ${stale.join(", ")}`
+  );
+
+  // And every excuse must be true. This is the assertion the free-text version could not make.
+  const unfounded = [...runElsewhere.entries()]
+    .filter(([file, kind]) => {
+      const owner = owners.get(kind);
+      return !owner || !owner(file);
+    })
+    .map(([file, kind]) => `${file} (claimed: ${kind})`);
+  assert.deepStrictEqual(
+    unfounded,
+    [],
+    `these linters are excused from Repo Lint by an owner that does not run them -- either wire ` +
+      `them up, correct the kind, or delete the linter: ${unfounded.join(", ")}`
   );
 });
 

--- a/scripts/tests/test-run-repo-lint.js
+++ b/scripts/tests/test-run-repo-lint.js
@@ -99,15 +99,17 @@ function registryLeafCommands() {
 }
 
 /**
- * A file's text with comments and bare YAML list entries removed.
+ * A file's text with everything that MENTIONS a script but does not RUN it removed.
  *
- * Both removals are load-bearing. `llm-instructions-lint.yml` names
- * `scripts/lint-llm-instructions.ps1` twice in `paths:` filters before it ever runs it, so a plain
- * substring search cannot tell "this workflow re-runs when the linter changes" from "this workflow
- * runs the linter" -- and the first is true of workflows that do not run it at all.
+ * Every removal here is a shape that produced a false "this owner runs it":
+ * - Comments, whole-line and trailing. `llm-instructions-lint.yml` names
+ *   `scripts/lint-llm-instructions.ps1` twice in `paths:` filters before it ever runs it.
+ * - `paths:` / `paths-ignore:` / `files:` keys, including a flow sequence written on the same line
+ *   (`paths: ["scripts/x.ps1"]`), and the bare list entries under them.
+ * - Documentation keys (`name:`, `description:`, `title:`), which are prose about the step.
  *
  * @param {string} relativePath Repo-relative file.
- * @returns {string} Text with comments and path-filter entries dropped.
+ * @returns {string} Text with mentions dropped and invocations kept.
  */
 function invocationText(relativePath) {
   const full = path.join(repoRoot, relativePath);
@@ -117,9 +119,23 @@ function invocationText(relativePath) {
   return fs
     .readFileSync(full, "utf8")
     .split(/\r?\n/)
+    .map((line) => line.replace(/\s+#.*$/, ""))
     .filter((line) => !/^\s*#/.test(line))
+    .filter((line) => !/^\s*-?\s*(?:paths|paths-ignore|files|exclude)\s*:/.test(line))
+    .filter((line) => !/^\s*-?\s*(?:name|description|title|summary)\s*:/.test(line))
     .filter((line) => !/^\s*-\s*["']?!?[^:\s"']+["']?\s*$/.test(line))
     .join("\n");
+}
+
+/**
+ * @param {string} file Repo-relative script path.
+ * @returns {RegExp} Matches the path as a token, not as a suffix of a longer one.
+ */
+function invocationPattern(file) {
+  const escaped = file.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // The leading class excludes `/`, so `tools/scripts/lint-foo.ps1` does not answer for
+  // `scripts/lint-foo.ps1`; the trailing lookahead excludes a longer file name.
+  return new RegExp(`(?:^|[^\\w/.-])(?:\\./)?${escaped}(?![\\w.-])`, "m");
 }
 
 /**
@@ -132,7 +148,7 @@ function fileInvokes(containerRelativePath, file) {
   if (!text) {
     return false;
   }
-  if (text.includes(file)) {
+  if (invocationPattern(file).test(text)) {
     return true;
   }
   for (const match of text.matchAll(/npm run ([\w:.-]+)/g)) {
@@ -144,19 +160,25 @@ function fileInvokes(containerRelativePath, file) {
 }
 
 /**
- * @param {string} dir Repo-relative directory to scan, one level deep.
+ * @param {string} dir Repo-relative directory to scan, recursively.
  * @param {string} file Repo-relative script path.
- * @returns {string[]} The files in `dir` that invoke it.
+ * @returns {string[]} The files under `dir` that invoke it.
  */
 function filesInvoking(dir, file) {
   const full = path.join(repoRoot, dir);
   if (!fs.existsSync(full)) {
     return [];
   }
-  return fs
-    .readdirSync(full)
-    .map((name) => `${dir}/${name}`)
-    .filter((candidate) => fileInvokes(candidate, file));
+  const found = [];
+  for (const entry of fs.readdirSync(full, { withFileTypes: true })) {
+    const candidate = `${dir}/${entry.name}`;
+    if (entry.isDirectory()) {
+      found.push(...filesInvoking(candidate, file));
+    } else if (fileInvokes(candidate, file)) {
+      found.push(candidate);
+    }
+  }
+  return found;
 }
 
 console.log("Testing scripts/run-repo-lint.js...\n");
@@ -431,9 +453,10 @@ runTest("no linter in scripts/ has been left unreachable", () => {
     ["scripts/validate-git-push-config.ps1", "prepush"]
   ]);
 
+  // Only the kinds something actually claims. A registered predicate nothing uses is a dead branch
+  // inside the one test whose whole point is that a claim has to be executable.
   const owners = new Map([
     ["workflow", (file) => filesInvoking(".github/workflows", file).length > 0],
-    ["hook", (file) => filesInvoking(".githooks", file).length > 0],
     ["preflight", (file) => fileInvokes("scripts/agent-preflight.ps1", file)],
     ["prepush", (file) => scriptPathsIn(expandNpmScript("validate:prepush")).has(file)],
     ["precommit-config", (file) => fileInvokes(".pre-commit-config.yaml", file)]

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -81,6 +81,36 @@ function Test-RunnerBootstrapPassesMaintenanceForce {
     return $maintenanceArgsHasForceKey -or $maintenanceArgsDirectForceAssignment
 }
 
+function Test-WatchdogCadenceFitsRecoveryWindow {
+    <#
+    .SYNOPSIS
+        Asserts the watchdog is delivered often enough to still repair what it repairs.
+    .DESCRIPTION
+        The #342 recovery -- a run GitHub reported cancelled with every step green -- is only
+        available inside MAX_RERUN_AGE_SECONDS of the run finishing. The cron is a REQUEST, not a
+        cadence: measured over 300 runs (#448), GitHub delivered 65.5 of 288 requested triggers a
+        day, a median gap of 21.3 minutes against a five-minute cron. So the interval that matters
+        is the requested one multiplied by the throttle factor, and comparing the cron alone to the
+        window would pass a schedule whose real gaps swallow it.
+
+        Fails closed on a schedule this cannot read, because an unparsed cron is an unchecked one.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][int]$ThrottleFactor
+    )
+
+    $cronMatch = [regex]::Match($Content, '(?m)^\s*-\s*cron:\s*"\*/(?<minutes>\d+) \* \* \* \*"\s*$')
+    $windowMatch = [regex]::Match($Content, '(?m)^\s*MAX_RERUN_AGE_SECONDS:\s*"(?<seconds>\d+)"\s*$')
+    if (-not $cronMatch.Success -or -not $windowMatch.Success) {
+        return $false
+    }
+
+    $requestedSeconds = [int]$cronMatch.Groups['minutes'].Value * 60
+    $windowSeconds = [int]$windowMatch.Groups['seconds'].Value
+    return ($requestedSeconds * $ThrottleFactor) -lt $windowSeconds
+}
+
 function Get-BuildLockActionPins {
     param(
         [Parameter(Mandatory = $true)][string]$GitHubRoot,
@@ -3146,7 +3176,18 @@ if (-not (Test-Path -LiteralPath $watchdogPath)) {
                 $watchdogContent.Contains('(.run_attempt // 1) <= $maxAttempt') -and
                 $watchdogContent.Contains('rerun-${run_id}.json')
             )
-            Message = 'Automatic re-runs must be bounded twice: by run_attempt (a re-run that lands in the same cancelled state escalates to a human instead of looping every five minutes) and by a per-run daily cap in its own state file. The cap file must be distinct from the cancel state file, whose reader falls back to a .reruns key and would otherwise consume the cancel budget.'
+            Message = 'Automatic re-runs must be bounded twice: by run_attempt (a re-run that lands in the same cancelled state escalates to a human instead of looping on every delivered tick) and by a per-run daily cap in its own state file. The cap file must be distinct from the cancel state file, whose reader falls back to a .reruns key and would otherwise consume the cancel budget.'
+            File = '.github/workflows/stuck-job-watchdog.yml'
+        },
+        @{
+            # Measured over 300 runs (#448): 288 cron requests a day produce 65.5
+            # delivered runs, a median gap of 21.3 min and a maximum of 58.5. So the
+            # requested interval understates the real one by roughly four times, and a
+            # cadence chosen against the cron alone would silently exceed the only
+            # window in which an all-green cancelled run (#342) can still be recovered.
+            Name = 'watchdog cadence leaves room inside the re-run recovery window'
+            Ok = (Test-WatchdogCadenceFitsRecoveryWindow -Content $watchdogContent -ThrottleFactor 4)
+            Message = 'The watchdog schedule must satisfy (cron interval x 4) < MAX_RERUN_AGE_SECONDS. GitHub delivers roughly one run per four requested ticks, so a cron of 15 minutes is already an hour of real latency -- and at an hour a run cancelled with every step green ages out of the recovery window between two ticks, which is the one failure this workflow exists to repair automatically. Express the schedule as "*/N * * * *" so this contract can read it.'
             File = '.github/workflows/stuck-job-watchdog.yml'
         }
     )

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -100,15 +100,35 @@ function Test-WatchdogCadenceFitsRecoveryWindow {
         [Parameter(Mandatory = $true)][int]$ThrottleFactor
     )
 
-    $cronMatch = [regex]::Match($Content, '(?m)^\s*-\s*cron:\s*"\*/(?<minutes>\d+) \* \* \* \*"\s*$')
-    $windowMatch = [regex]::Match($Content, '(?m)^\s*MAX_RERUN_AGE_SECONDS:\s*"(?<seconds>\d+)"\s*$')
-    if (-not $cronMatch.Success -or -not $windowMatch.Success) {
+    # EVERY schedule, not the first: a workflow with two crons is delivered on the union, and the
+    # slowest one is what a reader would reason from. Quoting is accepted in all three YAML spellings
+    # so a purely stylistic edit cannot redden this with a message about intervals.
+    $cronMatches = [regex]::Matches($Content, '(?m)^\s*-\s*cron:\s*(?<quote>["'']?)(?<schedule>[^"''\r\n]+)\k<quote>\s*$')
+    $windowMatch = [regex]::Match($Content, '(?m)^\s*MAX_RERUN_AGE_SECONDS:\s*["'']?(?<seconds>\d+)["'']?\s*$')
+    if ($cronMatches.Count -eq 0 -or -not $windowMatch.Success) {
         return $false
     }
 
-    $requestedSeconds = [int]$cronMatch.Groups['minutes'].Value * 60
+    $slowestSeconds = 0
+    foreach ($cronMatch in $cronMatches) {
+        $everyMatch = [regex]::Match($cronMatch.Groups['schedule'].Value.Trim(), '^\*/(?<minutes>\d+) \* \* \* \*$')
+        if (-not $everyMatch.Success) {
+            return $false
+        }
+
+        $minutes = [int]$everyMatch.Groups['minutes'].Value
+        if ($minutes -lt 1) {
+            return $false
+        }
+
+        $seconds = $minutes * 60
+        if ($seconds -gt $slowestSeconds) {
+            $slowestSeconds = $seconds
+        }
+    }
+
     $windowSeconds = [int]$windowMatch.Groups['seconds'].Value
-    return ($requestedSeconds * $ThrottleFactor) -lt $windowSeconds
+    return ($slowestSeconds * $ThrottleFactor) -lt $windowSeconds
 }
 
 function Get-BuildLockActionPins {
@@ -3187,7 +3207,7 @@ if (-not (Test-Path -LiteralPath $watchdogPath)) {
             # window in which an all-green cancelled run (#342) can still be recovered.
             Name = 'watchdog cadence leaves room inside the re-run recovery window'
             Ok = (Test-WatchdogCadenceFitsRecoveryWindow -Content $watchdogContent -ThrottleFactor 4)
-            Message = 'The watchdog schedule must satisfy (cron interval x 4) < MAX_RERUN_AGE_SECONDS. GitHub delivers roughly one run per four requested ticks, so a cron of 15 minutes is already an hour of real latency -- and at an hour a run cancelled with every step green ages out of the recovery window between two ticks, which is the one failure this workflow exists to repair automatically. Express the schedule as "*/N * * * *" so this contract can read it.'
+            Message = 'The watchdog schedule must satisfy (slowest cron interval x 4) < MAX_RERUN_AGE_SECONDS. GitHub delivers roughly one run per four requested ticks, so a cron of 15 minutes is already an hour of real latency -- and at an hour a run cancelled with every step green ages out of the recovery window between two ticks, which is the one failure this workflow exists to repair automatically. Every schedule must be written as "*/N * * * *" (quoted or not) with N of at least 1, because that is the only form whose delivered gap this can reason about; a fixed-time cron fails closed here rather than being waved through.'
             File = '.github/workflows/stuck-job-watchdog.yml'
         }
     )


### PR DESCRIPTION
Four issues, all closed and each mutation-proven: an editor API that threw away the data its caller
needed, four gaps in a one-session-old fuzz suite, an allowlist whose entries nobody read, and a
credential path that still opened a window.

## #451 — an enumerable that discards its own provenance

`GetSpritesFromClip` walks every object-reference binding in a clip and yields every `Sprite`. The
binding carries `path`, `type` and `propertyName`, and all three are dropped before the caller sees
anything — so a clip animating a **child's** `SpriteRenderer` is indistinguishable from one animating
the root's.

That is not a missing answer, it is a **wrong** one. A 2D level that sorts renderers by the bottom
edge of the art they draw has to read the clip, because the scene records `m_Sprite: {fileID: 0}`;
attributing a child's frames to the parent composes a front edge through the wrong transform. The
reporter hand-rolled the filtered walk for exactly that reason — this method plus three comparisons,
the kind of copy that drifts.

- `GetSpriteFramesFromClip()` yields `(EditorCurveBinding binding, Sprite sprite)`.
- `GetSpritesFromClip(path, propertyName, type)` is the one-line `Where` over it, defaulting to
  `UnityExtensions.SpriteBindingProperty`. A `null` filter matches anything; `type` is matched
  exactly, because a subclass answering for its base is the ambiguity the overload exists to remove.
- The existing `GetSpritesFromClip()` is now that projection rather than a second walk. Its behaviour
  is unchanged.

Deliberately **not** changed: `AnimationViewerWindow` walks the bindings a second time for its
`BindingPath`, which looks like this duplication and is not — it wants the first
`SpriteRenderer.m_Sprite` binding *whether or not it carries sprite keyframes*, and the frames
enumerator only sees bindings that do.

The fixture states what it built — four curves differing in exactly one binding field each, plus an
assertion that the editor stored all four, so a filter bug and a curve Unity declined to store are
not the same red.

## #449 — four gaps the fuzz suite's own review found

**The facade was not a target, and it is what a game meets.** `Serializer.ProtoDeserialize` reaches
`WProtoFacade`, which deliberately *throws* where the formatter returns `false`; nothing pinned which
exceptions may escape, which is in open tension with the `TryXxx`-never-throws rule. Every payload
from every strategy now goes through it, and the correspondence is asserted both ways: it accepts
exactly what the formatter accepts, and refuses with `InvalidOperationException` and nothing else.

**The writer was not fuzzed at all.** The fixed-point check only compares encodings of values a
*decode* produced. A per-target value factory now writes generated values into a buffer of exactly
`Measure` bytes, so a disagreement is a failed or short write rather than a silent overrun into the
previous message's tail. The corpus deliberately includes what an encoder can disagree with itself
about: a lone surrogate, NaN and the infinities reconstituted from raw bits, a rectangular array with
a zero axis.

**The allocation ceiling was inert by a factor of 1,300.** Both replacement numbers are measured, and
the measurement is printed every run:

| | |
| --- | ---: |
| Worst allocation accepted | **160,128 B** on a 74,453-byte payload (the nesting bomb) — 2.2x its length |
| Worst per-byte cost | **152x** — 304 B from two bytes, which is one contract object |
| New ceiling | **4 KB + 256 x length**, from `128 KB + 256x` |

A synthetic reader allocating 32 KB from ten bytes is a permanent test that the ceiling *fails* —
tightening is only worth doing if the new value is provably not inert either. The high-water mark is
recorded **after** the assertion, or that amplifier sets it. Tightening also needed the warm-up that
came with it: a first decode pays for type initialization, all of it on iteration zero.

**Coverage was per corpus and could not support the claim it implied** — a strategy that dies on
field 1 every time scores 100% reach while nine members are untouched, which is how the
capacity-claim strategy shipped covering one field of seven. It is per member now, with the expected
members **read out of the seeds**, so a member added to a contract and set in its sample extends the
gate with no second list to remember. Both sides of that gate come from one field scanner, so the
scanner is pinned separately by eleven hand-written payloads — otherwise a scanner that stopped early
would shrink both sides and stay green.

**`WPROTO_FUZZ_ITERATIONS=3` reported a defect that did not exist**, so the variable — which exists to
*raise* the count — is floored at 200.

| Mutation | Result |
| --- | --- |
| The facade declines instead of throwing | 8 tests red |
| `StringSize` returns char count, not UTF-8 bytes (ASCII seeds unaffected) | 4 red, including the new writer fuzz |
| Coverage records only field 1 | 1 red, naming the member and the count |
| The axis refusal reverted (#434's fix) | 1 red, the named regression case |
| `WPROTO_FUZZ_ITERATIONS=3` | green — the floor holds |

## #445 / #448 — two contracts that named a thing where they meant a requirement

Repo Lint's contract test excuses seven linters from the registry, each with a free-text string
naming what runs it instead. **Only the keys were ever validated.** Three of the seven were false:

| Linter | Claimed | Actual |
| --- | --- | --- |
| `lint-csharp-format.ps1` | `csharpier-autofix.yml` gates C# format | that workflow runs CSharpier directly and never touches the linter; `agent-preflight.ps1` runs it |
| `validate-git-push-config.ps1` | pre-push | no hook invokes it; `npm run validate:prepush` does |
| `lint-staged-links.ps1`, `lint-staged-markdown.ps1` | git hooks | nothing in `.githooks/`; `.pre-commit-config.yaml` is their only caller |

Each entry is now a **kind** — `workflow`, `hook`, `preflight`, `prepush`, `precommit-config` — and
each kind is a predicate the test evaluates. Proven both ways: restoring the old CSharpier claim
reddens it, and so does moving the work out of a workflow while the named file stays, which is #445's
quiet mode. Comments are stripped and bare YAML list entries dropped, because
`llm-instructions-lint.yml` names its linter twice in `paths:` filters before it ever runs it.

**The near-miss is worth stating.** The sweep first concluded both staged-file linters were dead and
they were nearly deleted. They are not — `.pre-commit-config.yaml` invokes both — and it was missed
because `rg <pattern> .` does not search dotfiles. Whether that config should exist at all is #453,
filed rather than decided here. The remaining #445 instances are classified in a comment on that
issue.

**The watchdog reasons in five-minute ticks and GitHub delivers every ~21 minutes** (#448). The
measurement now lives in the workflow, and the part that is a requirement rather than a note is a
contract: `cron interval x 4 < MAX_RERUN_AGE_SECONDS`, using the measured throttle factor, failing
closed on a schedule it cannot parse. Raising the cron to `*/15` reddens it — at an hour of real
latency a run cancelled with every step green (#342) ages out of the recovery window between two
ticks.

## #450 — being the askpass

Credentials resolve from a 0600 cache, but an **empty** cache never reached that code: git falls
through to `GIT_ASKPASS`, which the editor sets to its own dialog on the owner's desktop. No
credential helper can override it — precedence is `GIT_ASKPASS`, then `core.askPass`, then
`SSH_ASKPASS` — and `GIT_TERMINAL_PROMPT=0` does not cover askpass. So the container is the askpass:
`remoteEnv` points it at a script that prints the two commands that fix it and exits non-zero.

The editor's Git UI is untouched, because the extension sets `GIT_ASKPASS` explicitly for the
processes it launches; what this replaces is the copy terminals inherit, which is the one an
unattended push uses. **Printing nothing on stdout is the security property**, not tidiness: git
reads the program's stdout as the answer, so one stray character is handed to the remote as a
credential. A mutation that echoes `x-access-token` reddens the test.

## Verification

- `Generator~`: **398 cases** against protobuf-net 3.2.56 and **397** against 2.4.9, both green, from
  a 376-case baseline.
- `scripts/tests/test-github-token.sh`: **33 passed, 0 failed** (4 new).
- `test-run-repo-lint.js` 11/11, `test-unity-workflow-matrix-contract.ps1`,
  `validate-devcontainer-config.ps1` 18/18, `test:shell-portability` 18/18.
- `npm run validate:tests:fast`: exit 0. `typecheck:unity` / `typecheck:tests` clean in every
  configuration.
- `lint:docs`, `lint:markdown`, `lint:changelog`, `lint:spelling`, `lint:yaml`, `agent:preflight` on
  every commit.
- A real Unity 6000.4.6f1 editor through the MCP bridge: **65 of 65 WallstopStudios assemblies built,
  no missing outputs, no errors in the console.**

**Not verifiable locally**: the EditMode/PlayMode assertions for #451 — no Unity licence in the
container, and the MCP command sandbox cannot reference package types (#435). CI's four-editor matrix
is the signal for those.

Closes #451
Closes #449
Closes #448
Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect deserialization error behavior (`WProtoFacade` throws), CI watchdog recovery timing assumptions, and container git credential UX; core runtime paths are mostly editor-only APIs plus expanded fuzz coverage rather than new player-facing logic.
> 
> **Overview**
> **Animation clips (#451)** — `GetSpriteFramesFromClip()` yields each sprite with its `EditorCurveBinding`; `GetSpritesFromClip(path, propertyName, type)` filters that walk (default property `UnityExtensions.SpriteBindingProperty`). The parameterless overload is now a projection over the same walk. Editor sprite/animation tools stop hard-coding `"m_Sprite"`.
> 
> **WallstopProto fuzz (#449)** — Hostile payloads also go through `WProtoFacade` with `InvalidOperationException` pinned as the only refusal shape. A generated-value write path checks `Measure` vs `Write` into an exact-size buffer. Allocation limits move to **4 KB + 256× length** (with warm-up and teardown reporting). Per-member coverage is derived from seed wire keys; iteration count is floored at 200. `WProtoFacade` XML docs document the throw contract.
> 
> **Repo hygiene (#445 / #448)** — Repo-lint “runs elsewhere” excuses are **kinds** (`workflow`, `preflight`, `prepush`, `precommit-config`) verified by predicates, not free-text. The stuck-job watchdog documents measured schedule delivery (~21 min median) and adds a matrix contract: `(slowest */N cron) × 4 < MAX_RERUN_AGE_SECONDS`.
> 
> **Devcontainer (#450)** — `remoteEnv.GIT_ASKPASS` points at `scripts/git-askpass-refuse.sh` so an empty credential cache fails with fix instructions on stderr (no stdout), with tests for exec bit, wiring, and devcontainer.json.
> 
> **Docs** — AnimationClip sprite extraction on the utilities page; contributing/context updates; validate-before-commit notes MkDocs `--strict` for links outside `docs/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298f2bfdc1df7822dab24813f332e82b04b2eef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## What CI found, and the review round

Two commits after the first push are things this branch could not verify locally, plus one the
adversarial review found.

**A test asserting the wrong answer.** `GetSpritesFromClip(path)` defaults `type` to "any", so the
root Image's `m_Sprite` curve is in the result — and the assertion said `"root0,root1"`. The
`[TestCase]` matrix two lines above had the same scenario right. Unity 6000.3 playmode agreed:
9,081 passed, 1 failed, and the failure message is that string pair. There is no Unity licence in
this container, so a PlayMode expectation is not executable before it is pushed; the only local gate
is deriving each expected value from the fixture a second time, which a `[TestCase]` table makes
cheap and an ad-hoc `[Test]` does not.

**Two coverage gaps from the review, both real.** The documented "a base of the binding's type
matches nothing" rule was enforced nowhere — the fixture only used unrelated types, so an
`IsAssignableFrom` implementation passed every row; `typeof(Renderer)` and `typeof(Graphic)` rows now
discriminate. And the per-member coverage gate recorded field numbers while a generated reader
dispatches on field **and wire type**, so the roughly three-in-eight mutations that flip a wire type
were counted as "this member's reader ran" while the reader was skipping the field. It records the
whole key now; the tightest member is 70 hits against a minimum of 15, and it reddens at 75.

**Four claims that outran their evidence**, all now false-by-test: the Repo Lint predicate answered
true for a flow-sequence `paths:`, for a list entry with a trailing comment, for a `description:`
naming the script, and for `tools/scripts/x.ps1`. The cron contract accepted only double quotes and
read only the first schedule; it takes the slowest of every schedule in any spelling now, verified
across eleven. The askpass tests ran the script through `bash`, which succeeds on a 644 file, so a
lost exec bit would have left them green. And the facade docstring sold assertions that are
unreachable against shipped code — it now says which, and why they are still worth having.

**Two docs gates, learned in order.** `mkdocs build --strict` fails on a link from `docs/` to a
repository file, which `npm run lint:docs` passes; then the sentence documenting that broke
`doc-links -Mode All`'s rule against backtick-wrapped markdown references — because the linter was
run before the edit rather than after. Both are recorded in
[validate-before-commit](../blob/main/.llm/skills/validate-before-commit.md).

## The one red check that is not this branch's

`copilot-pull-request-reviewer` fails at `Processing Request` in 53 seconds without reading any code
— the #428 signature (HTTP 402, monthly quota). Nothing in the repository can turn it green;
restoring the quota is an organization-settings act, and per
[ship-changes Step 10](../blob/main/.llm/skills/ship-changes.md) it is recorded here rather than
chased. Repository-owned checks are what "all green" means for this pull request.