### PR TITLE
Refuse the JSON a converter cannot read, and read the JSON it writes

### DIFF
--- a/.llm/skills/mcp-configuration.md
+++ b/.llm/skills/mcp-configuration.md
@@ -59,6 +59,14 @@ When calling the MCP tools directly, `Unity_ManageEditor GetProjectRoot` is the
 same one-request check — make it the first call of any session that is about to
 trust the editor.
 
+## The editor compiles your working tree
+
+The container workspace and the host project's embedded package are the same filesystem, so the
+editor on the other end of this bridge builds the code you are editing. That makes the bridge a real
+test runner when no Unity license is available -- see
+[unity-devcontainer-testing](./unity-devcontainer-testing.md#no-license-the-mcp-editor-still-runs-the-real-fixtures)
+for the reflection loop and its three constraints.
+
 ## "My agent has no `Unity_*` tools"
 
 Most often the server is reachable but the agent session is stale. Order of checks:

--- a/.llm/skills/unity-devcontainer-testing.md
+++ b/.llm/skills/unity-devcontainer-testing.md
@@ -199,6 +199,46 @@ npm run validate:prepush
 
 Do NOT attempt to create `.unity-secrets/` files programmatically — use the wizard.
 
+## No license? The MCP editor still runs the real fixtures
+
+**The container's working tree and the host Unity project's embedded package are the same
+filesystem.** Proven 2026-08-16 by writing a probe file in the container and reading it back through
+`Unity_RunCommand`; the `.git` bind mount in `devcontainer.json` is an addition to the default
+workspace bind, not a substitute for it. So the editor on the other end of the MCP bridge compiles
+**your edits**, and an `AssetDatabase.Refresh` picks up a file you just wrote.
+
+Two sessions in a row concluded that an editor-only change "has no local verification path at all",
+because `Unity_RunCommand` fails with `CS0234` on `WallstopStudios.UnityHelpers.*`. That is
+[#435](https://github.com/Ambiguous-Interactive/unity-helpers/issues/435), and it is a
+**compile-time reference** limitation of the MCP sandbox assembly only. Reflection reaches
+everything:
+
+```csharp
+Type fixture = Type.GetType(
+    "WallstopStudios.UnityHelpers.Tests.Serialization.MyTests, WallstopStudios.UnityHelpers.Tests.Runtime");
+object instance = Activator.CreateInstance(fixture);
+foreach (var method in fixture.GetMethods()) { /* find [Test], Invoke, catch */ }
+```
+
+The loop is worth writing out each time rather than committing a helper: `[TestCase]` arguments come
+off the attribute's `Arguments` property and `[TestCaseSource]` off the named static property, and a
+failure arrives as `TargetInvocationException.InnerException`.
+
+Three constraints, all discovered the hard way:
+
+- **The sandbox rejects the token `System.Reflection` anywhere in the script**, including
+  `BindingFlags`. Use `var` for `MethodInfo` locals and the parameterless `GetMethods()`.
+- **A fixture deriving from `CommonTestBase` cannot run this way.** Its teardown calls
+  `LogAssert.NoUnexpectedReceived()`, which needs the Unity test runner's log scope and reports
+  `No log scope is available` outside it. Skip lifecycle failures for a smoke run, or keep a new
+  fixture free of Unity object allocation so `lint-tests.ps1` does not require the base class.
+- **Compile errors do not surface in the tool result.** When `Type.GetType` returns null, read the
+  tail of `%LOCALAPPDATA%/Unity/Editor/Editor.log` for lines containing an `error CS` code.
+
+This is a fast inner loop (a 250-case fixture ran in 1.5 s), not a substitute for CI: it is one
+editor version, EditMode only, on Mono. `[UnityTest]` coroutines and anything needing PlayMode still
+belong to the Docker legs and to CI.
+
 ## Limitations
 
 - `WaitForEndOfFrame` does not work in batch mode (PlayMode tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `AssetChangeDetectionUtility.Enabled`, `ResetEnabledToDefault()` and `EnabledScope(bool)` to turn the `[DetectAssetChanged]` watcher on and off. The returned `AssetChangeDetectionEnabledScope` restores the previous setting on dispose ([#327](https://github.com/Ambiguous-Interactive/unity-helpers/issues/327)).
 - Add `SingleThreadedThreadPool.DrainAsync()`, which closes the pool and waits for queued work to finish instead of dropping it, plus `IsAcceptingWork` ([#318](https://github.com/Ambiguous-Interactive/unity-helpers/issues/318)).
 - Add `SerializableList<T>`, a list that survives Unity serialization inside another serialized collection ([#314](https://github.com/Ambiguous-Interactive/unity-helpers/issues/314)).
+- Add `WGuid.TryCreate(Guid, out WGuid)`, which wraps an existing GUID without throwing when it is not version 4 ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
 - Add `Enum.TryConvertToUInt64()` and `TryConvertToInt64()`, which convert any enum value to its 64-bit bit pattern without overflowing on negative or very large members.
 - Add `SemaphoreSlim.Acquire()`, `TryAcquire()` and `AcquireAsync()`, so a permit can be taken with `using` instead of a `finally`. See [Semaphore Leases](./docs/features/utilities/helper-utilities.md#semaphore-leases).
 - Add `DurableFile`, whose writes cannot leave a truncated file behind: `TryWriteAllText`, `TryAppendAllText`, `TryCopy`, `TryDelete` and async equivalents. See [Durable Writes for Player Data](./docs/features/utilities/helper-utilities.md#durable-writes-for-player-data) ([#319](https://github.com/Ambiguous-Interactive/unity-helpers/issues/319)).
@@ -63,11 +64,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bound a rectangular array's dimensions individually: an empty one whose axis exceeds `SerializationCapacityLimits.MaximumRestoredCapacity` (default 1,048,576) no longer deserializes — raise that limit if you persist one. Arrays that carry elements are unaffected, at any limit ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
 - Size a repeated member from the element count already in the packed run, so reading 128 `int`s into an array allocates 560 bytes instead of 1,744. Throughput is unchanged ([#398](https://github.com/Ambiguous-Interactive/unity-helpers/issues/398)).
 - Allow a `struct` backing set in `SerializableSetBase<T, TSet>`: the `where TSet : class` constraint is gone ([#388](https://github.com/Ambiguous-Interactive/unity-helpers/issues/388)).
+- Report a read of the write-only `GameObject` and `Touch` JSON converters as `NotSupportedException` instead of `NotImplementedException` ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
 - Ship the bundled `System.Text.Json` and friends only on editors that do not provide them; Unity supplies its own from 6000.5. See [Bundled Assembly Conflicts](./docs/guides/bundled-assembly-conflicts.md) ([#331](https://github.com/Ambiguous-Interactive/unity-helpers/issues/331)).
 - Fail the build (`WPROTO018`) when a `[WProtoContract]`'s base is one too but is not declared with `[WProtoInclude]`. It previously failed only when something serialized it ([#394](https://github.com/Ambiguous-Interactive/unity-helpers/issues/394)).
 - Bound `WProtoReader` message nesting at `MaxNestingDepth` (64). A few kilobytes of hostile payload could otherwise describe thousands of nested sub-messages, which a formatter turns into thousands of stack frames ([#343](https://github.com/Ambiguous-Interactive/unity-helpers/issues/343)).
 
 ### Fixed
+
+- Fix a save holding an unset `WGuid` failing to load: JSON wrote the empty GUID and then refused to read it back ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
+- Fix a JSON payload with `min` greater than `max`, or with `max` missing, crashing a `Range<T>` load with `ArgumentException` instead of reporting corrupt data ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
+- Fix a `Gradient` with more than eight colour or alpha keys silently losing the extras and filling the player log with errors. The payload is now refused ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
+- Fix `Serializer.JsonStringify` and `JsonSerialize` failing on a `Type`, at the root of a graph or behind an `object` member, despite the shipped `Type` converter ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
 
 - Fix an unattributed field joining the wrong group when a type declares more than one `[WGroup]`, and a bare `[WGroupEnd]` closing a group other than the one it follows. Auto-include now targets the most recently declared group, and a bare end closes every open group ([#455](https://github.com/Ambiguous-Interactive/unity-helpers/issues/455)).
 - Fix a `SerializableDictionary`'s "Add entry" Value field being drawn 8.5px left of its Key field wherever the inspector indents it ([#284](https://github.com/Ambiguous-Interactive/unity-helpers/issues/284)).

--- a/Runtime/Core/DataStructure/Adapters/WGuid.cs
+++ b/Runtime/Core/DataStructure/Adapters/WGuid.cs
@@ -230,6 +230,35 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure.Adapters
         }
 
         /// <summary>
+        /// Attempts to wrap an existing <see cref="Guid"/>, enforcing version 4 semantics.
+        /// </summary>
+        /// <param name="guid">The GUID to wrap. <see cref="Guid.Empty"/> yields <see cref="EmptyGuid"/>.</param>
+        /// <param name="value">When this method returns, the wrapper or <see cref="EmptyGuid"/>.</param>
+        /// <returns><c>true</c> when the GUID could be wrapped.</returns>
+        /// <example>
+        /// <code>
+        /// if (WGuid.TryCreate(externalId, out WGuid wrapped)) { Use(wrapped); }
+        /// </code>
+        /// </example>
+        public static bool TryCreate(Guid guid, out WGuid value)
+        {
+            if (guid == global::System.Guid.Empty)
+            {
+                value = EmptyGuid;
+                return true;
+            }
+
+            if (IsVersionFour(guid, out _))
+            {
+                value = new WGuid(guid);
+                return true;
+            }
+
+            value = EmptyGuid;
+            return false;
+        }
+
+        /// <summary>
         /// Attempts to parse a textual GUID, enforcing version 4 semantics.
         /// </summary>
         /// <param name="value">The GUID string to parse.</param>

--- a/Runtime/Core/Serialization/JsonConverters/GameObjectConverter.cs
+++ b/Runtime/Core/Serialization/JsonConverters/GameObjectConverter.cs
@@ -21,7 +21,10 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
             JsonSerializerOptions options
         )
         {
-            throw new NotImplementedException(nameof(Read));
+            throw new NotSupportedException(
+                $"{nameof(GameObject)} is written as a name/type/instance-id record for diagnostics "
+                    + "only; a scene object cannot be reconstructed from it."
+            );
         }
 
         public override void Write(

--- a/Runtime/Core/Serialization/JsonConverters/GradientConverter.cs
+++ b/Runtime/Core/Serialization/JsonConverters/GradientConverter.cs
@@ -22,6 +22,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
         private static readonly JsonEncodedText AlphaProp = JsonEncodedText.Encode("alpha");
         private static readonly JsonEncodedText TimeProp = JsonEncodedText.Encode("time");
 
+        /// <summary>The number of keys a <see cref="Gradient"/> stores per channel.</summary>
+        private const int MaximumKeys = 8;
+
         private GradientConverter() { }
 
         public override Gradient Read(
@@ -84,6 +87,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
 
                             list.Add(ReadColorKey(ref reader, options));
                         }
+                        RefuseKeyOverflow(list.Count, "colorKeys");
                         colorKeys =
                             list.Count == 0 ? Array.Empty<GradientColorKey>() : list.ToArray();
                     }
@@ -105,6 +109,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
 
                             list.Add(ReadAlphaKey(ref reader));
                         }
+                        RefuseKeyOverflow(list.Count, "alphaKeys");
                         alphaKeys =
                             list.Count == 0 ? Array.Empty<GradientAlphaKey>() : list.ToArray();
                     }
@@ -116,6 +121,22 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
             }
 
             throw new JsonException("Incomplete JSON for Gradient");
+        }
+
+        /// <remarks>
+        /// Unity's <see cref="Gradient"/> setters do not throw past the ceiling: they log an error
+        /// and keep the first eight keys, so a payload with more silently loses the rest and fills
+        /// the player log. Refusing it names the payload instead.
+        /// </remarks>
+        private static void RefuseKeyOverflow(int count, string member)
+        {
+            if (MaximumKeys < count)
+            {
+                throw new JsonException(
+                    $"Gradient.{member} holds at most {MaximumKeys} keys, but the payload "
+                        + $"delivered {count}."
+                );
+            }
         }
 
         private static GradientColorKey ReadColorKey(

--- a/Runtime/Core/Serialization/JsonConverters/RangeConverterFactory.cs
+++ b/Runtime/Core/Serialization/JsonConverters/RangeConverterFactory.cs
@@ -53,6 +53,17 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
                 {
                     if (reader.TokenType == JsonTokenType.EndObject)
                     {
+                        // The constructor validates the ordering and throws ArgumentException. A
+                        // payload that omits "max" reaches it just as readily as a hostile one,
+                        // because the omitted member defaults to zero.
+                        if (0 < min.CompareTo(max))
+                        {
+                            throw new JsonException(
+                                $"Range<{typeof(T).Name}> requires min <= max, but read "
+                                    + $"min {min} and max {max}."
+                            );
+                        }
+
                         return new Range<T>(min, max, startInclusive, endInclusive);
                     }
                     if (reader.TokenType != JsonTokenType.PropertyName)

--- a/Runtime/Core/Serialization/JsonConverters/TouchConverter.cs
+++ b/Runtime/Core/Serialization/JsonConverters/TouchConverter.cs
@@ -20,7 +20,10 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
             JsonSerializerOptions options
         )
         {
-            throw new NotImplementedException("Deserializing Touch is not supported");
+            throw new NotSupportedException(
+                $"{nameof(Touch)} is written for diagnostics only; the platform owns every field, "
+                    + "so there is nothing to restore it into."
+            );
         }
 
         public override void Write(

--- a/Runtime/Core/Serialization/JsonConverters/WGuidConverter.cs
+++ b/Runtime/Core/Serialization/JsonConverters/WGuidConverter.cs
@@ -37,6 +37,13 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
                     return parsed;
                 }
 
+                // WGuid.Empty is representable and is what Write emits for an unset id, but it is
+                // not a version-4 GUID, so TryParse refuses the very text this converter produced.
+                if (Guid.TryParse(value, out Guid raw) && WGuid.TryCreate(raw, out WGuid wrapped))
+                {
+                    return wrapped;
+                }
+
                 throw new JsonException($"Invalid {nameof(WGuid)} string value.");
             }
 
@@ -97,7 +104,17 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
                             buffer.Slice(8, 8),
                             unchecked((ulong)high)
                         );
-                        return new WGuid(new Guid(buffer));
+                        // A payload states the two halves; the constructor validates them and
+                        // throws FormatException, which is not the answer a converter owes a reader.
+                        if (WGuid.TryCreate(new Guid(buffer), out WGuid fromHalves))
+                        {
+                            return fromHalves;
+                        }
+
+                        throw new JsonException(
+                            $"{WGuid.LowFieldName}/{WGuid.HighFieldName} on {nameof(WGuid)} do not "
+                                + "form a version 4 GUID."
+                        );
                     }
 
                     return WGuid.Empty;

--- a/Runtime/Core/Serialization/JsonConverters/WGuidConverter.cs
+++ b/Runtime/Core/Serialization/JsonConverters/WGuidConverter.cs
@@ -32,16 +32,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
                     return WGuid.Empty;
                 }
 
-                if (WGuid.TryParse(value, out WGuid parsed))
+                if (TryReadText(value, out WGuid parsed))
                 {
                     return parsed;
-                }
-
-                // WGuid.Empty is representable and is what Write emits for an unset id, but it is
-                // not a version-4 GUID, so TryParse refuses the very text this converter produced.
-                if (Guid.TryParse(value, out Guid raw) && WGuid.TryCreate(raw, out WGuid wrapped))
-                {
-                    return wrapped;
                 }
 
                 throw new JsonException($"Invalid {nameof(WGuid)} string value.");
@@ -69,6 +62,25 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
             writer.WriteStringValue(value.ToString());
         }
 
+        /// <summary>
+        /// The single place a GUID's text becomes a <see cref="WGuid"/>, because this converter
+        /// accepts it in two shapes and they must agree.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="WGuid.TryParse(string)"/> alone is not enough: <see cref="WGuid.Empty"/> is
+        /// what an unset id writes and it is not a version-4 GUID, so parsing rejects the very text
+        /// this converter produced.
+        /// </remarks>
+        private static bool TryReadText(string value, out WGuid result)
+        {
+            if (WGuid.TryParse(value, out result))
+            {
+                return true;
+            }
+
+            return Guid.TryParse(value, out Guid raw) && WGuid.TryCreate(raw, out result);
+        }
+
         private static WGuid ReadFromObject(ref Utf8JsonReader reader)
         {
             long low = 0L;
@@ -83,7 +95,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
                 {
                     if (!string.IsNullOrEmpty(guidString))
                     {
-                        if (WGuid.TryParse(guidString, out WGuid parsed))
+                        if (TryReadText(guidString, out WGuid parsed))
                         {
                             return parsed;
                         }

--- a/Runtime/Core/Serialization/Serializer.cs
+++ b/Runtime/Core/Serialization/Serializer.cs
@@ -3156,6 +3156,17 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
         /// </remarks>
         private static Type ResolveRuntimeWriteType(Type runtimeType, JsonSerializerOptions options)
         {
+            // The search below is per member of every object this writer walks, so it must not run
+            // for the values that never needed it. A type System.Text.Json can name is one the
+            // caller could have declared, and every such type is public or a public nested type.
+            // Measured: Vector3, List<int>, string and int[] are IsPublic; ParticleSystem.MinMaxCurve
+            // is IsNestedPublic; System.RuntimeType -- the type this whole method exists for -- is
+            // neither.
+            if (runtimeType.IsPublic || runtimeType.IsNestedPublic)
+            {
+                return runtimeType;
+            }
+
             IList<JsonConverter> converters = options?.Converters;
             int converterCount = converters?.Count ?? 0;
             if (converterCount == 0)

--- a/Runtime/Core/Serialization/Serializer.cs
+++ b/Runtime/Core/Serialization/Serializer.cs
@@ -2749,8 +2749,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                         return;
                     }
 
-                    Type type = data.GetType();
-                    WriteValueAotSafe(writer, data, type, options);
+                    // Deliberately not data.GetType(): the runtime type is resolved once, below,
+                    // where a registered converter for a base type can claim the value.
+                    WriteValueAotSafe(writer, data, null, options);
                 }
                 else
                 {
@@ -2863,10 +2864,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                 return;
             }
 
-            Type runtimeType = value.GetType();
             Type effectiveType =
                 type == null || type == typeof(object) || type.IsAbstract || type.IsInterface
-                    ? runtimeType
+                    ? ResolveRuntimeWriteType(value.GetType(), options)
                     : type;
 
             if (!RequiresReflectionLightObjectWriter(effectiveType, options))
@@ -3141,6 +3141,42 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             }
         }
 
+        /// <summary>
+        /// Chooses the type a value is written as when its declaration is <see cref="object"/>, an
+        /// interface, or abstract.
+        /// </summary>
+        /// <remarks>
+        /// Substituting the runtime type is what makes a polymorphic member serialize as what it
+        /// actually holds, but the runtime type can be one no converter claims. Every
+        /// <see cref="Type"/> instance is the internal <c>System.RuntimeType</c>, which
+        /// System.Text.Json refuses outright -- so a <see cref="Type"/> at the root of a graph, or
+        /// behind an <see cref="object"/> member, failed even though this package registers a
+        /// converter for <see cref="Type"/>. A registered converter that claims a base type is a
+        /// statement that the base is the wire shape, so the nearest such base wins.
+        /// </remarks>
+        private static Type ResolveRuntimeWriteType(Type runtimeType, JsonSerializerOptions options)
+        {
+            IList<JsonConverter> converters = options?.Converters;
+            int converterCount = converters?.Count ?? 0;
+            if (converterCount == 0)
+            {
+                return runtimeType;
+            }
+
+            for (Type candidate = runtimeType; candidate != null; candidate = candidate.BaseType)
+            {
+                for (int index = 0; index < converterCount; index++)
+                {
+                    if (converters[index].CanConvert(candidate))
+                    {
+                        return candidate;
+                    }
+                }
+            }
+
+            return runtimeType;
+        }
+
         private static string SerializeValueAotSafe(
             object value,
             Type type,
@@ -3154,7 +3190,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
             Type effectiveType =
                 type == null || type == typeof(object) || type.IsAbstract || type.IsInterface
-                    ? value.GetType()
+                    ? ResolveRuntimeWriteType(value.GetType(), options)
                     : type;
 
             if (!RequiresReflectionLightObjectWriter(effectiveType, options))
@@ -3259,8 +3295,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                     return "{}";
                 }
 
-                Type type = data.GetType();
-                return SerializeValueAotSafe(data, type, options);
+                return SerializeValueAotSafe(data, null, options);
             }
 
             return SerializeValueAotSafe(input, parameterType, options);
@@ -3313,8 +3348,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                         return;
                     }
 
-                    Type type = data.GetType();
-                    WriteValueAotSafe(writer, data, type, options);
+                    // Deliberately not data.GetType(): the runtime type is resolved once, below,
+                    // where a registered converter for a base type can claim the value.
+                    WriteValueAotSafe(writer, data, null, options);
                 }
                 else
                 {

--- a/Runtime/Core/Serialization/Serializer.cs
+++ b/Runtime/Core/Serialization/Serializer.cs
@@ -3142,31 +3142,42 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
         }
 
         /// <summary>
+        /// Every runtime type this writer has already resolved, per options instance. The options
+        /// hold the converter list the answer depends on, and System.Text.Json makes an options
+        /// instance read-only the first time it is used to serialize, so an answer cannot go stale
+        /// under a caller who adds a converter later. The table holds the options weakly, so a
+        /// caller who builds options per call does not leak them.
+        /// </summary>
+        private static readonly ConditionalWeakTable<
+            JsonSerializerOptions,
+            ConcurrentDictionary<Type, Type>
+        > RuntimeWriteTypeCache = new();
+
+        /// <summary>
         /// Chooses the type a value is written as when its declaration is <see cref="object"/>, an
         /// interface, or abstract.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Substituting the runtime type is what makes a polymorphic member serialize as what it
         /// actually holds, but the runtime type can be one no converter claims. Every
-        /// <see cref="Type"/> instance is the internal <c>System.RuntimeType</c>, which
-        /// System.Text.Json refuses outright -- so a <see cref="Type"/> at the root of a graph, or
-        /// behind an <see cref="object"/> member, failed even though this package registers a
+        /// <see cref="Type"/> obtained from <c>typeof</c> is the internal <c>System.RuntimeType</c>,
+        /// which System.Text.Json refuses outright -- so a <see cref="Type"/> at the root of a graph,
+        /// or behind an <see cref="object"/> member, failed even though this package registers a
         /// converter for <see cref="Type"/>. A registered converter that claims a base type is a
         /// statement that the base is the wire shape, so the nearest such base wins.
+        /// </para>
+        /// <para>
+        /// The rule is deliberately not narrowed to non-public runtime types. That was tried, to
+        /// avoid the search below, and it made this summary false: <c>TypeDelegator</c> is a
+        /// <b>public</b> subclass of <see cref="Type"/>, so it would have skipped the walk and
+        /// reached the reflection-light writer, which throws <see cref="NullReferenceException"/>
+        /// walking it. The cost is answered by the cache instead, because
+        /// <c>WriteValueAotSafe</c> calls this once per property and per field.
+        /// </para>
         /// </remarks>
         private static Type ResolveRuntimeWriteType(Type runtimeType, JsonSerializerOptions options)
         {
-            // The search below is per member of every object this writer walks, so it must not run
-            // for the values that never needed it. A type System.Text.Json can name is one the
-            // caller could have declared, and every such type is public or a public nested type.
-            // Measured: Vector3, List<int>, string and int[] are IsPublic; ParticleSystem.MinMaxCurve
-            // is IsNestedPublic; System.RuntimeType -- the type this whole method exists for -- is
-            // neither.
-            if (runtimeType.IsPublic || runtimeType.IsNestedPublic)
-            {
-                return runtimeType;
-            }
-
             IList<JsonConverter> converters = options?.Converters;
             int converterCount = converters?.Count ?? 0;
             if (converterCount == 0)
@@ -3174,18 +3185,37 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                 return runtimeType;
             }
 
+            ConcurrentDictionary<Type, Type> resolved = RuntimeWriteTypeCache.GetValue(
+                options,
+                static _ => new ConcurrentDictionary<Type, Type>()
+            );
+            if (resolved.TryGetValue(runtimeType, out Type cached))
+            {
+                return cached;
+            }
+
+            Type answer = runtimeType;
             for (Type candidate = runtimeType; candidate != null; candidate = candidate.BaseType)
             {
+                bool claimed = false;
                 for (int index = 0; index < converterCount; index++)
                 {
                     if (converters[index].CanConvert(candidate))
                     {
-                        return candidate;
+                        claimed = true;
+                        break;
                     }
+                }
+
+                if (claimed)
+                {
+                    answer = candidate;
+                    break;
                 }
             }
 
-            return runtimeType;
+            resolved[runtimeType] = answer;
+            return answer;
         }
 
         private static string SerializeValueAotSafe(

--- a/Tests/Runtime/DataStructures/WGuidTests.cs
+++ b/Tests/Runtime/DataStructures/WGuidTests.cs
@@ -102,6 +102,31 @@ namespace WallstopStudios.UnityHelpers.Tests.DataStructures
         }
 
         [Test]
+        public void TryCreateAcceptsVersionFourGuid()
+        {
+            Guid source = Guid.NewGuid();
+            bool success = WGuid.TryCreate(source, out WGuid created);
+            Assert.IsTrue(success);
+            Assert.AreEqual(source, created.ToGuid());
+        }
+
+        [Test]
+        public void TryCreateAcceptsTheEmptyGuid()
+        {
+            bool success = WGuid.TryCreate(Guid.Empty, out WGuid created);
+            Assert.IsTrue(success);
+            Assert.IsTrue(created.IsEmpty);
+        }
+
+        [Test]
+        public void TryCreateRejectsNonVersionFourGuid()
+        {
+            bool success = WGuid.TryCreate(Guid.Parse(NonVersionFourGuid), out WGuid created);
+            Assert.IsFalse(success);
+            Assert.AreEqual(WGuid.EmptyGuid, created);
+        }
+
+        [Test]
         public void IsValidReturnsTrueForVersionFourGuid()
         {
             WGuid guid = WGuid.NewGuid();

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
@@ -297,6 +297,32 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         }
 
         /// <summary>
+        /// A <see cref="Type"/> written through an <see cref="object"/> reaches the package's
+        /// <c>TypeConverter</c> whatever concrete <see cref="Type"/> subclass carries it.
+        /// </summary>
+        /// <remarks>
+        /// <c>typeof(X)</c> hands back the internal <c>System.RuntimeType</c>, so a rule that
+        /// exempted public runtime types from the base-converter walk looked correct and was not:
+        /// <see cref="System.Reflection.TypeDelegator"/> is a <b>public</b> subclass of
+        /// <see cref="Type"/>, and it reached the reflection-light writer instead, which threw
+        /// <see cref="NullReferenceException"/> walking it.
+        /// </remarks>
+        [Test]
+        public void ATypeSubclassIsWrittenThroughTheTypeConverter()
+        {
+            System.Reflection.TypeDelegator delegated = new(typeof(Vector3));
+
+            string viaDelegator = Serializer.JsonStringify<object>(delegated);
+            string viaType = Serializer.JsonStringify<object>(typeof(Vector3));
+
+            Assert.AreEqual(
+                viaType,
+                viaDelegator,
+                "A public Type subclass must be written by the same converter as the Type it carries."
+            );
+        }
+
+        /// <summary>
         /// A converter that only writes must say so with <see cref="NotSupportedException"/>.
         /// </summary>
         /// <remarks>

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
@@ -1,0 +1,851 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Serialization
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Text.Json;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.Rendering;
+    using UnityEngine.SceneManagement;
+    using WallstopStudios.UnityHelpers.Core.DataStructure;
+    using WallstopStudios.UnityHelpers.Core.DataStructure.Adapters;
+    using WallstopStudios.UnityHelpers.Core.Math;
+    using WallstopStudios.UnityHelpers.Core.Serialization;
+    using WallstopStudios.UnityHelpers.Tests.Core;
+
+    /// <summary>
+    /// Feeds structure-aware malformed JSON to every Unity-aware converter and asserts what a
+    /// shipped player needs from a save file it did not write (#437).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The existing <see cref="SerializerFuzzTests"/> fuzzes random <b>bytes</b>, which the
+    /// System.Text.Json tokenizer rejects before a converter is ever entered, so the forty-odd
+    /// converters in this package had no hostile-input coverage at all. The payloads here are
+    /// derived from each converter's <b>own output</b> and then mutated, so every one of them is
+    /// well-formed JSON that reaches <c>Read</c> and disagrees with it about a value.
+    /// </para>
+    /// <para>
+    /// A converter's contract with System.Text.Json is that malformed input is reported as
+    /// <see cref="JsonException"/>. The reader's own accessors already honour it -- <c>GetInt32</c>
+    /// handed a string throws <see cref="InvalidOperationException"/>, but System.Text.Json tags and
+    /// re-wraps that one, which is why every scalar converter here passes untouched. What escapes is
+    /// what a converter throws on its <b>own</b> behalf: five defects were found this way, and every
+    /// one of them is a converter handing payload-derived values to an API that validates them --
+    /// a constructor, a Unity setter -- and letting that API's exception out.
+    /// </para>
+    /// <para>
+    /// The re-encoding check is the other half, and it caught the worst of the five: a value a
+    /// converter <b>writes</b> and then refuses to read back is a save file that cannot be loaded,
+    /// with no hostile input involved at all.
+    /// </para>
+    /// <para>
+    /// Every payload is reproducible: the corpus is generated from a fixed seed and a deterministic
+    /// walk, and a failure prints the exact JSON, which is a <c>[TestCase]</c> for
+    /// <see cref="AKnownHostilePayloadIsRefusedCleanly"/>.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    [NUnit.Framework.Category("Fast")]
+    [SkipUnderIL2CPP]
+    public sealed class JsonConverterFuzzTests
+    {
+        /// <summary>
+        /// Values substituted for one node of a valid payload at a time. Chosen for the accessor
+        /// each one breaks: a wrong token kind breaks <c>GetInt32</c>/<c>GetString</c>, a fractional
+        /// or out-of-range number breaks the integral accessors, and a container where a scalar
+        /// belongs breaks any reader that assumes it can step over one token.
+        /// </summary>
+        private static readonly string[] HostileValues =
+        {
+            "null",
+            "true",
+            "\"\"",
+            "\"not-a-number\"",
+            "1.5",
+            "-1",
+            "2147483648",
+            "-2147483649",
+            "99999999999999999999999999",
+            "1e309",
+            "[]",
+            "[1,2,3]",
+            "{}",
+            "{\"nested\":1}",
+        };
+
+        private const int TruncationSamples = 24;
+
+        private const int ByteMutationSamples = 48;
+
+        /// <summary>
+        /// How many times a repeated member's contents are repeated by <c>GrowArray</c>. Twelve
+        /// clears the eight-key ceiling <see cref="Gradient"/> enforces and the sixteen-element
+        /// shape <see cref="Matrix4x4"/> expects, which no single-node substitution reaches.
+        /// </summary>
+        private const int GrownArrayLength = 12;
+
+        private static IReadOnlyList<FuzzTarget> _targets;
+
+        /// <summary>
+        /// One entry per converter registered in <c>Serializer.CreateNormalJsonOptions</c>. The seed is
+        /// a value the converter can write; the corpus is derived from its own output.
+        /// </summary>
+        public static IReadOnlyList<FuzzTarget> Targets
+        {
+            get
+            {
+                if (_targets == null)
+                {
+                    _targets = BuildTargets();
+                }
+                return _targets;
+            }
+        }
+
+        /// <summary>
+        /// A converter handed a value it cannot read must say so with <see cref="JsonException"/>.
+        /// Anything else is a framework exception escaping through a public API, which a consumer
+        /// calling <c>JsonSerializer.Deserialize</c> with these options cannot catch by contract.
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(Targets))]
+        public void MalformedPayloadsAreReportedAsJsonException(FuzzTarget target)
+        {
+            JsonSerializerOptions options = Serializer.CreateNormalJsonOptions();
+            StringBuilder failures = new();
+            int failureCount = 0;
+            int accepted = 0;
+            int examined = 0;
+
+            foreach (string payload in Corpus(target))
+            {
+                examined++;
+                try
+                {
+                    object decoded = JsonSerializer.Deserialize(payload, target.Type, options);
+                    if (decoded != null)
+                    {
+                        // A null result for a reference type is System.Text.Json answering the
+                        // `null` literal itself; the converter's Read was never entered, so it
+                        // counts for neither the coverage gate nor the write-only one.
+                        accepted++;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // The documented answer for input a converter cannot read.
+                }
+                catch (NotSupportedException)
+                {
+                    // System.Text.Json's own answer for a type it declines to construct.
+                }
+                catch (Exception unexpected)
+                {
+                    failureCount++;
+                    if (failureCount <= 5)
+                    {
+                        failures
+                            .Append("  ")
+                            .Append(unexpected.GetType().FullName)
+                            .Append(" from ")
+                            .Append(Abbreviate(payload))
+                            .Append(" -> ")
+                            .Append(unexpected.Message)
+                            .Append('\n');
+                    }
+                }
+            }
+
+            Assert.Zero(
+                failureCount,
+                $"{target.Name}: {failureCount} of {examined} malformed payloads left a "
+                    + $"non-JsonException escape the converter.\n{failures}"
+            );
+
+            if (target.ReadSupported)
+            {
+                Assert.Positive(
+                    accepted,
+                    $"{target.Name}: no payload in a corpus of {examined} was accepted, so this "
+                        + "target proves nothing about the read path. The seed or the mutator is "
+                        + "broken."
+                );
+            }
+            else
+            {
+                Assert.Zero(
+                    accepted,
+                    $"{target.Name} is declared write-only, but {accepted} payloads were read back. "
+                        + "Either the converter gained a read path or the declaration is stale."
+                );
+            }
+        }
+
+        /// <summary>
+        /// The package-level entry point converts every failure into
+        /// <see cref="SerializationFailureException"/>, including one a converter reports oddly.
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(Targets))]
+        public void SerializerOnlyLeaksSerializationFailureException(FuzzTarget target)
+        {
+            foreach (string payload in Corpus(target))
+            {
+                try
+                {
+                    _ = Serializer.JsonDeserialize<object>(payload, target.Type);
+                }
+                catch (SerializationFailureException)
+                {
+                    // The documented answer.
+                }
+                catch (Exception unexpected)
+                {
+                    Assert.Fail(
+                        $"{target.Name}: JsonDeserialize leaked "
+                            + $"{unexpected.GetType().FullName} on {Abbreviate(payload)}: "
+                            + unexpected.Message
+                    );
+                }
+            }
+        }
+
+        /// <summary>
+        /// <c>TryJsonDeserialize</c> promises a bool rather than an exception, for every input.
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(Targets))]
+        public void TryJsonDeserializeNeverThrows(FuzzTarget target)
+        {
+            foreach (string payload in Corpus(target))
+            {
+                try
+                {
+                    _ = Serializer.TryJsonDeserialize(payload, out object _, target.Type);
+                }
+                catch (Exception unexpected)
+                {
+                    Assert.Fail(
+                        $"{target.Name}: TryJsonDeserialize threw "
+                            + $"{unexpected.GetType().FullName} on {Abbreviate(payload)}: "
+                            + unexpected.Message
+                    );
+                }
+            }
+        }
+
+        /// <summary>
+        /// A payload a converter accepts must survive its own re-encoding. A shape that reads back
+        /// but cannot be written and read again is a converter whose <c>Write</c> and <c>Read</c>
+        /// disagree, which corrupts the next save rather than the one being loaded.
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(Targets))]
+        public void AcceptedPayloadsSurviveTheirOwnReEncoding(FuzzTarget target)
+        {
+            JsonSerializerOptions options = Serializer.CreateNormalJsonOptions();
+
+            foreach (string payload in Corpus(target))
+            {
+                object first;
+                try
+                {
+                    first = JsonSerializer.Deserialize(payload, target.Type, options);
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+
+                string reEncoded;
+                try
+                {
+                    reEncoded = JsonSerializer.Serialize(first, target.Type, options);
+                }
+                catch (Exception unexpected)
+                {
+                    Assert.Fail(
+                        $"{target.Name}: a value read from {Abbreviate(payload)} could not be "
+                            + $"written back: {unexpected.GetType().FullName}: {unexpected.Message}"
+                    );
+                    return;
+                }
+
+                try
+                {
+                    _ = JsonSerializer.Deserialize(reEncoded, target.Type, options);
+                }
+                catch (Exception unexpected)
+                {
+                    Assert.Fail(
+                        $"{target.Name}: this converter wrote {Abbreviate(reEncoded)} and then "
+                            + $"refused to read it: {unexpected.GetType().FullName}: "
+                            + $"{unexpected.Message} (source payload {Abbreviate(payload)})"
+                    );
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// A converter that only writes must say so with <see cref="NotSupportedException"/>.
+        /// </summary>
+        /// <remarks>
+        /// Both threw <see cref="NotImplementedException"/>, which reads as an unfinished converter
+        /// rather than a deliberate one-way encoding, and which no caller would think to catch.
+        /// <see cref="GameObject"/> is asserted here rather than as a fuzz target because reading
+        /// one needs no instance, and allocating one would pull this whole fixture into Unity object
+        /// lifecycle management for a converter with no read path to fuzz.
+        /// </remarks>
+        [Test]
+        [TestCase(typeof(Touch))]
+        [TestCase(typeof(GameObject))]
+        public void AWriteOnlyConverterRefusesToRead(Type type)
+        {
+            JsonSerializerOptions options = Serializer.CreateNormalJsonOptions();
+
+            Assert.Throws<NotSupportedException>(
+                () => JsonSerializer.Deserialize("{}", type, options),
+                $"{type.Name} is write-only and must refuse a read with NotSupportedException"
+            );
+        }
+
+        /// <summary>
+        /// An empty <see cref="WGuid"/> is what an unset id serializes to, and it must load again.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="WGuid"/> is version-4-only, so <c>WGuid.TryParse</c> refuses the all-zero GUID
+        /// that <c>Write</c> emits for <see cref="WGuid.Empty"/> -- the converter rejected its own
+        /// output, and every save holding an unset id was unreadable.
+        /// </remarks>
+        [Test]
+        public void AnEmptyWGuidSurvivesAJsonRoundTrip()
+        {
+            string json = Serializer.JsonStringify(WGuid.Empty);
+            WGuid restored = Serializer.JsonDeserialize<WGuid>(json);
+
+            Assert.IsTrue(restored.IsEmpty, $"An empty WGuid wrote {json} and did not read back.");
+        }
+
+        /// <summary>
+        /// Every converter-backed value must be writable at the root of a graph, not only as a
+        /// member of a POCO whose declared property type names it.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Type"/> is the case that failed: it is abstract, so the write path replaced
+        /// the declared type with <c>value.GetType()</c>, which is the internal
+        /// <c>System.RuntimeType</c>. System.Text.Json refuses that outright, and the package's own
+        /// <c>TypeConverter</c> never matched it.
+        /// </remarks>
+        [Test]
+        [TestCaseSource(nameof(Targets))]
+        public void ASeedValueCanBeWrittenAtTheRoot(FuzzTarget target)
+        {
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    _ = Serializer.JsonStringify(target.Seed);
+                },
+                $"{target.Name}: a value of this type could not be written at the root of a graph."
+            );
+        }
+
+        /// <summary>
+        /// The payloads the fuzzer has already found, pinned so a regression is a named failure
+        /// rather than a corpus that happens to still contain the shape.
+        /// </summary>
+        [Test]
+        [TestCase(typeof(Vector2Int), "{\"x\":\"not-a-number\",\"y\":0}")]
+        [TestCase(typeof(Vector2Int), "{\"x\":1.5,\"y\":0}")]
+        [TestCase(typeof(Vector2Int), "{\"x\":2147483648,\"y\":0}")]
+        [TestCase(typeof(Vector3), "{\"x\":true,\"y\":0,\"z\":0}")]
+        [TestCase(typeof(Color), "{\"r\":{},\"g\":0,\"b\":0,\"a\":1}")]
+        [TestCase(typeof(Type), "12345")]
+        [TestCase(typeof(BitSet), "{\"capacity\":\"huge\",\"indices\":[]}")]
+        [TestCase(
+            typeof(Range<int>),
+            "{\"min\":1,\"max\":-1,\"startInclusive\":true,\"endInclusive\":false}"
+        )]
+        [TestCase(typeof(Range<int>), "{\"min\":1,\"startInclusive\":true,\"endInclusive\":false}")]
+        [TestCase(
+            typeof(Range<float>),
+            "{\"min\":2.5,\"max\":-1.5,\"startInclusive\":true,\"endInclusive\":true}"
+        )]
+        [TestCase(typeof(WGuid), "{\"_low\":81985529216486895,\"_high\":-1147797409030816257}")]
+        [TestCase(
+            typeof(Gradient),
+            "{\"mode\":\"Blend\",\"colorKeys\":[{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0},"
+                + "{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0},"
+                + "{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0},"
+                + "{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0},"
+                + "{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0},"
+                + "{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0},"
+                + "{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0},"
+                + "{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0},"
+                + "{\"color\":{\"r\":1,\"g\":0,\"b\":0,\"a\":1},\"time\":0}],\"alphaKeys\":[]}"
+        )]
+        public void AKnownHostilePayloadIsRefusedCleanly(Type type, string payload)
+        {
+            JsonSerializerOptions options = Serializer.CreateNormalJsonOptions();
+
+            Assert.Throws<JsonException>(
+                () => JsonSerializer.Deserialize(payload, type, options),
+                $"{type.Name} must refuse {payload} with JsonException"
+            );
+        }
+
+        private static IEnumerable<string> Corpus(FuzzTarget target)
+        {
+            foreach (string seed in target.Seeds)
+            {
+                foreach (string payload in CorpusFor(seed))
+                {
+                    yield return payload;
+                }
+            }
+        }
+
+        private static IEnumerable<string> CorpusFor(string seed)
+        {
+            yield return seed;
+
+            JsonDocument document;
+            try
+            {
+                document = JsonDocument.Parse(seed);
+            }
+            catch (JsonException)
+            {
+                document = null;
+            }
+
+            if (document != null)
+            {
+                using (document)
+                {
+                    int nodeCount = CountNodes(document.RootElement);
+                    for (int node = 0; node < nodeCount; node++)
+                    {
+                        foreach (string hostile in HostileValues)
+                        {
+                            yield return Rebuild(
+                                document.RootElement,
+                                new Mutation(node, MutationKind.ReplaceValue, hostile)
+                            );
+                        }
+
+                        yield return Rebuild(
+                            document.RootElement,
+                            new Mutation(node, MutationKind.RenameProperty, null)
+                        );
+                        yield return Rebuild(
+                            document.RootElement,
+                            new Mutation(node, MutationKind.DropProperty, null)
+                        );
+                        yield return Rebuild(
+                            document.RootElement,
+                            new Mutation(node, MutationKind.DuplicateProperty, null)
+                        );
+                        yield return Rebuild(
+                            document.RootElement,
+                            new Mutation(node, MutationKind.DuplicateArrayElement, null)
+                        );
+                        yield return Rebuild(
+                            document.RootElement,
+                            new Mutation(node, MutationKind.GrowArray, null)
+                        );
+                    }
+                }
+            }
+
+            for (int sample = 1; sample <= TruncationSamples && sample < seed.Length; sample++)
+            {
+                yield return seed.Substring(0, seed.Length * sample / (TruncationSamples + 1));
+            }
+
+            System.Random random = new(unchecked((int)0x5EED_F0DD));
+            char[] scratch = seed.ToCharArray();
+            for (int sample = 0; sample < ByteMutationSamples; sample++)
+            {
+                int index = random.Next(scratch.Length);
+                char original = scratch[index];
+                scratch[index] = (char)('!' + random.Next(90));
+                yield return new string(scratch);
+                scratch[index] = original;
+            }
+        }
+
+        private static int CountNodes(JsonElement element)
+        {
+            int count = 1;
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    foreach (JsonProperty property in element.EnumerateObject())
+                    {
+                        count += CountNodes(property.Value);
+                    }
+                    break;
+                case JsonValueKind.Array:
+                    foreach (JsonElement item in element.EnumerateArray())
+                    {
+                        count += CountNodes(item);
+                    }
+                    break;
+            }
+            return count;
+        }
+
+        private static string Rebuild(JsonElement root, Mutation mutation)
+        {
+            ArrayBufferWriter<byte> buffer = new();
+            // Not a `using` statement: Utf8JsonWriter also implements IAsyncDisposable, whose
+            // metadata this test assembly does not reference (overrideReferences).
+            Utf8JsonWriter writer = new(buffer);
+            try
+            {
+                int cursor = 0;
+                WriteMutated(writer, root, null, false, ref cursor, mutation);
+                writer.Flush();
+            }
+            finally
+            {
+                writer.Dispose();
+            }
+            return Encoding.UTF8.GetString(buffer.WrittenSpan.ToArray());
+        }
+
+        private static void WriteMutated(
+            Utf8JsonWriter writer,
+            JsonElement element,
+            string propertyName,
+            bool inArray,
+            ref int cursor,
+            Mutation mutation
+        )
+        {
+            int index = cursor;
+            cursor++;
+
+            if (index == mutation.NodeIndex && propertyName != null)
+            {
+                switch (mutation.Kind)
+                {
+                    case MutationKind.DropProperty:
+                        SkipSubtree(element, ref cursor);
+                        return;
+                    case MutationKind.RenameProperty:
+                        writer.WritePropertyName(propertyName + "§unknown");
+                        WriteVerbatim(writer, element, ref cursor);
+                        return;
+                    case MutationKind.DuplicateProperty:
+                        writer.WritePropertyName(propertyName);
+                        int firstCopy = cursor;
+                        WriteVerbatim(writer, element, ref firstCopy);
+                        writer.WritePropertyName(propertyName);
+                        WriteVerbatim(writer, element, ref cursor);
+                        return;
+                }
+            }
+
+            if (
+                index == mutation.NodeIndex
+                && inArray
+                && mutation.Kind == MutationKind.DuplicateArrayElement
+            )
+            {
+                int firstCopy = cursor;
+                WriteVerbatim(writer, element, ref firstCopy);
+                WriteVerbatim(writer, element, ref cursor);
+                return;
+            }
+
+            if (propertyName != null)
+            {
+                writer.WritePropertyName(propertyName);
+            }
+
+            if (index == mutation.NodeIndex && mutation.Kind == MutationKind.ReplaceValue)
+            {
+                using JsonDocument replacement = JsonDocument.Parse(mutation.Replacement);
+                replacement.RootElement.WriteTo(writer);
+                SkipSubtree(element, ref cursor);
+                return;
+            }
+
+            if (
+                index == mutation.NodeIndex
+                && mutation.Kind == MutationKind.GrowArray
+                && element.ValueKind == JsonValueKind.Array
+            )
+            {
+                writer.WriteStartArray();
+                for (int repeat = 0; repeat < GrownArrayLength; repeat++)
+                {
+                    foreach (JsonElement item in element.EnumerateArray())
+                    {
+                        item.WriteTo(writer);
+                    }
+                }
+                writer.WriteEndArray();
+                SkipSubtree(element, ref cursor);
+                return;
+            }
+
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    writer.WriteStartObject();
+                    foreach (JsonProperty property in element.EnumerateObject())
+                    {
+                        WriteMutated(
+                            writer,
+                            property.Value,
+                            property.Name,
+                            false,
+                            ref cursor,
+                            mutation
+                        );
+                    }
+                    writer.WriteEndObject();
+                    break;
+                case JsonValueKind.Array:
+                    writer.WriteStartArray();
+                    foreach (JsonElement item in element.EnumerateArray())
+                    {
+                        WriteMutated(writer, item, null, true, ref cursor, mutation);
+                    }
+                    writer.WriteEndArray();
+                    break;
+                default:
+                    element.WriteTo(writer);
+                    break;
+            }
+        }
+
+        private static void WriteVerbatim(
+            Utf8JsonWriter writer,
+            JsonElement element,
+            ref int cursor
+        )
+        {
+            element.WriteTo(writer);
+            SkipSubtree(element, ref cursor);
+        }
+
+        private static void SkipSubtree(JsonElement element, ref int cursor)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    foreach (JsonProperty property in element.EnumerateObject())
+                    {
+                        cursor++;
+                        SkipSubtree(property.Value, ref cursor);
+                    }
+                    break;
+                case JsonValueKind.Array:
+                    foreach (JsonElement item in element.EnumerateArray())
+                    {
+                        cursor++;
+                        SkipSubtree(item, ref cursor);
+                    }
+                    break;
+            }
+        }
+
+        private static string Abbreviate(string payload)
+        {
+            if (payload == null)
+            {
+                return "<null>";
+            }
+            return payload.Length <= 120 ? payload : payload.Substring(0, 120) + "...";
+        }
+
+        private static IReadOnlyList<FuzzTarget> BuildTargets()
+        {
+            AnimationCurve curve = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+            Gradient gradient = new();
+            gradient.SetKeys(
+                new[] { new GradientColorKey(Color.red, 0f), new GradientColorKey(Color.blue, 1f) },
+                new[] { new GradientAlphaKey(1f, 0f), new GradientAlphaKey(0f, 1f) }
+            );
+
+            BitSet bits = new(64);
+            _ = bits.TrySet(3);
+            _ = bits.TrySet(61);
+
+            Deque<int> deque = new(8);
+            deque.PushBack(1);
+            deque.PushBack(2);
+
+            CyclicBuffer<int> cyclic = new(4);
+            cyclic.Add(7);
+            cyclic.Add(9);
+
+            return new List<FuzzTarget>
+            {
+                new(typeof(Vector2), new Vector2(1.5f, -2.25f)),
+                new(typeof(Vector3), new Vector3(1.5f, -2.25f, 3f)),
+                new(typeof(Vector4), new Vector4(1f, 2f, 3f, 4f)),
+                new(typeof(Vector2Int), new Vector2Int(3, -4)),
+                new(typeof(Vector3Int), new Vector3Int(3, -4, 5)),
+                new(typeof(FastVector2Int), new FastVector2Int(3, -4)),
+                new(typeof(FastVector3Int), new FastVector3Int(3, -4, 5)),
+                new(typeof(Quaternion), new Quaternion(0.1f, 0.2f, 0.3f, 0.9f)),
+                new(typeof(Matrix4x4), Matrix4x4.identity),
+                new(typeof(Color), new Color(0.1f, 0.2f, 0.3f, 0.4f)),
+                new(typeof(Color32), new Color32(10, 20, 30, 40)),
+                new(typeof(Rect), new Rect(1f, 2f, 3f, 4f)),
+                new(typeof(RectInt), new RectInt(1, 2, 3, 4)),
+                new(typeof(RectOffset), new RectOffset(1, 2, 3, 4)),
+                new(typeof(Bounds), new Bounds(Vector3.one, Vector3.one * 2f)),
+                new(typeof(BoundsInt), new BoundsInt(Vector3Int.one, Vector3Int.one * 2)),
+                new(typeof(BoundingSphere), new BoundingSphere(Vector3.one, 2f)),
+                new(typeof(Plane), new Plane(Vector3.up, 3f)),
+                new(typeof(Ray), new Ray(Vector3.zero, Vector3.forward)),
+                new(typeof(Ray2D), new Ray2D(Vector2.zero, Vector2.right)),
+                new(typeof(Pose), new Pose(Vector3.one, Quaternion.identity)),
+                new(typeof(LayerMask), (LayerMask)5),
+                new(typeof(RangeInt), new RangeInt(2, 7)),
+                new(typeof(Hash128), Hash128.Compute("fuzz")),
+                new(typeof(Resolution), new Resolution { width = 1920, height = 1080 }),
+                new(typeof(RenderTextureDescriptor), new RenderTextureDescriptor(256, 128)),
+                new(typeof(SphericalHarmonicsL2), default(SphericalHarmonicsL2)),
+                new(typeof(AnimationCurve), curve),
+                new(typeof(Gradient), gradient),
+                new(typeof(ParticleSystem.MinMaxCurve), new ParticleSystem.MinMaxCurve(2f)),
+                new(
+                    typeof(ParticleSystem.MinMaxGradient),
+                    new ParticleSystem.MinMaxGradient(Color.green)
+                ),
+                new(typeof(UnityEngine.UI.ColorBlock), UnityEngine.UI.ColorBlock.defaultColorBlock),
+                new(typeof(RaycastHit), default(RaycastHit)),
+                FuzzTarget.WriteOnly(typeof(Touch), default(Touch)),
+                new(typeof(Scene), SceneManager.GetActiveScene()),
+                new(typeof(Type), typeof(Vector3)),
+                new(
+                    typeof(WGuid),
+                    WGuid.NewGuid(),
+                    "{\"_low\":81985529216486895,\"_high\":-1147797409030816257}",
+                    "{\"Guid\":\"2f3a9b4c-8d1f-4cba-8df7-2af00f5c6c1e\"}",
+                    "\"\""
+                ),
+                new(typeof(Range<int>), new Range<int>(1, 10, true, false)),
+                new(typeof(Range<float>), new Range<float>(-1.5f, 2.5f, false, true)),
+                new(typeof(BitSet), bits),
+                new(typeof(ImmutableBitSet), bits.ToImmutable()),
+                new(typeof(Deque<int>), deque),
+                new(typeof(CyclicBuffer<int>), cyclic),
+                new(typeof(SerializableList<int>), new SerializableList<int> { 1, 2, 3 }),
+                new(typeof(SerializableHashSet<int>), new SerializableHashSet<int> { 1, 2, 3 }),
+                new(
+                    typeof(SerializableDictionary<string, int>),
+                    new SerializableDictionary<string, int> { { "a", 1 }, { "b", 2 } }
+                ),
+                new(
+                    typeof(SerializableSortedDictionary<string, int>),
+                    new SerializableSortedDictionary<string, int> { { "a", 1 }, { "b", 2 } }
+                ),
+            };
+        }
+
+        private enum MutationKind
+        {
+            ReplaceValue = 1,
+            RenameProperty = 2,
+            DropProperty = 3,
+            DuplicateProperty = 4,
+            DuplicateArrayElement = 5,
+            GrowArray = 6,
+        }
+
+        private readonly struct Mutation
+        {
+            public Mutation(int nodeIndex, MutationKind kind, string replacement)
+            {
+                NodeIndex = nodeIndex;
+                Kind = kind;
+                Replacement = replacement;
+            }
+
+            public int NodeIndex { get; }
+            public MutationKind Kind { get; }
+            public string Replacement { get; }
+        }
+
+        /// <summary>
+        /// A converter-backed type, the value used to generate its corpus, and that value's JSON.
+        /// </summary>
+        public sealed class FuzzTarget
+        {
+            private readonly object _seed;
+            private readonly string[] _alternateSeeds;
+            private string[] _seeds;
+
+            /// <param name="alternateSeeds">
+            /// Shapes a converter accepts that it never writes -- a legacy encoding, or a second
+            /// object form. Mutating only the converter's own output leaves those branches unvisited.
+            /// </param>
+            public FuzzTarget(Type type, object seed, params string[] alternateSeeds)
+            {
+                Type = type;
+                Name = type.Name;
+                _seed = seed;
+                _alternateSeeds = alternateSeeds ?? Array.Empty<string>();
+                ReadSupported = true;
+            }
+
+            /// <summary>
+            /// A converter that writes a value for diagnostics and cannot rebuild it. Every payload
+            /// must be refused, and refused with <see cref="NotSupportedException"/> rather than
+            /// with <see cref="NotImplementedException"/>, which reads as an unfinished converter.
+            /// </summary>
+            public static FuzzTarget WriteOnly(Type type, object seed)
+            {
+                return new FuzzTarget(type, seed) { ReadSupported = false };
+            }
+
+            public Type Type { get; }
+            public string Name { get; }
+            public object Seed => _seed;
+            public bool ReadSupported { get; private set; }
+
+            /// <summary>
+            /// Built on first use rather than in the constructor: a seed that cannot be written is a
+            /// finding about one converter, and building it eagerly would take the whole corpus
+            /// down with it.
+            /// </summary>
+            public IReadOnlyList<string> Seeds
+            {
+                get
+                {
+                    if (_seeds == null)
+                    {
+                        string[] built = new string[_alternateSeeds.Length + 1];
+                        built[0] = JsonSerializer.Serialize(
+                            _seed,
+                            Type,
+                            Serializer.CreateNormalJsonOptions()
+                        );
+                        Array.Copy(_alternateSeeds, 0, built, 1, _alternateSeeds.Length);
+                        _seeds = built;
+                    }
+                    return _seeds;
+                }
+            }
+
+            public override string ToString()
+            {
+                return Name;
+            }
+        }
+    }
+}

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
@@ -67,6 +67,9 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             "true",
             "\"\"",
             "\"not-a-number\"",
+            // An all-zero identifier: the value a type's own "unset" writes, and the one a reader
+            // that validates its input is most likely to refuse for being unset.
+            "\"00000000-0000-0000-0000-000000000000\"",
             "1.5",
             "-1",
             "2147483648",
@@ -331,6 +334,24 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             WGuid restored = Serializer.JsonDeserialize<WGuid>(json);
 
             Assert.IsTrue(restored.IsEmpty, $"An empty WGuid wrote {json} and did not read back.");
+        }
+
+        /// <summary>
+        /// The converter accepts a GUID's text in two shapes, and they must agree about the empty
+        /// one. The first fix reached only the bare string, which left the object form refusing an
+        /// unset id -- the same defect one branch over.
+        /// </summary>
+        [Test]
+        [TestCase("\"00000000-0000-0000-0000-000000000000\"")]
+        [TestCase("{\"Guid\":\"00000000-0000-0000-0000-000000000000\"}")]
+        [TestCase("{\"_low\":0,\"_high\":0}")]
+        [TestCase("\"\"")]
+        [TestCase("null")]
+        public void EveryEncodingOfAnEmptyWGuidReadsBack(string payload)
+        {
+            WGuid restored = Serializer.JsonDeserialize<WGuid>(payload);
+
+            Assert.IsTrue(restored.IsEmpty, $"{payload} should read back as an empty WGuid.");
         }
 
         /// <summary>

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs.meta
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc1cc69e4c0a11a104758ac591352872
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/Serialization/JsonConverterTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterTests.cs
@@ -872,17 +872,17 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         }
 
         [Test]
-        public void GameObjectConverterReadWrapsNotImplementedAsCorruptData()
+        public void GameObjectConverterReadWrapsNotSupportedAsCorruptData()
         {
             string json = "{\"name\":\"Test\"}";
 
-            // The GameObjectConverter.Read throws NotImplementedException; the Serializer wraps that
-            // codec failure as SerializationCorruptDataException, preserving the original as inner.
+            // GameObjectConverter is write-only, which it reports as NotSupportedException; the
+            // Serializer wraps that codec failure, preserving the original as inner.
             SerializationCorruptDataException ex = Assert.Throws<SerializationCorruptDataException>(
                 () =>
                     Serializer.JsonDeserialize<GameObject>(json)
             );
-            Assert.IsTrue(ex.InnerException is NotImplementedException);
+            Assert.IsTrue(ex.InnerException is NotSupportedException);
         }
 
         [Test]
@@ -1210,16 +1210,16 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         }
 
         [Test]
-        public void TouchConverterReadWrapsNotImplementedAsCorruptData()
+        public void TouchConverterReadWrapsNotSupportedAsCorruptData()
         {
             string json = "{}";
-            // TouchConverter.Read throws NotImplementedException; the Serializer wraps it as
-            // SerializationCorruptDataException with the original preserved as inner.
+            // TouchConverter is write-only, which it reports as NotSupportedException; the
+            // Serializer wraps it with the original preserved as inner.
             SerializationCorruptDataException ex = Assert.Throws<SerializationCorruptDataException>(
                 () =>
                     Serializer.JsonDeserialize<Touch>(json)
             );
-            Assert.IsTrue(ex.InnerException is NotImplementedException);
+            Assert.IsTrue(ex.InnerException is NotSupportedException);
         }
 
         [Test]

--- a/Tests/Runtime/Serialization/UnityEngineObjectJsonTests.cs
+++ b/Tests/Runtime/Serialization/UnityEngineObjectJsonTests.cs
@@ -101,13 +101,13 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             GameObject go = Track(new GameObject("NoReadSupport"));
             string json = Serializer.JsonStringify(go);
 
-            // Our converter intentionally does not implement Read (throws NotImplementedException);
-            // the Serializer wraps that as SerializationCorruptDataException with the original inner.
+            // Our converter is deliberately write-only and reports that as NotSupportedException;
+            // the Serializer wraps it as SerializationCorruptDataException with the original inner.
             SerializationCorruptDataException ex = Assert.Throws<SerializationCorruptDataException>(
                 () =>
                     Serializer.JsonDeserialize<GameObject>(json)
             );
-            Assert.IsTrue(ex.InnerException is NotImplementedException);
+            Assert.IsTrue(ex.InnerException is NotSupportedException);
         }
 
         [UnityTest]

--- a/docs/features/serialization/serialization.md
+++ b/docs/features/serialization/serialization.md
@@ -222,6 +222,34 @@ if (!Serializer.TryWriteToJsonFile(data, "save.json"))
 - Handling corrupted save files gracefully
 - Writing to paths that may not be writable
 
+### Reading Untrusted JSON
+
+A save file, a downloaded payload, and anything that crossed a network are all input nobody in
+your team wrote. Two guarantees hold for them:
+
+- `Serializer.JsonDeserialize` reports every failure as a `SerializationFailureException`, and
+  `Serializer.TryJsonDeserialize` returns `false` instead of throwing at all.
+- The Unity-aware converters report a payload they cannot read as `JsonException`, which is the
+  contract System.Text.Json defines. This matters when you call `JsonSerializer.Deserialize`
+  yourself with `Serializer.CreateNormalJsonOptions()` rather than going through `Serializer`.
+
+Two converters are deliberately **write-only**, because what they write is a diagnostic record and
+not a value that can be rebuilt: `GameObject` (name, type and instance id) and `Touch` (owned by the
+platform). Reading either reports `NotSupportedException`.
+
+```csharp
+// A grid that came from a downloaded level pack.
+if (!Serializer.TryJsonDeserialize(downloaded, out LevelPack pack))
+{
+    UseBuiltInLevels();
+    return;
+}
+```
+
+The converters are fuzzed against structure-aware mutations of their own output on every CI run --
+wrong token kinds, out-of-range numbers, dropped and duplicated members, truncations and oversized
+repeated members -- and each one must also read back anything it writes.
+
 ### Fast Serialization (Hot Paths)
 
 For performance-critical scenarios where you serialize/deserialize frequently:


### PR DESCRIPTION
## What this fixes

Every Unity-aware JSON converter is now fuzzed with **structure-aware mutations of its own output** ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)), and the five defects that found are fixed.

The existing `SerializerFuzzTests` fuzzes random *bytes*, which the System.Text.Json tokenizer rejects before a converter is ever entered — so the forty-seven converter-backed types in this package had no hostile-input coverage at all. Every payload here is well-formed JSON derived from a converter's own `Write`, then mutated one node at a time.

### The five defects

| | Defect | Why it matters |
| --- | --- | --- |
| 1 | `WGuid.Empty` wrote `"00000000-…"` and its own reader refused it | **A save holding an unset id would not load.** No hostile input involved. `WGuid` is version-4-only, so `TryParse` rejects the all-zero GUID that `Write` emits |
| 2 | `Range<T>` with `min > max` — or with `max` simply **omitted**, which defaults it to zero — escaped as `ArgumentException` | A truncated save crashes the load path instead of reporting corrupt data |
| 3 | `WGuid`'s `{_low,_high}` form escaped as `FormatException` for a non-v4 pair | Same class: payload data handed straight to a validating constructor |
| 4 | A `Gradient` with more than eight keys silently dropped the extras | Unity's setter logs an error rather than throwing, so this loses data *and* fills the player log |
| 5 | `Serializer.JsonStringify`/`JsonSerialize` could not write a `Type` **at all** | Every `Type` instance is the internal `System.RuntimeType`, which the write path substituted for the declared type; STJ refuses it outright, so the shipped `TypeConverter` was never reached. It worked only as a POCO property, which is the one shape the existing test covered |

Four of the five are the same class: **a converter hands payload-derived values to an API that validates them, and lets that API's exception out.** The remedy is the same each time — decide before constructing, and report `JsonException`, which is the contract System.Text.Json defines.

### Also

- `WGuid.TryCreate(Guid, out WGuid)` — the type had `TryParse(string)` but no non-throwing way to wrap a `Guid` a caller already holds, which is why the converter had to risk `FormatException`.
- `GameObject` and `Touch` are deliberately write-only; they now report `NotSupportedException` rather than `NotImplementedException`, which reads as an unfinished converter and which no caller would think to catch. Three existing tests asserted the old behaviour and are updated.

### The suite

`JsonConverterFuzzTests` is data-driven over 47 converter-backed types × six mutation kinds (value substitution from fifteen hostile literals, property rename/drop/duplicate, array-element duplication, array growth) plus truncations and seeded byte flips — ~450 payloads per target, four invariants each:

1. malformed input is reported as `JsonException`;
2. `Serializer.JsonDeserialize` leaks only `SerializationFailureException`;
3. `TryJsonDeserialize` never throws;
4. **anything accepted survives its own re-encoding** — which is what caught defect 1.

Two coverage gates keep it from going vacuous: a readable target must accept at least one payload (counting only non-null results, since a `null` is STJ answering the literal without entering `Read`), and a write-only target must accept none.

## Verification

Run in a live Unity 6000.4.6f1 editor against this working tree:

| | |
| --- | ---: |
| New fixture | **255 / 255** (2 s) |
| Every `Tests.Serialization` fixture | **876 / 876** (18 s) |
| `WGuidTests`, `TypeConverterTests`, `SerializerFuzzTests` | **36 / 36** |

`npm run typecheck:unity` green in all four configurations; `agent:preflight` and `validate:prepush` green.

**Confirmed on CI too, read by name rather than by conclusion.** `Unity 2021.3.45f1 playmode`: `total=9363 passed=9343 failed=0 skipped=4`, with all 255 fixture cases present (47 targets × 5 target-driven tests, plus 12 pinned payloads, 5 empty-`WGuid` encodings, 2 write-only converters and the round-trip) and the three new `WGuidTests.TryCreate*` cases. Worth stating explicitly: the **editmode** legs run none of this — `Tests.Runtime` contributes no tests there, and that leg's `total=4689` is unchanged by this branch. The playmode legs are the ones that exercise it.

**The suite is proven able to fail.** Reverting the four changed production files to `origin/main` and re-running turns **13 tests red** — every defect class, each by the invariant that found it — and brings the `Max number of color keys is 8 (given 24)` console errors back. Restored: 255/255.

## Review round

Cursor Bugbot caught a real gap in the first push: `WGuidConverter` accepts a GUID's text in **two** shapes and the initial fix reached only the bare string, so `{"Guid":"00000000-…"}` still refused an unset id — the same defect one branch over. Both shapes now go through a single `TryReadText`, the all-zero identifier joined the corpus's hostile literals (mutation could not have generated it: it is not *malformed*, it is *unset*), and `EveryEncodingOfAnEmptyWGuidReadsBack` pins all five encodings.

## A note on how this was verified

The container's working tree **is** the host Unity project's embedded package, so the MCP editor compiles our edits and can execute real fixtures in seconds. Sessions 193 and 194 both concluded an editor-only change had "no local verification path at all" because `Unity_RunCommand` fails `CS0234` on package types — that is [#435](https://github.com/Ambiguous-Interactive/unity-helpers/issues/435), a *compile-time reference* limit of the sandbox assembly only. Written up with its three constraints in [unity-devcontainer-testing](../blob/dev/wallstop/session-195-json-fuzz/.llm/skills/unity-devcontainer-testing.md#no-license-the-mcp-editor-still-runs-the-real-fixtures).

## Follow-ups filed

- [#459](https://github.com/Ambiguous-Interactive/unity-helpers/issues/459) — nothing stops a *new* write-only converter, or one that refuses its own output, being added unnoticed. The `ContractMirrorTests` shape applied to JSON.
- [#460](https://github.com/Ambiguous-Interactive/unity-helpers/issues/460) — `copilot-pull-request-reviewer` is red on every PR including the last three merged; the cause is a Copilot quota limit, reported in the review body rather than as check output. Pre-existing, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect save/load and JSON error surfaces across many converters; behavior is intentionally stricter (reject bad data) with broad new test coverage, but any consumer depending on old exception types or silent truncation could see breakage.
> 
> **Overview**
> Introduces **`JsonConverterFuzzTests`**, which mutates each converter’s own JSON output and asserts malformed input surfaces as **`JsonException`**, **`Serializer`** only leaks **`SerializationFailureException`**, and accepted values round-trip through re-encoding.
> 
> **Converter and API fixes** from that coverage: **`WGuid`** empty GUID and object forms read back via shared **`TryReadText`** and new **`WGuid.TryCreate(Guid, out WGuid)`**; **`Range<T>`** rejects **`min > max`** or missing **`max`** before the constructor throws; **`Gradient`** refuses more than eight keys instead of silently truncating; **`GameObject`** / **`Touch`** reads throw **`NotSupportedException`** instead of **`NotImplementedException`**; **`Serializer`** **`ResolveRuntimeWriteType`** walks the type hierarchy so **`Type`** (and subclasses like **`TypeDelegator`**) serialize at the root through the registered converter.
> 
> Docs add **untrusted JSON** guidance in **`serialization.md`**, **CHANGELOG** entries for #437, and agent skills describing **MCP Unity** as a compile/test loop when the devcontainer shares the host package tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 233be9b80301a433783d6f4822f1eea534856143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->