### PR TITLE
Refuse to conjure a singleton whose state is authored, and hold three converter lists to one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix defining `UNITY_DISABLE_UI` breaking the runtime assembly. The JSON options named `ColorBlockConverter` while the converter itself was compiled out ([#459](https://github.com/Ambiguous-Interactive/unity-helpers/issues/459)).
 - Fix a save holding an unset `WGuid` failing to load: JSON wrote the empty GUID and then refused to read it back ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
 - Fix a JSON payload with `min` greater than `max`, or with `max` missing, crashing a `Range<T>` load with `ArgumentException` instead of reporting corrupt data ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
 - Fix a `Gradient` with more than eight colour or alpha keys silently losing the extras and filling the player log with errors. The payload is now refused ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `[SingletonCreation(SingletonCreationPolicy.NeverCreate)]`, which stops `RuntimeSingleton<T>.Instance` creating a bare stand-in when no instance exists. It returns `null` and names the type instead. See [Controlling on-demand creation](./docs/features/utilities/singletons.md#controlling-on-demand-creation) ([#321](https://github.com/Ambiguous-Interactive/unity-helpers/issues/321)).
 - Add `AnimationClip.GetSpriteFramesFromClip()`, which pairs every sprite a clip references with the binding that supplies it, a `GetSpritesFromClip(path, propertyName, type)` overload that filters on that binding, and `UnityExtensions.SpriteBindingProperty`. Editor-only. See [Sprites from an AnimationClip](./docs/features/utilities/math-and-extensions.md#sprites-from-an-animationclip) ([#451](https://github.com/Ambiguous-Interactive/unity-helpers/issues/451)).
 - Add `AssetChangeDetectionUtility.Enabled`, `ResetEnabledToDefault()` and `EnabledScope(bool)` to turn the `[DetectAssetChanged]` watcher on and off. The returned `AssetChangeDetectionEnabledScope` restores the previous setting on dispose ([#327](https://github.com/Ambiguous-Interactive/unity-helpers/issues/327)).
 - Add `SingleThreadedThreadPool.DrainAsync()`, which closes the pool and waits for queued work to finish instead of dropping it, plus `IsAcceptingWork` ([#318](https://github.com/Ambiguous-Interactive/unity-helpers/issues/318)).
@@ -71,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix defining `UNITY_DISABLE_UI` breaking the runtime assembly. The JSON options named `ColorBlockConverter` while the converter itself was compiled out ([#459](https://github.com/Ambiguous-Interactive/unity-helpers/issues/459)).
 - Fix a save holding an unset `WGuid` failing to load: JSON wrote the empty GUID and then refused to read it back ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
 - Fix a JSON payload with `min` greater than `max`, or with `max` missing, crashing a `Range<T>` load with `ArgumentException` instead of reporting corrupt data ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).
 - Fix a `Gradient` with more than eight colour or alpha keys silently losing the extras and filling the player log with errors. The payload is now refused ([#437](https://github.com/Ambiguous-Interactive/unity-helpers/issues/437)).

--- a/Editor/Tags/AttributeMetadataCacheGenerator.cs
+++ b/Editor/Tags/AttributeMetadataCacheGenerator.cs
@@ -84,6 +84,15 @@ namespace WallstopStudios.UnityHelpers.Editor.Tags
 
                 AutoLoadSingletonEntry[] autoLoadEntries = BuildAutoLoadSingletonEntries();
 
+                foreach (
+                    string problem in FindSingletonCreationProblems(
+                        TypeCache.GetTypesWithAttribute<SingletonCreationAttribute>()
+                    )
+                )
+                {
+                    Debug.LogWarning(problem);
+                }
+
                 // Get or create the cache asset
                 AttributeMetadataCache cache = GetOrCreateCache(out bool metadataChanged);
 
@@ -311,6 +320,87 @@ namespace WallstopStudios.UnityHelpers.Editor.Tags
 
             entries.Sort((left, right) => string.CompareOrdinal(left.typeName, right.typeName));
             return entries.ToArray();
+        }
+
+        /// <summary>
+        /// Reports every <see cref="SingletonCreationAttribute"/> that cannot do what its author meant.
+        /// Separate from the generator so each rule can be driven from types written for the purpose;
+        /// a rule only ever run over this repository's own sources is indistinguishable from one that
+        /// always agrees.
+        /// </summary>
+        /// <param name="annotatedTypes">Types carrying <see cref="SingletonCreationAttribute"/>.</param>
+        /// <returns>One message per problem, ordered by type name.</returns>
+        internal static List<string> FindSingletonCreationProblems(IEnumerable<Type> annotatedTypes)
+        {
+            List<string> problems = new();
+            if (annotatedTypes == null)
+            {
+                return problems;
+            }
+
+            foreach (Type type in annotatedTypes)
+            {
+                if (type == null || type.IsAbstract || type.ContainsGenericParameters)
+                {
+                    continue;
+                }
+
+                if (
+                    !ReflectionHelpers.TryGetAttributeSafe(
+                        type,
+                        out SingletonCreationAttribute creation,
+                        inherit: true
+                    )
+                )
+                {
+                    continue;
+                }
+
+                if (
+                    !IsSubclassOfRawGeneric(
+                        type,
+                        typeof(WallstopStudios.UnityHelpers.Utils.RuntimeSingleton<>)
+                    )
+                )
+                {
+                    problems.Add(
+                        $"AttributeMetadataCacheGenerator: {type.FullName} is marked with [{nameof(SingletonCreationAttribute)}] but does not derive from RuntimeSingleton<>, so the attribute has no effect. ScriptableObjectSingleton<> never creates an asset at runtime and needs no policy."
+                    );
+                    continue;
+                }
+
+                if (creation.Policy != SingletonCreationPolicy.NeverCreate)
+                {
+                    continue;
+                }
+
+                if (
+                    !ReflectionHelpers.TryGetAttributeSafe(
+                        type,
+                        out AutoLoadSingletonAttribute autoLoad,
+                        inherit: false
+                    )
+                )
+                {
+                    continue;
+                }
+
+                // AfterSceneLoad is the one phase where an authored instance already exists, so
+                // auto-loading a NeverCreate singleton there binds the static cache to it. Every
+                // earlier phase runs before any GameObject exists, so the lookup can only find
+                // nothing and the pair is a contradiction rather than a choice.
+                if (autoLoad.LoadType == RuntimeInitializeLoadType.AfterSceneLoad)
+                {
+                    continue;
+                }
+
+                problems.Add(
+                    $"AttributeMetadataCacheGenerator: {type.FullName} is marked [{nameof(AutoLoadSingletonAttribute)}({nameof(RuntimeInitializeLoadType)}.{autoLoad.LoadType})] and [{nameof(SingletonCreationAttribute)}({nameof(SingletonCreationPolicy)}.{nameof(SingletonCreationPolicy.NeverCreate)})]. That phase runs before any scene has loaded, so the auto-load can only find nothing. Use {nameof(RuntimeInitializeLoadType)}.{nameof(RuntimeInitializeLoadType.AfterSceneLoad)} or drop one of the two attributes."
+                );
+            }
+
+            problems.Sort(StringComparer.Ordinal);
+            return problems;
         }
 
         private static SingletonAutoLoadKind? ResolveSingletonKind(Type type)

--- a/Editor/Tags/AttributeMetadataCacheGenerator.cs
+++ b/Editor/Tags/AttributeMetadataCacheGenerator.cs
@@ -85,12 +85,38 @@ namespace WallstopStudios.UnityHelpers.Editor.Tags
                 AutoLoadSingletonEntry[] autoLoadEntries = BuildAutoLoadSingletonEntries();
 
                 foreach (
-                    string problem in FindSingletonCreationProblems(
-                        TypeCache.GetTypesWithAttribute<SingletonCreationAttribute>()
-                    )
+                    Type annotated in TypeCache.GetTypesWithAttribute<SingletonCreationAttribute>()
                 )
                 {
-                    Debug.LogWarning(problem);
+                    if (
+                        annotated == null
+                        || annotated.IsAbstract
+                        || annotated.ContainsGenericParameters
+                    )
+                    {
+                        continue;
+                    }
+
+                    _ = ReflectionHelpers.TryGetAttributeSafe(
+                        annotated,
+                        out SingletonCreationAttribute creation,
+                        inherit: true
+                    );
+                    _ = ReflectionHelpers.TryGetAttributeSafe(
+                        annotated,
+                        out AutoLoadSingletonAttribute autoLoad,
+                        inherit: false
+                    );
+
+                    string problem = DescribeSingletonCreationProblem(
+                        annotated,
+                        creation,
+                        autoLoad
+                    );
+                    if (problem != null)
+                    {
+                        Debug.LogWarning(problem);
+                    }
                 }
 
                 // Get or create the cache asset
@@ -323,84 +349,56 @@ namespace WallstopStudios.UnityHelpers.Editor.Tags
         }
 
         /// <summary>
-        /// Reports every <see cref="SingletonCreationAttribute"/> that cannot do what its author meant.
-        /// Separate from the generator so each rule can be driven from types written for the purpose;
-        /// a rule only ever run over this repository's own sources is indistinguishable from one that
-        /// always agrees.
+        /// Reports a <see cref="SingletonCreationAttribute"/> that cannot do what its author meant,
+        /// or <c>null</c> when the annotation is sound.
         /// </summary>
-        /// <param name="annotatedTypes">Types carrying <see cref="SingletonCreationAttribute"/>.</param>
-        /// <returns>One message per problem, ordered by type name.</returns>
-        internal static List<string> FindSingletonCreationProblems(IEnumerable<Type> annotatedTypes)
+        /// <remarks>
+        /// The attributes arrive as arguments rather than being read off <paramref name="type"/> so a
+        /// test can drive every branch without annotating a deliberately wrong type -- which
+        /// <see cref="TypeCache"/> would then find on every editor load, and this method would then
+        /// complain about forever. It is the technique <c>RuntimeMismatchSingleton</c> already uses
+        /// for the auto-loader's own mismatch rules.
+        /// </remarks>
+        /// <param name="type">The annotated type.</param>
+        /// <param name="creation">Its <see cref="SingletonCreationAttribute"/>, or <c>null</c>.</param>
+        /// <param name="autoLoad">Its <see cref="AutoLoadSingletonAttribute"/>, or <c>null</c>.</param>
+        /// <returns>A message naming the problem, or <c>null</c>.</returns>
+        internal static string DescribeSingletonCreationProblem(
+            Type type,
+            SingletonCreationAttribute creation,
+            AutoLoadSingletonAttribute autoLoad
+        )
         {
-            List<string> problems = new();
-            if (annotatedTypes == null)
+            if (type == null || creation == null)
             {
-                return problems;
+                return null;
             }
 
-            foreach (Type type in annotatedTypes)
+            if (
+                !IsSubclassOfRawGeneric(
+                    type,
+                    typeof(WallstopStudios.UnityHelpers.Utils.RuntimeSingleton<>)
+                )
+            )
             {
-                if (type == null || type.IsAbstract || type.ContainsGenericParameters)
-                {
-                    continue;
-                }
-
-                if (
-                    !ReflectionHelpers.TryGetAttributeSafe(
-                        type,
-                        out SingletonCreationAttribute creation,
-                        inherit: true
-                    )
-                )
-                {
-                    continue;
-                }
-
-                if (
-                    !IsSubclassOfRawGeneric(
-                        type,
-                        typeof(WallstopStudios.UnityHelpers.Utils.RuntimeSingleton<>)
-                    )
-                )
-                {
-                    problems.Add(
-                        $"AttributeMetadataCacheGenerator: {type.FullName} is marked with [{nameof(SingletonCreationAttribute)}] but does not derive from RuntimeSingleton<>, so the attribute has no effect. ScriptableObjectSingleton<> never creates an asset at runtime and needs no policy."
-                    );
-                    continue;
-                }
-
-                if (creation.Policy != SingletonCreationPolicy.NeverCreate)
-                {
-                    continue;
-                }
-
-                if (
-                    !ReflectionHelpers.TryGetAttributeSafe(
-                        type,
-                        out AutoLoadSingletonAttribute autoLoad,
-                        inherit: false
-                    )
-                )
-                {
-                    continue;
-                }
-
-                // AfterSceneLoad is the one phase where an authored instance already exists, so
-                // auto-loading a NeverCreate singleton there binds the static cache to it. Every
-                // earlier phase runs before any GameObject exists, so the lookup can only find
-                // nothing and the pair is a contradiction rather than a choice.
-                if (autoLoad.LoadType == RuntimeInitializeLoadType.AfterSceneLoad)
-                {
-                    continue;
-                }
-
-                problems.Add(
-                    $"AttributeMetadataCacheGenerator: {type.FullName} is marked [{nameof(AutoLoadSingletonAttribute)}({nameof(RuntimeInitializeLoadType)}.{autoLoad.LoadType})] and [{nameof(SingletonCreationAttribute)}({nameof(SingletonCreationPolicy)}.{nameof(SingletonCreationPolicy.NeverCreate)})]. That phase runs before any scene has loaded, so the auto-load can only find nothing. Use {nameof(RuntimeInitializeLoadType)}.{nameof(RuntimeInitializeLoadType.AfterSceneLoad)} or drop one of the two attributes."
-                );
+                return $"AttributeMetadataCacheGenerator: {type.FullName} is marked with [{nameof(SingletonCreationAttribute)}] but does not derive from RuntimeSingleton<>, so the attribute has no effect. ScriptableObjectSingleton<> never creates an asset at runtime and needs no policy.";
             }
 
-            problems.Sort(StringComparer.Ordinal);
-            return problems;
+            if (creation.Policy != SingletonCreationPolicy.NeverCreate || autoLoad == null)
+            {
+                return null;
+            }
+
+            // AfterSceneLoad is the one phase where an authored instance already exists, so
+            // auto-loading a NeverCreate singleton there binds the static cache to it. Every earlier
+            // phase runs before any GameObject exists, so the lookup can only find nothing and the
+            // pair is a contradiction rather than a choice.
+            if (autoLoad.LoadType == RuntimeInitializeLoadType.AfterSceneLoad)
+            {
+                return null;
+            }
+
+            return $"AttributeMetadataCacheGenerator: {type.FullName} is marked [{nameof(AutoLoadSingletonAttribute)}({nameof(RuntimeInitializeLoadType)}.{autoLoad.LoadType})] and [{nameof(SingletonCreationAttribute)}({nameof(SingletonCreationPolicy)}.{nameof(SingletonCreationPolicy.NeverCreate)})]. That phase runs before any scene has loaded, so the auto-load can only find nothing. Use {nameof(RuntimeInitializeLoadType)}.{nameof(RuntimeInitializeLoadType.AfterSceneLoad)} or drop one of the two attributes.";
         }
 
         private static SingletonAutoLoadKind? ResolveSingletonKind(Type type)

--- a/Editor/Tags/AttributeMetadataCacheGenerator.cs
+++ b/Editor/Tags/AttributeMetadataCacheGenerator.cs
@@ -84,9 +84,28 @@ namespace WallstopStudios.UnityHelpers.Editor.Tags
 
                 AutoLoadSingletonEntry[] autoLoadEntries = BuildAutoLoadSingletonEntries();
 
+                // Both attribute sets, because TypeCache reports only types carrying the attribute
+                // DIRECTLY while the runtime resolves SingletonCreationAttribute with inherit: true.
+                // An annotated abstract base with a concrete [AutoLoadSingleton] subclass is the
+                // contradiction below, and enumerating either set alone cannot see it: the base is
+                // skipped as abstract and the subclass carries no SingletonCreationAttribute of its
+                // own.
+                HashSet<Type> singletonCandidates = new();
                 foreach (
                     Type annotated in TypeCache.GetTypesWithAttribute<SingletonCreationAttribute>()
                 )
+                {
+                    singletonCandidates.Add(annotated);
+                }
+
+                foreach (
+                    Type annotated in TypeCache.GetTypesWithAttribute<AutoLoadSingletonAttribute>()
+                )
+                {
+                    singletonCandidates.Add(annotated);
+                }
+
+                foreach (Type annotated in singletonCandidates)
                 {
                     if (
                         annotated == null

--- a/Runtime/Core/Attributes/ChildComponentAttribute.cs
+++ b/Runtime/Core/Attributes/ChildComponentAttribute.cs
@@ -8,6 +8,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     using System.Collections.Generic;
     using Extension;
     using UnityEngine;
+    using UnityEngine.Scripting;
     using WallstopStudios.UnityHelpers.Core.Helper;
     using WallstopStudios.UnityHelpers.Utils;
     using static RelationalComponentProcessor;
@@ -66,6 +67,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     /// ]]></code>
     /// </example>
     [AttributeUsage(AttributeTargets.Field)]
+    [Preserve]
     public sealed class ChildComponentAttribute : BaseRelationalComponentAttribute
     {
         /// <summary>

--- a/Runtime/Core/Attributes/EnumDisplayNameAttribute.cs
+++ b/Runtime/Core/Attributes/EnumDisplayNameAttribute.cs
@@ -4,8 +4,10 @@
 namespace WallstopStudios.UnityHelpers.Core.Attributes
 {
     using System;
+    using UnityEngine.Scripting;
 
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+    [Preserve]
     public sealed class EnumDisplayNameAttribute : Attribute
     {
         public string DisplayName { get; }

--- a/Runtime/Core/Attributes/ParentComponentAttribute.cs
+++ b/Runtime/Core/Attributes/ParentComponentAttribute.cs
@@ -8,6 +8,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     using System.Collections.Generic;
     using Extension;
     using UnityEngine;
+    using UnityEngine.Scripting;
     using WallstopStudios.UnityHelpers.Utils;
     using static RelationalComponentProcessor;
 #if UNITY_EDITOR && UNITY_2020_2_OR_NEWER
@@ -70,6 +71,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     /// ]]></code>
     /// </example>
     [AttributeUsage(AttributeTargets.Field)]
+    [Preserve]
     public sealed class ParentComponentAttribute : BaseRelationalComponentAttribute
     {
         /// <summary>

--- a/Runtime/Core/Attributes/ScriptableSingletonPathAttribute.cs
+++ b/Runtime/Core/Attributes/ScriptableSingletonPathAttribute.cs
@@ -4,8 +4,10 @@
 namespace WallstopStudios.UnityHelpers.Core.Attributes
 {
     using System;
+    using UnityEngine.Scripting;
 
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    [Preserve]
     public sealed class ScriptableSingletonPathAttribute : Attribute
     {
         public readonly string resourcesPath;

--- a/Runtime/Core/Attributes/SiblingComponentAttribute.cs
+++ b/Runtime/Core/Attributes/SiblingComponentAttribute.cs
@@ -7,6 +7,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     using System.Collections;
     using System.Collections.Generic;
     using UnityEngine;
+    using UnityEngine.Scripting;
     using WallstopStudios.UnityHelpers.Core.Extension;
     using WallstopStudios.UnityHelpers.Utils;
     using static RelationalComponentProcessor;
@@ -62,6 +63,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     /// ]]></code>
     /// </example>
     [AttributeUsage(AttributeTargets.Field)]
+    [Preserve]
     public sealed class SiblingComponentAttribute : BaseRelationalComponentAttribute { }
 
     public static class SiblingComponentExtensions

--- a/Runtime/Core/Attributes/SingletonCreationAttribute.cs
+++ b/Runtime/Core/Attributes/SingletonCreationAttribute.cs
@@ -4,6 +4,7 @@
 namespace WallstopStudios.UnityHelpers.Core.Attributes
 {
     using System;
+    using UnityEngine.Scripting;
     using WallstopStudios.UnityHelpers.Core.Helper;
 
     /// <summary>
@@ -35,6 +36,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     /// </code>
     /// </example>
     [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    [Preserve]
     public sealed class SingletonCreationAttribute : Attribute
     {
         /// <summary>

--- a/Runtime/Core/Attributes/SingletonCreationAttribute.cs
+++ b/Runtime/Core/Attributes/SingletonCreationAttribute.cs
@@ -1,0 +1,56 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Core.Attributes
+{
+    using System;
+    using WallstopStudios.UnityHelpers.Core.Helper;
+
+    /// <summary>
+    /// Decides whether <see cref="WallstopStudios.UnityHelpers.Utils.RuntimeSingleton{T}.Instance"/>
+    /// may create the singleton when none exists in any loaded scene.
+    /// </summary>
+    /// <remarks>
+    /// A singleton authored in a scene or a prefab holds serialized state, and a created stand-in has
+    /// every <c>[SerializeField]</c> left at its default - so it behaves like the real thing while
+    /// carrying none of the data. Annotate those with
+    /// <see cref="SingletonCreationPolicy.NeverCreate"/> so a missing instance is reported instead of
+    /// substituted. Leave a singleton that holds no serialized state alone; creating one on demand is
+    /// what makes <c>Instance</c> work from anywhere.
+    ///
+    /// The decision is read from the type rather than from an overridable member because there is no
+    /// instance to ask when the question is whether to make one.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [SingletonCreation(SingletonCreationPolicy.NeverCreate)]
+    /// public sealed class SaveManager : RuntimeSingleton&lt;SaveManager&gt;
+    /// {
+    ///     [SerializeField]
+    ///     private SaveSettings _settings;
+    /// }
+    ///
+    /// // Returns null instead of a SaveManager with no settings.
+    /// SaveManager manager = SaveManager.Instance;
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    public sealed class SingletonCreationAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the policy <c>Instance</c> applies when no instance exists.
+        /// </summary>
+        public SingletonCreationPolicy Policy { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SingletonCreationAttribute"/> class.
+        /// </summary>
+        /// <param name="policy">
+        /// What <c>Instance</c> should do when no instance of the singleton exists.
+        /// </param>
+        public SingletonCreationAttribute(SingletonCreationPolicy policy)
+        {
+            Policy = policy;
+        }
+    }
+}

--- a/Runtime/Core/Attributes/SingletonCreationAttribute.cs.meta
+++ b/Runtime/Core/Attributes/SingletonCreationAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54c75a13938134c2d003fad1c9fb19e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Core/Attributes/WShowIfAttribute.cs
+++ b/Runtime/Core/Attributes/WShowIfAttribute.cs
@@ -6,6 +6,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     using System;
     using System.Collections.Generic;
     using UnityEngine;
+    using UnityEngine.Scripting;
     using WallstopStudios.UnityHelpers.Utils;
 
     /// <summary>
@@ -110,6 +111,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
     /// public AbilityOverrides overrideSettings;
     /// </code>
     /// </example>
+    [Preserve]
     public sealed class WShowIfAttribute : PropertyAttribute
     {
         /// <summary>

--- a/Runtime/Core/Helper/SingletonCreationPolicy.cs
+++ b/Runtime/Core/Helper/SingletonCreationPolicy.cs
@@ -1,0 +1,33 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Core.Helper
+{
+    using System;
+
+    /// <summary>
+    /// Decides what <see cref="WallstopStudios.UnityHelpers.Utils.RuntimeSingleton{T}.Instance"/> does
+    /// when no instance of the singleton exists in any loaded scene.
+    /// </summary>
+    public enum SingletonCreationPolicy : byte
+    {
+        /// <summary>
+        /// Default uninitialized value - should never be used.
+        /// </summary>
+        [Obsolete("Use a specific SingletonCreationPolicy value instead of Unknown.")]
+        Unknown = 0,
+
+        /// <summary>
+        /// Create a new <see cref="UnityEngine.GameObject"/> holding the component on first access.
+        /// This is the behavior a singleton carrying no
+        /// <see cref="WallstopStudios.UnityHelpers.Core.Attributes.SingletonCreationAttribute"/> gets.
+        /// </summary>
+        CreateOnDemand = 1,
+
+        /// <summary>
+        /// Never create one. <c>Instance</c> returns the existing instance when there is one and
+        /// <c>null</c> otherwise, logging a single warning naming the type.
+        /// </summary>
+        NeverCreate = 2,
+    }
+}

--- a/Runtime/Core/Helper/SingletonCreationPolicy.cs.meta
+++ b/Runtime/Core/Helper/SingletonCreationPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b965f3e6008d3731dea4069f8776d1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Core/Random/RandomGeneratorMetadata.cs
+++ b/Runtime/Core/Random/RandomGeneratorMetadata.cs
@@ -4,6 +4,7 @@
 namespace WallstopStudios.UnityHelpers.Core.Random
 {
     using System;
+    using UnityEngine.Scripting;
     using WallstopStudios.UnityHelpers.Core.Helper;
 
     /// <summary>
@@ -24,6 +25,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
     /// Describes statistical quality metadata that can be attached to <see cref="IRandom"/> implementations.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [Preserve]
     public sealed class RandomGeneratorMetadataAttribute : Attribute
     {
         public RandomGeneratorMetadataAttribute(

--- a/Runtime/Core/Serialization/JsonConverters/ColorBlockConverter.cs
+++ b/Runtime/Core/Serialization/JsonConverters/ColorBlockConverter.cs
@@ -1,8 +1,6 @@
 // MIT License - Copyright (c) 2025 wallstop
 // Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
 
-// Requires UnityEngine.UI; file can be excluded if UI module isn't referenced.
-#if !UNITY_DISABLE_UI
 namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
 {
     using System;
@@ -123,4 +121,3 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.JsonConverters
         }
     }
 }
-#endif

--- a/Runtime/Core/Serialization/Serializer.cs
+++ b/Runtime/Core/Serialization/Serializer.cs
@@ -82,13 +82,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             converters.Add(RenderTextureDescriptorConverter.Instance);
             converters.Add(MinMaxCurveConverter.Instance);
             converters.Add(MinMaxGradientConverter.Instance);
-            // Honours the guard the converter file already carried. Before this list was shared, three
-            // copies of it named ColorBlockConverter unguarded, so defining UNITY_DISABLE_UI compiled
-            // the converter out and then broke the runtime assembly on the references to it -- a guard
-            // that could not be used was indistinguishable from protection that existed.
-#if !UNITY_DISABLE_UI
             converters.Add(ColorBlockConverter.Instance);
-#endif
             converters.Add(BoundingSphereConverter.Instance);
             converters.Add(RaycastHitConverter.Instance);
             converters.Add(TouchConverter.Instance);

--- a/Runtime/Core/Serialization/Serializer.cs
+++ b/Runtime/Core/Serialization/Serializer.cs
@@ -40,9 +40,89 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
         public static readonly JsonSerializerOptions FastJsonOptions;
         public static readonly JsonSerializerOptions FastPocoJsonOptions;
 
+        /// <summary>
+        /// Registers every converter this package ships, in the order the shipped options have
+        /// always registered them.
+        /// </summary>
+        /// <remarks>
+        /// One list, not one per configuration. The normal, pretty and fast builders each carried a
+        /// verbatim copy of the same forty-six entries, so a forty-seventh converter added to one and
+        /// missed on another would silently change what a value round-trips through based only on
+        /// which options the caller reached for -- and nothing compared the three.
+        ///
+        /// Order is part of the contract: System.Text.Json consults converters in registration order
+        /// and takes the first that claims the type.
+        /// </remarks>
+        /// <param name="options">Options to register into.</param>
+        /// <param name="stringEnums">
+        /// Whether to register <see cref="JsonStringEnumConverter"/>, which writes an enum as its
+        /// name. The fast configuration leaves it off and writes the underlying number.
+        /// </param>
+        private static void AddPackageConverters(JsonSerializerOptions options, bool stringEnums)
+        {
+            IList<JsonConverter> converters = options.Converters;
+            converters.Add(WGuidConverter.Instance);
+            converters.Add(RangeConverterFactory.Instance);
+            converters.Add(FastVector2IntConverter.Instance);
+            converters.Add(FastVector3IntConverter.Instance);
+            if (stringEnums)
+            {
+                converters.Add(new JsonStringEnumConverter());
+            }
+
+            converters.Add(Vector3Converter.Instance);
+            converters.Add(Vector2Converter.Instance);
+            converters.Add(Vector4Converter.Instance);
+            converters.Add(Vector2IntConverter.Instance);
+            converters.Add(Vector3IntConverter.Instance);
+            converters.Add(Matrix4x4Converter.Instance);
+            converters.Add(QuaternionConverter.Instance);
+            converters.Add(LayerMaskConverter.Instance);
+            converters.Add(ResolutionConverter.Instance);
+            converters.Add(RenderTextureDescriptorConverter.Instance);
+            converters.Add(MinMaxCurveConverter.Instance);
+            converters.Add(MinMaxGradientConverter.Instance);
+            // Honours the guard the converter file already carried. Before this list was shared, three
+            // copies of it named ColorBlockConverter unguarded, so defining UNITY_DISABLE_UI compiled
+            // the converter out and then broke the runtime assembly on the references to it -- a guard
+            // that could not be used was indistinguishable from protection that existed.
+#if !UNITY_DISABLE_UI
+            converters.Add(ColorBlockConverter.Instance);
+#endif
+            converters.Add(BoundingSphereConverter.Instance);
+            converters.Add(RaycastHitConverter.Instance);
+            converters.Add(TouchConverter.Instance);
+            converters.Add(SceneConverter.Instance);
+            converters.Add(PoseConverter.Instance);
+            converters.Add(PlaneConverter.Instance);
+            converters.Add(RayConverter.Instance);
+            converters.Add(Ray2DConverter.Instance);
+            converters.Add(RectOffsetConverter.Instance);
+            converters.Add(RangeIntConverter.Instance);
+            converters.Add(Hash128Converter.Instance);
+            converters.Add(AnimationCurveConverter.Instance);
+            converters.Add(GradientConverter.Instance);
+            converters.Add(SphericalHarmonicsL2Converter.Instance);
+            converters.Add(TypeConverter.Instance);
+            converters.Add(GameObjectConverter.Instance);
+            converters.Add(ColorConverter.Instance);
+            converters.Add(Color32Converter.Instance);
+            converters.Add(RectConverter.Instance);
+            converters.Add(RectIntConverter.Instance);
+            converters.Add(BoundsConverter.Instance);
+            converters.Add(BoundsIntConverter.Instance);
+            converters.Add(BitSetConverter.Instance);
+            converters.Add(ImmutableBitSetConverter.Instance);
+            converters.Add(DequeConverterFactory.Instance);
+            converters.Add(CyclicBufferConverterFactory.Instance);
+            converters.Add(SerializableSetConverterFactory.Instance);
+            converters.Add(SerializableDictionaryConverterFactory.Instance);
+            converters.Add(SerializableSortedDictionaryConverterFactory.Instance);
+        }
+
         public static JsonSerializerOptions GetNormalJsonOptions()
         {
-            return new JsonSerializerOptions
+            JsonSerializerOptions options = new()
             {
                 IgnoreReadOnlyFields = false,
                 IgnoreReadOnlyProperties = false,
@@ -54,62 +134,14 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                     | JsonNumberHandling.AllowReadingFromString,
                 ReadCommentHandling = JsonCommentHandling.Skip,
                 AllowTrailingCommas = true,
-                Converters =
-                {
-                    WGuidConverter.Instance,
-                    RangeConverterFactory.Instance,
-                    FastVector2IntConverter.Instance,
-                    FastVector3IntConverter.Instance,
-                    new JsonStringEnumConverter(),
-                    Vector3Converter.Instance,
-                    Vector2Converter.Instance,
-                    Vector4Converter.Instance,
-                    Vector2IntConverter.Instance,
-                    Vector3IntConverter.Instance,
-                    Matrix4x4Converter.Instance,
-                    QuaternionConverter.Instance,
-                    LayerMaskConverter.Instance,
-                    ResolutionConverter.Instance,
-                    RenderTextureDescriptorConverter.Instance,
-                    MinMaxCurveConverter.Instance,
-                    MinMaxGradientConverter.Instance,
-                    ColorBlockConverter.Instance,
-                    BoundingSphereConverter.Instance,
-                    RaycastHitConverter.Instance,
-                    TouchConverter.Instance,
-                    SceneConverter.Instance,
-                    PoseConverter.Instance,
-                    PlaneConverter.Instance,
-                    RayConverter.Instance,
-                    Ray2DConverter.Instance,
-                    RectOffsetConverter.Instance,
-                    RangeIntConverter.Instance,
-                    Hash128Converter.Instance,
-                    AnimationCurveConverter.Instance,
-                    GradientConverter.Instance,
-                    SphericalHarmonicsL2Converter.Instance,
-                    TypeConverter.Instance,
-                    GameObjectConverter.Instance,
-                    ColorConverter.Instance,
-                    Color32Converter.Instance,
-                    RectConverter.Instance,
-                    RectIntConverter.Instance,
-                    BoundsConverter.Instance,
-                    BoundsIntConverter.Instance,
-                    BitSetConverter.Instance,
-                    ImmutableBitSetConverter.Instance,
-                    DequeConverterFactory.Instance,
-                    CyclicBufferConverterFactory.Instance,
-                    SerializableSetConverterFactory.Instance,
-                    SerializableDictionaryConverterFactory.Instance,
-                    SerializableSortedDictionaryConverterFactory.Instance,
-                },
             };
+            AddPackageConverters(options, stringEnums: true);
+            return options;
         }
 
         public static JsonSerializerOptions GetPrettyJsonOptions()
         {
-            return new JsonSerializerOptions
+            JsonSerializerOptions options = new()
             {
                 IgnoreReadOnlyFields = false,
                 IgnoreReadOnlyProperties = false,
@@ -121,63 +153,15 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                     | JsonNumberHandling.AllowReadingFromString,
                 ReadCommentHandling = JsonCommentHandling.Skip,
                 AllowTrailingCommas = true,
-                Converters =
-                {
-                    WGuidConverter.Instance,
-                    RangeConverterFactory.Instance,
-                    FastVector2IntConverter.Instance,
-                    FastVector3IntConverter.Instance,
-                    new JsonStringEnumConverter(),
-                    Vector3Converter.Instance,
-                    Vector2Converter.Instance,
-                    Vector4Converter.Instance,
-                    Vector2IntConverter.Instance,
-                    Vector3IntConverter.Instance,
-                    Matrix4x4Converter.Instance,
-                    QuaternionConverter.Instance,
-                    LayerMaskConverter.Instance,
-                    ResolutionConverter.Instance,
-                    RenderTextureDescriptorConverter.Instance,
-                    MinMaxCurveConverter.Instance,
-                    MinMaxGradientConverter.Instance,
-                    ColorBlockConverter.Instance,
-                    BoundingSphereConverter.Instance,
-                    RaycastHitConverter.Instance,
-                    TouchConverter.Instance,
-                    SceneConverter.Instance,
-                    PoseConverter.Instance,
-                    PlaneConverter.Instance,
-                    RayConverter.Instance,
-                    Ray2DConverter.Instance,
-                    RectOffsetConverter.Instance,
-                    RangeIntConverter.Instance,
-                    Hash128Converter.Instance,
-                    AnimationCurveConverter.Instance,
-                    GradientConverter.Instance,
-                    SphericalHarmonicsL2Converter.Instance,
-                    TypeConverter.Instance,
-                    GameObjectConverter.Instance,
-                    ColorConverter.Instance,
-                    Color32Converter.Instance,
-                    RectConverter.Instance,
-                    RectIntConverter.Instance,
-                    BoundsConverter.Instance,
-                    BoundsIntConverter.Instance,
-                    BitSetConverter.Instance,
-                    ImmutableBitSetConverter.Instance,
-                    DequeConverterFactory.Instance,
-                    CyclicBufferConverterFactory.Instance,
-                    SerializableSetConverterFactory.Instance,
-                    SerializableDictionaryConverterFactory.Instance,
-                    SerializableSortedDictionaryConverterFactory.Instance,
-                },
                 WriteIndented = true,
             };
+            AddPackageConverters(options, stringEnums: true);
+            return options;
         }
 
         public static JsonSerializerOptions GetFastJsonOptions()
         {
-            return new JsonSerializerOptions
+            JsonSerializerOptions options = new()
             {
                 IgnoreReadOnlyFields = false,
                 IgnoreReadOnlyProperties = true,
@@ -187,56 +171,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                 NumberHandling = JsonNumberHandling.Strict,
                 ReadCommentHandling = JsonCommentHandling.Disallow,
                 AllowTrailingCommas = false,
-                Converters =
-                {
-                    WGuidConverter.Instance,
-                    RangeConverterFactory.Instance,
-                    FastVector2IntConverter.Instance,
-                    FastVector3IntConverter.Instance,
-                    Vector3Converter.Instance,
-                    Vector2Converter.Instance,
-                    Vector4Converter.Instance,
-                    Vector2IntConverter.Instance,
-                    Vector3IntConverter.Instance,
-                    Matrix4x4Converter.Instance,
-                    QuaternionConverter.Instance,
-                    LayerMaskConverter.Instance,
-                    ResolutionConverter.Instance,
-                    RenderTextureDescriptorConverter.Instance,
-                    MinMaxCurveConverter.Instance,
-                    MinMaxGradientConverter.Instance,
-                    ColorBlockConverter.Instance,
-                    BoundingSphereConverter.Instance,
-                    RaycastHitConverter.Instance,
-                    TouchConverter.Instance,
-                    SceneConverter.Instance,
-                    PoseConverter.Instance,
-                    PlaneConverter.Instance,
-                    RayConverter.Instance,
-                    Ray2DConverter.Instance,
-                    RectOffsetConverter.Instance,
-                    RangeIntConverter.Instance,
-                    Hash128Converter.Instance,
-                    AnimationCurveConverter.Instance,
-                    GradientConverter.Instance,
-                    SphericalHarmonicsL2Converter.Instance,
-                    TypeConverter.Instance,
-                    GameObjectConverter.Instance,
-                    ColorConverter.Instance,
-                    Color32Converter.Instance,
-                    RectConverter.Instance,
-                    RectIntConverter.Instance,
-                    BoundsConverter.Instance,
-                    BoundsIntConverter.Instance,
-                    BitSetConverter.Instance,
-                    ImmutableBitSetConverter.Instance,
-                    DequeConverterFactory.Instance,
-                    CyclicBufferConverterFactory.Instance,
-                    SerializableSetConverterFactory.Instance,
-                    SerializableDictionaryConverterFactory.Instance,
-                    SerializableSortedDictionaryConverterFactory.Instance,
-                },
             };
+            AddPackageConverters(options, stringEnums: false);
+            return options;
         }
 
         public static JsonSerializerOptions GetFastPocoJsonOptions()

--- a/Runtime/Utils/RuntimeSingleton.cs
+++ b/Runtime/Utils/RuntimeSingleton.cs
@@ -64,7 +64,11 @@ namespace WallstopStudios.UnityHelpers.Utils
 
         private static readonly SingletonCreationPolicy _creationPolicy = ResolveCreationPolicy();
 
+        private static bool _creationRefused;
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
         private static bool _creationRefusedWarningLogged;
+#endif
 
         static RuntimeSingleton()
         {
@@ -132,6 +136,23 @@ namespace WallstopStudios.UnityHelpers.Utils
 
                 UnityMainThreadGuard.EnsureMainThread();
 
+                // A refusal is remembered, because a scene-wide search that already came back empty
+                // cannot start returning something without Awake running -- and Awake assigns
+                // _instance, which is answered above. Without this a NeverCreate singleton with
+                // nothing in the scene pays a full FindAnyObjectByType on EVERY access, forever,
+                // which is exactly what the documented `if (X.Instance != null)` guard does per
+                // frame. CreateOnDemand never had the problem: it creates one and caches it.
+                //
+                // Play mode only, and that is not caution -- the invariant is Awake, and Unity does
+                // not run Awake outside play mode. Measured: AddComponent in the editor produces a
+                // live, active instance with _instance still null, so remembering a refusal there
+                // would hide a singleton that is genuinely in the scene from editor tooling.
+                bool canRememberRefusal = Application.isPlaying;
+                if (canRememberRefusal && _creationRefused)
+                {
+                    return null;
+                }
+
                 _instance = FindAnyObjectByType<T>(FindObjectsInactive.Exclude);
                 if (_instance != null)
                 {
@@ -141,6 +162,7 @@ namespace WallstopStudios.UnityHelpers.Utils
                 Type type = typeof(T);
                 if (_creationPolicy == SingletonCreationPolicy.NeverCreate)
                 {
+                    _creationRefused = canRememberRefusal;
                     WarnCreationRefused(type);
                     return null;
                 }
@@ -164,6 +186,12 @@ namespace WallstopStudios.UnityHelpers.Utils
         /// instance on the next <see cref="Instance"/> access. Automatic clearing on domain reload is
         /// handled by <see cref="RuntimeSingletonRegistry"/> because Unity disallows
         /// <c>[RuntimeInitializeOnLoadMethod]</c> on methods in generic classes.
+        ///
+        /// <b>There is no fresh instance for a <see cref="SingletonCreationPolicy.NeverCreate"/>
+        /// singleton.</b> This destroys every live instance, including one authored in a scene, and
+        /// such a type will not build a replacement -- <see cref="Instance"/> returns <c>null</c>
+        /// until something else creates one. Clearing those is for tests and for editor tooling that
+        /// is about to reload the scene, not for ordinary runtime resets.
         /// </remarks>
         public static void ClearInstance()
         {
@@ -195,10 +223,13 @@ namespace WallstopStudios.UnityHelpers.Utils
 
             Interlocked.Exchange(ref _initializeCount, 0);
             _instance = null;
-            // The refusal is deduplicated so a per-frame Instance access cannot flood the console, and
-            // an explicit clear is exactly the moment that dedupe should end: the next refusal is about
-            // a fresh situation, and a test that expects the warning twice would otherwise never see it.
+            // An explicit clear is exactly the moment the remembered refusal should end: the next
+            // access is a fresh question, and a test that expects the warning twice would otherwise
+            // never see it a second time.
+            _creationRefused = false;
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
             _creationRefusedWarningLogged = false;
+#endif
         }
 
         private static void WarnCreationRefused(Type type)
@@ -215,7 +246,6 @@ namespace WallstopStudios.UnityHelpers.Utils
                     + $"{nameof(SingletonCreationPolicy)}.{nameof(SingletonCreationPolicy.NeverCreate)} forbids creating one. Returning null."
             );
 #else
-            _creationRefusedWarningLogged = true;
             _ = type;
 #endif
         }

--- a/Runtime/Utils/RuntimeSingleton.cs
+++ b/Runtime/Utils/RuntimeSingleton.cs
@@ -64,7 +64,8 @@ namespace WallstopStudios.UnityHelpers.Utils
 
         private static readonly SingletonCreationPolicy _creationPolicy = ResolveCreationPolicy();
 
-        private static bool _creationRefused;
+        // -1 rather than 0, because frame 0 is a real frame.
+        private static int _creationRefusedFrame = -1;
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
         private static bool _creationRefusedWarningLogged;
@@ -136,19 +137,21 @@ namespace WallstopStudios.UnityHelpers.Utils
 
                 UnityMainThreadGuard.EnsureMainThread();
 
-                // A refusal is remembered, because a scene-wide search that already came back empty
-                // cannot start returning something without Awake running -- and Awake assigns
-                // _instance, which is answered above. Without this a NeverCreate singleton with
-                // nothing in the scene pays a full FindAnyObjectByType on EVERY access, forever,
-                // which is exactly what the documented `if (X.Instance != null)` guard does per
-                // frame. CreateOnDemand never had the problem: it creates one and caches it.
+                // An empty search is remembered for the rest of the FRAME, and only that. Without it
+                // a NeverCreate singleton with nothing in the scene pays a full FindAnyObjectByType
+                // on every access, forever -- which is exactly what the `if (X.Instance != null)`
+                // guard this type's documentation recommends does, once per call site per frame.
+                // CreateOnDemand never had the problem: it creates one and caches it.
                 //
-                // Play mode only, and that is not caution -- the invariant is Awake, and Unity does
-                // not run Awake outside play mode. Measured: AddComponent in the editor produces a
-                // live, active instance with _instance still null, so remembering a refusal there
-                // would hide a singleton that is genuinely in the scene from editor tooling.
-                bool canRememberRefusal = Application.isPlaying;
-                if (canRememberRefusal && _creationRefused)
+                // A frame is the bound rather than "until something calls ClearInstance" because
+                // every stronger claim is wrong somewhere. "Nothing can appear without Awake
+                // assigning the cache" is false in the editor, where Unity does not run Awake at all
+                // (measured: AddComponent produced a live instance a sticky refusal then hid), and
+                // false for a subclass whose Awake override forgets base.Awake(). Scoping to the
+                // frame removes the invariant instead of weakening it: the worst case is one search
+                // per frame, which is what a single guarded call site already cost.
+                int frame = Time.frameCount;
+                if (_creationRefusedFrame == frame)
                 {
                     return null;
                 }
@@ -162,7 +165,7 @@ namespace WallstopStudios.UnityHelpers.Utils
                 Type type = typeof(T);
                 if (_creationPolicy == SingletonCreationPolicy.NeverCreate)
                 {
-                    _creationRefused = canRememberRefusal;
+                    _creationRefusedFrame = frame;
                     WarnCreationRefused(type);
                     return null;
                 }
@@ -223,10 +226,10 @@ namespace WallstopStudios.UnityHelpers.Utils
 
             Interlocked.Exchange(ref _initializeCount, 0);
             _instance = null;
-            // An explicit clear is exactly the moment the remembered refusal should end: the next
+            // An explicit clear is exactly the moment a remembered refusal should end: the next
             // access is a fresh question, and a test that expects the warning twice would otherwise
             // never see it a second time.
-            _creationRefused = false;
+            _creationRefusedFrame = -1;
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
             _creationRefusedWarningLogged = false;
 #endif

--- a/Runtime/Utils/RuntimeSingleton.cs
+++ b/Runtime/Utils/RuntimeSingleton.cs
@@ -23,6 +23,10 @@ namespace WallstopStudios.UnityHelpers.Utils
     /// <remarks>
     /// Access the global instance via <see cref="Instance"/>; if no active instance exists,
     /// a new <see cref="GameObject"/> named "&lt;Type&gt;-Singleton" is created and the component is added.
+    /// Annotate the type with
+    /// <see cref="WallstopStudios.UnityHelpers.Core.Attributes.SingletonCreationAttribute"/> and
+    /// <see cref="SingletonCreationPolicy.NeverCreate"/> to keep that from happening, which is what a
+    /// singleton holding authored <c>[SerializeField]</c> state wants.
     ///
     /// Lifecycle:
     /// - On first access, searches for an active instance; otherwise creates one.
@@ -47,9 +51,20 @@ namespace WallstopStudios.UnityHelpers.Utils
 
         public static long InitializeCount => Interlocked.Read(ref _initializeCount);
 
+        /// <summary>
+        /// Gets what <see cref="Instance"/> does when no instance exists, taken from the
+        /// <see cref="SingletonCreationAttribute"/> on <typeparamref name="T"/> and
+        /// <see cref="SingletonCreationPolicy.CreateOnDemand"/> when there is none.
+        /// </summary>
+        public static SingletonCreationPolicy CreationPolicy => _creationPolicy;
+
         protected static long _initializeCount;
 
         protected internal static T _instance;
+
+        private static readonly SingletonCreationPolicy _creationPolicy = ResolveCreationPolicy();
+
+        private static bool _creationRefusedWarningLogged;
 
         static RuntimeSingleton()
         {
@@ -59,6 +74,26 @@ namespace WallstopStudios.UnityHelpers.Utils
                 () => _instance,
                 () => Resources.FindObjectsOfTypeAll<T>()
             );
+        }
+
+        private static SingletonCreationPolicy ResolveCreationPolicy()
+        {
+            if (
+                !ReflectionHelpers.TryGetAttributeSafe(
+                    typeof(T),
+                    out SingletonCreationAttribute attribute,
+                    inherit: true
+                )
+            )
+            {
+                return SingletonCreationPolicy.CreateOnDemand;
+            }
+
+            // An unrecognized value is treated as the default rather than as a refusal: a policy this
+            // build does not know about must not silently stop a singleton from existing.
+            return attribute.Policy == SingletonCreationPolicy.NeverCreate
+                ? SingletonCreationPolicy.NeverCreate
+                : SingletonCreationPolicy.CreateOnDemand;
         }
 
         /// <summary>
@@ -71,7 +106,8 @@ namespace WallstopStudios.UnityHelpers.Utils
         protected virtual bool LogErrorOnDestruction => true;
 
         /// <summary>
-        /// Gets the global instance, creating one if needed.
+        /// Gets the global instance, creating one if needed. Returns <c>null</c> when none exists and
+        /// <see cref="CreationPolicy"/> is <see cref="SingletonCreationPolicy.NeverCreate"/>.
         /// </summary>
         /// <example>
         /// <code>
@@ -103,6 +139,12 @@ namespace WallstopStudios.UnityHelpers.Utils
                 }
 
                 Type type = typeof(T);
+                if (_creationPolicy == SingletonCreationPolicy.NeverCreate)
+                {
+                    WarnCreationRefused(type);
+                    return null;
+                }
+
                 GameObject instance = new($"{type.Name}-Singleton", type);
                 if (_instance == null)
                 {
@@ -153,6 +195,29 @@ namespace WallstopStudios.UnityHelpers.Utils
 
             Interlocked.Exchange(ref _initializeCount, 0);
             _instance = null;
+            // The refusal is deduplicated so a per-frame Instance access cannot flood the console, and
+            // an explicit clear is exactly the moment that dedupe should end: the next refusal is about
+            // a fresh situation, and a test that expects the warning twice would otherwise never see it.
+            _creationRefusedWarningLogged = false;
+        }
+
+        private static void WarnCreationRefused(Type type)
+        {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            if (_creationRefusedWarningLogged)
+            {
+                return;
+            }
+
+            _creationRefusedWarningLogged = true;
+            Debug.LogWarning(
+                $"RuntimeSingleton could not locate an active instance of {type.FullName}, and "
+                    + $"{nameof(SingletonCreationPolicy)}.{nameof(SingletonCreationPolicy.NeverCreate)} forbids creating one. Returning null."
+            );
+#else
+            _creationRefusedWarningLogged = true;
+            _ = type;
+#endif
         }
 
         protected virtual void Awake()

--- a/Tests/Editor/Tags/SingletonCreationDiagnosticsTests.cs
+++ b/Tests/Editor/Tags/SingletonCreationDiagnosticsTests.cs
@@ -1,0 +1,132 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+#if UNITY_EDITOR
+    using System;
+    using NUnit.Framework;
+    using UnityEngine;
+    using WallstopStudios.UnityHelpers.Core.Attributes;
+    using WallstopStudios.UnityHelpers.Core.Helper;
+    using WallstopStudios.UnityHelpers.Editor.Tags;
+    using WallstopStudios.UnityHelpers.Tags;
+    using WallstopStudios.UnityHelpers.Tests.Core.TestTypes;
+    using WallstopStudios.UnityHelpers.Utils;
+
+    /// <summary>
+    /// Drives every branch of the editor's <see cref="SingletonCreationAttribute"/> diagnostic.
+    /// </summary>
+    /// <remarks>
+    /// The attributes are constructed here rather than applied to purpose-built wrong types, because
+    /// <c>TypeCache</c> would find those on every editor load and the diagnostic under test would
+    /// then report this fixture's own fixtures forever. Real types supply the only thing the rule
+    /// reads off a <see cref="Type"/> -- whether it derives from <see cref="RuntimeSingleton{T}"/>.
+    /// </remarks>
+    [TestFixture]
+    [NUnit.Framework.Category("Fast")]
+    public sealed class SingletonCreationDiagnosticsTests
+    {
+        [Test]
+        public void ASoundAnnotationOnARuntimeSingletonIsQuiet()
+        {
+            Assert.IsTrue(
+                AttributeMetadataCacheGenerator.DescribeSingletonCreationProblem(
+                    typeof(RuntimeMismatchSingleton),
+                    new SingletonCreationAttribute(SingletonCreationPolicy.NeverCreate),
+                    null
+                ) == null
+            );
+        }
+
+        [Test]
+        public void AnUnannotatedTypeIsQuiet()
+        {
+            Assert.IsTrue(
+                AttributeMetadataCacheGenerator.DescribeSingletonCreationProblem(
+                    typeof(RuntimeMismatchSingleton),
+                    null,
+                    new AutoLoadSingletonAttribute(RuntimeInitializeLoadType.BeforeSplashScreen)
+                ) == null
+            );
+        }
+
+        /// <summary>
+        /// The realistic version of the mistake is the attribute on a <c>ScriptableObjectSingleton</c>,
+        /// which never creates an asset at runtime and so has nothing for the policy to govern.
+        /// </summary>
+        [Test]
+        [TestCase(typeof(AttributeMetadataCache))]
+        [TestCase(typeof(SingletonCreationDiagnosticsTests))]
+        public void TheAttributeOnSomethingThatIsNotARuntimeSingletonIsReportedAsInert(Type type)
+        {
+            string problem = AttributeMetadataCacheGenerator.DescribeSingletonCreationProblem(
+                type,
+                new SingletonCreationAttribute(SingletonCreationPolicy.NeverCreate),
+                null
+            );
+
+            Assert.IsTrue(problem != null);
+            StringAssert.Contains(type.FullName, problem);
+            StringAssert.Contains("has no effect", problem);
+        }
+
+        /// <summary>
+        /// Auto-loading a singleton that refuses to be created can only find nothing at any phase
+        /// that runs before a scene exists.
+        /// </summary>
+        [Test]
+        [TestCase(RuntimeInitializeLoadType.SubsystemRegistration)]
+        [TestCase(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+        [TestCase(RuntimeInitializeLoadType.BeforeSplashScreen)]
+        [TestCase(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        public void NeverCreatePairedWithAPreSceneAutoLoadIsReported(
+            RuntimeInitializeLoadType phase
+        )
+        {
+            string problem = AttributeMetadataCacheGenerator.DescribeSingletonCreationProblem(
+                typeof(RuntimeMismatchSingleton),
+                new SingletonCreationAttribute(SingletonCreationPolicy.NeverCreate),
+                new AutoLoadSingletonAttribute(phase)
+            );
+
+            Assert.IsTrue(problem != null);
+            StringAssert.Contains(phase.ToString(), problem);
+            StringAssert.Contains(nameof(SingletonCreationPolicy.NeverCreate), problem);
+        }
+
+        /// <summary>
+        /// The control the refusals need: <c>AfterSceneLoad</c> runs once an authored instance
+        /// exists, so the pair binds the static cache to it and is a choice rather than a mistake.
+        /// </summary>
+        [Test]
+        public void NeverCreatePairedWithAnAfterSceneLoadAutoLoadIsQuiet()
+        {
+            Assert.IsTrue(
+                AttributeMetadataCacheGenerator.DescribeSingletonCreationProblem(
+                    typeof(RuntimeMismatchSingleton),
+                    new SingletonCreationAttribute(SingletonCreationPolicy.NeverCreate),
+                    new AutoLoadSingletonAttribute(RuntimeInitializeLoadType.AfterSceneLoad)
+                ) == null
+            );
+        }
+
+        /// <summary>
+        /// A creating singleton is what auto-load is for, at every phase.
+        /// </summary>
+        [Test]
+        [TestCase(RuntimeInitializeLoadType.BeforeSplashScreen)]
+        [TestCase(RuntimeInitializeLoadType.AfterSceneLoad)]
+        public void CreateOnDemandPairedWithAnyAutoLoadIsQuiet(RuntimeInitializeLoadType phase)
+        {
+            Assert.IsTrue(
+                AttributeMetadataCacheGenerator.DescribeSingletonCreationProblem(
+                    typeof(RuntimeMismatchSingleton),
+                    new SingletonCreationAttribute(SingletonCreationPolicy.CreateOnDemand),
+                    new AutoLoadSingletonAttribute(phase)
+                ) == null
+            );
+        }
+    }
+#endif
+}

--- a/Tests/Editor/Tags/SingletonCreationDiagnosticsTests.cs.meta
+++ b/Tests/Editor/Tags/SingletonCreationDiagnosticsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a214eb4f40bde8ca0fbc37f7383c539
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/Serialization/JsonConverterCoverageTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterCoverageTests.cs
@@ -38,6 +38,18 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
     public sealed class JsonConverterCoverageTests
     {
         /// <summary>
+        /// How many converters the normal configuration registers, pinned against history so a
+        /// reorder or a silent addition to the one shared list is visible.
+        /// </summary>
+        private const int ShippedConverterCount = 47;
+
+        /// <summary>
+        /// Where <see cref="JsonStringEnumConverter"/> sits in that list. Registration order is
+        /// precedence, and this is the only entry claiming a category rather than a concrete type.
+        /// </summary>
+        private const int StringEnumConverterIndex = 4;
+
+        /// <summary>
         /// Registered converters this package does not own and does not fuzz, each with the reason.
         /// </summary>
         private static readonly IReadOnlyDictionary<Type, string> NotCovered = new Dictionary<
@@ -276,6 +288,22 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                 fast,
                 typeof(JsonStringEnumConverter),
                 "The fast configuration writes an enum as its underlying number; adding the string converter changes the wire format."
+            );
+
+            // Comparing the three lists to each other cannot see a change that reorders the shared
+            // list, because it reorders all three identically -- and that is the one risk collapsing
+            // three copies into one introduces. The count and the enum converter's position are
+            // pinned against history instead: order decides precedence, and JsonStringEnumConverter
+            // is the only registration that claims a whole category of types rather than one.
+            Assert.AreEqual(
+                ShippedConverterCount,
+                normal.Count,
+                "A converter was added or removed. If that is intended, update ShippedConverterCount and add a fuzz target."
+            );
+            Assert.AreEqual(
+                StringEnumConverterIndex,
+                normal.IndexOf(typeof(JsonStringEnumConverter)),
+                "JsonStringEnumConverter must stay at the index it has always occupied; moving it changes which converter claims an enum-shaped type first."
             );
         }
 

--- a/Tests/Runtime/Serialization/JsonConverterCoverageTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterCoverageTests.cs
@@ -95,6 +95,67 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         }
 
         /// <summary>
+        /// The second registration channel: a type carrying <see cref="JsonConverterAttribute"/> is
+        /// served by that converter wherever it appears, with or without the package's options.
+        /// </summary>
+        /// <remarks>
+        /// Enumerating <c>JsonSerializerOptions.Converters</c> alone misses these entirely -- three
+        /// of this package's own adapters are registered this way and nothing else in the shipped
+        /// options names them, so a converter added here is invisible to every check above.
+        /// </remarks>
+        [Test]
+        public void EveryTypeLevelConverterIsCoveredByAFuzzTarget()
+        {
+            List<Type> runtimeTypes = new();
+            try
+            {
+                runtimeTypes.AddRange(typeof(Serializer).Assembly.GetTypes());
+            }
+            catch (System.Reflection.ReflectionTypeLoadException loadFailure)
+            {
+                foreach (Type loaded in loadFailure.Types)
+                {
+                    if (loaded != null)
+                    {
+                        runtimeTypes.Add(loaded);
+                    }
+                }
+            }
+
+            List<string> failures = new();
+            foreach (Type type in runtimeTypes)
+            {
+                if (type == null || !type.IsDefined(typeof(JsonConverterAttribute), inherit: false))
+                {
+                    continue;
+                }
+
+                bool covered = false;
+                foreach (JsonConverterFuzzTests.FuzzTarget target in JsonConverterFuzzTests.Targets)
+                {
+                    Type candidate = target.Type.IsGenericType
+                        ? target.Type.GetGenericTypeDefinition()
+                        : target.Type;
+                    if (candidate == type)
+                    {
+                        covered = true;
+                        break;
+                    }
+                }
+
+                if (!covered)
+                {
+                    failures.Add(
+                        $"{type.Name} carries [{nameof(JsonConverterAttribute)}], so its converter serves it everywhere, but "
+                            + $"{nameof(JsonConverterFuzzTests)} has no target for it. A converter reached this way is never fuzzed and never round-trip checked."
+                    );
+                }
+            }
+
+            Assert.That(failures, Is.Empty, Join(failures));
+        }
+
+        /// <summary>
         /// The reverse: a declared exception must still name something that ships. A list naming a
         /// converter nobody registers is a claim about a file that no longer exists.
         /// </summary>

--- a/Tests/Runtime/Serialization/JsonConverterCoverageTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterCoverageTests.cs
@@ -1,0 +1,246 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+    using NUnit.Framework;
+    using WallstopStudios.UnityHelpers.Core.Serialization;
+    using WallstopStudios.UnityHelpers.Tests.Core;
+
+    /// <summary>
+    /// Holds the shipped JSON converter registrations and the fuzz suite that covers them to each
+    /// other, so a converter cannot be added to one and missed by the other (#459).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every converter is a save-file entry point, and the cost of missing one is a save that cannot
+    /// be loaded rather than a wrong pixel. <c>GameObjectConverter</c> and <c>TouchConverter</c> were
+    /// each added with a <c>Read</c> that throws, and nothing outside their own source said so; the
+    /// fuzz suite could not have noticed, because a target is only fuzzed once someone adds it to a
+    /// list by hand.
+    /// </para>
+    /// <para>
+    /// This is the <c>ContractMirrorTests</c> shape applied to JSON: enumerate what ships, compare it
+    /// to what is covered, and require anything left over to be declared with a reason. The
+    /// enumeration asks each converter what it claims through <see cref="JsonConverter.CanConvert"/>
+    /// rather than reading its generic argument, because six of the registrations are factories whose
+    /// converted type is decided per closure.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    [NUnit.Framework.Category("Fast")]
+    [SkipUnderIL2CPP]
+    public sealed class JsonConverterCoverageTests
+    {
+        /// <summary>
+        /// Registered converters this package does not own and does not fuzz, each with the reason.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<Type, string> NotCovered = new Dictionary<
+            Type,
+            string
+        >
+        {
+            [typeof(JsonStringEnumConverter)] =
+                "System.Text.Json's own enum converter; it writes a name for any enum, so no fixed type covers it and its behaviour is not this package's contract",
+        };
+
+        /// <summary>
+        /// Every converter in the shipped options must be reachable from the fuzz corpus, declared
+        /// write-only, or declared as not ours.
+        /// </summary>
+        [Test]
+        public void EveryRegisteredConverterIsCoveredDeclaredOrExplicitlyNotOurs()
+        {
+            List<Type> covered = new();
+            foreach (JsonConverterFuzzTests.FuzzTarget target in JsonConverterFuzzTests.Targets)
+            {
+                covered.Add(target.Type);
+            }
+
+            foreach (Type writeOnly in JsonConverterFuzzTests.WriteOnlyConverters.Keys)
+            {
+                covered.Add(writeOnly);
+            }
+
+            List<string> failures = new();
+            foreach (JsonConverter converter in Serializer.CreateNormalJsonOptions().Converters)
+            {
+                if (converter == null || NotCovered.ContainsKey(converter.GetType()))
+                {
+                    continue;
+                }
+
+                bool claimsSomething = false;
+                for (int i = 0; i < covered.Count && !claimsSomething; ++i)
+                {
+                    claimsSomething = converter.CanConvert(covered[i]);
+                }
+
+                if (!claimsSomething)
+                {
+                    failures.Add(
+                        $"{converter.GetType().Name} is registered in the shipped JSON options and claims no type that "
+                            + $"{nameof(JsonConverterFuzzTests)} covers. Add a seed value to its target list, or declare it "
+                            + $"in {nameof(JsonConverterFuzzTests)}.{nameof(JsonConverterFuzzTests.WriteOnlyConverters)} with the reason it cannot read what it writes."
+                    );
+                }
+            }
+
+            Assert.That(failures, Is.Empty, Join(failures));
+        }
+
+        /// <summary>
+        /// The reverse: a declared exception must still name something that ships. A list naming a
+        /// converter nobody registers is a claim about a file that no longer exists.
+        /// </summary>
+        [Test]
+        public void EveryDeclaredExceptionStillNamesARegisteredConverter()
+        {
+            List<JsonConverter> registered = new();
+            foreach (JsonConverter converter in Serializer.CreateNormalJsonOptions().Converters)
+            {
+                if (converter != null)
+                {
+                    registered.Add(converter);
+                }
+            }
+
+            List<string> failures = new();
+            foreach (
+                KeyValuePair<Type, string> writeOnly in JsonConverterFuzzTests.WriteOnlyConverters
+            )
+            {
+                bool claimed = false;
+                for (int i = 0; i < registered.Count && !claimed; ++i)
+                {
+                    claimed = registered[i].CanConvert(writeOnly.Key);
+                }
+
+                if (!claimed)
+                {
+                    failures.Add(
+                        $"{writeOnly.Key.Name} is declared write-only ({writeOnly.Value}) but no converter in the shipped options claims it."
+                    );
+                }
+            }
+
+            foreach (KeyValuePair<Type, string> notOurs in NotCovered)
+            {
+                bool present = false;
+                for (int i = 0; i < registered.Count && !present; ++i)
+                {
+                    present = registered[i].GetType() == notOurs.Key;
+                }
+
+                if (!present)
+                {
+                    failures.Add(
+                        $"{notOurs.Key.Name} is declared as not ours ({notOurs.Value}) but is not registered."
+                    );
+                }
+            }
+
+            Assert.That(failures, Is.Empty, Join(failures));
+        }
+
+        /// <summary>
+        /// A target's <c>ReadSupported</c> flag and the write-only declaration are two statements of
+        /// the same fact, so they are asserted against each other rather than maintained in parallel.
+        /// </summary>
+        [Test]
+        public void TheWriteOnlyDeclarationAgreesWithTheFuzzTargets()
+        {
+            List<string> failures = new();
+            foreach (JsonConverterFuzzTests.FuzzTarget target in JsonConverterFuzzTests.Targets)
+            {
+                bool declaredWriteOnly = JsonConverterFuzzTests.WriteOnlyConverters.ContainsKey(
+                    target.Type
+                );
+                if (declaredWriteOnly == target.ReadSupported)
+                {
+                    failures.Add(
+                        $"{target.Name}: declared write-only is {declaredWriteOnly} but the fuzz target says ReadSupported is {target.ReadSupported}."
+                    );
+                }
+            }
+
+            Assert.That(failures, Is.Empty, Join(failures));
+        }
+
+        /// <summary>
+        /// The three shipped configurations must register the same converters in the same order, and
+        /// the fast one must differ only by <see cref="JsonStringEnumConverter"/>.
+        /// </summary>
+        /// <remarks>
+        /// They used to be three verbatim copies of one forty-six entry list, so a converter added to
+        /// one and missed on another silently changed what a value round-trips through depending only
+        /// on which options the caller reached for. They are built from one list now; this pins that
+        /// they still are, and states the one deliberate difference -- the fast configuration writes
+        /// an enum as its number rather than its name -- as a contract rather than as an omission
+        /// nobody can tell from a mistake.
+        /// </remarks>
+        [Test]
+        public void EveryShippedConfigurationRegistersTheSameConvertersInTheSameOrder()
+        {
+            List<Type> normal = RegisteredTypes(Serializer.CreateNormalJsonOptions());
+            List<Type> pretty = RegisteredTypes(Serializer.CreatePrettyJsonOptions());
+            List<Type> fast = RegisteredTypes(Serializer.CreateFastJsonOptions());
+
+            CollectionAssert.AreEqual(
+                normal,
+                pretty,
+                "The pretty configuration must register exactly what the normal one does."
+            );
+
+            List<Type> normalWithoutEnums = new();
+            foreach (Type type in normal)
+            {
+                if (type != typeof(JsonStringEnumConverter))
+                {
+                    normalWithoutEnums.Add(type);
+                }
+            }
+
+            CollectionAssert.AreEqual(
+                normalWithoutEnums,
+                fast,
+                "The fast configuration must differ from the normal one by JsonStringEnumConverter and nothing else."
+            );
+            CollectionAssert.DoesNotContain(
+                fast,
+                typeof(JsonStringEnumConverter),
+                "The fast configuration writes an enum as its underlying number; adding the string converter changes the wire format."
+            );
+        }
+
+        private static List<Type> RegisteredTypes(JsonSerializerOptions options)
+        {
+            List<Type> types = new();
+            foreach (JsonConverter converter in options.Converters)
+            {
+                if (converter != null)
+                {
+                    types.Add(converter.GetType());
+                }
+            }
+
+            return types;
+        }
+
+        private static string Join(IReadOnlyList<string> failures)
+        {
+            StringBuilder builder = new();
+            for (int i = 0; i < failures.Count; ++i)
+            {
+                builder.AppendLine(failures[i]);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Tests/Runtime/Serialization/JsonConverterCoverageTests.cs.meta
+++ b/Tests/Runtime/Serialization/JsonConverterCoverageTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b8eebd24a486c650ca0936eaa68eade
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
@@ -859,6 +859,8 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                 new(typeof(Deque<int>), deque),
                 new(typeof(CyclicBuffer<int>), cyclic),
                 new(typeof(SerializableList<int>), new SerializableList<int> { 1, 2, 3 }),
+                new(typeof(SerializableType), new SerializableType(typeof(Vector3))),
+                new(typeof(SerializableNullable<int>), new SerializableNullable<int>(7)),
                 new(typeof(SerializableHashSet<int>), new SerializableHashSet<int> { 1, 2, 3 }),
                 new(
                     typeof(SerializableDictionary<string, int>),

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
@@ -408,6 +408,18 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                 restored != null,
                 $"{target.Name} wrote {Abbreviate(written)} and read it back as null."
             );
+
+            // Re-encoding rather than comparing values, for two reasons. `restored` is a boxed struct
+            // for most of this corpus, so a null check proves nothing there; and several reference
+            // targets (AnimationCurve, Gradient, RectOffset) have reference equality only. The bytes
+            // are the contract anyway -- a converter that reads its own output back as a *different*
+            // value writes different bytes for it, which the null check above cannot see.
+            string rewritten = JsonSerializer.Serialize(restored, target.Type, options);
+            Assert.AreEqual(
+                written,
+                rewritten,
+                $"{target.Name} wrote {Abbreviate(written)}, read it back, and then wrote {Abbreviate(rewritten)} -- the value did not survive."
+            );
         }
 
         /// <summary>
@@ -838,9 +850,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                     typeof(ParticleSystem.MinMaxGradient),
                     new ParticleSystem.MinMaxGradient(Color.green)
                 ),
-#if !UNITY_DISABLE_UI
                 new(typeof(UnityEngine.UI.ColorBlock), UnityEngine.UI.ColorBlock.defaultColorBlock),
-#endif
                 new(typeof(RaycastHit), default(RaycastHit)),
                 FuzzTarget.WriteOnly(typeof(Touch), default(Touch)),
                 new(typeof(Scene), SceneManager.GetActiveScene()),

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
@@ -96,6 +96,31 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         private static IReadOnlyList<FuzzTarget> _targets;
 
         /// <summary>
+        /// The converters that deliberately write a value they cannot rebuild, each with the reason.
+        /// This is the declaration <see cref="JsonConverterCoverageTests"/> checks the registered
+        /// converters against, so a forty-eighth converter cannot be added the way these two were --
+        /// with a <c>Read</c> that throws and nothing anywhere that says so.
+        /// </summary>
+        /// <remarks>
+        /// Adding an entry is the escape hatch and is meant to cost something: a type listed here is
+        /// asserted to refuse every read, so a converter that quietly gains a read path fails this
+        /// list rather than silently outgrowing it.
+        /// </remarks>
+        public static readonly IReadOnlyDictionary<Type, string> WriteOnlyConverters =
+            new Dictionary<Type, string>
+            {
+                [typeof(Touch)] =
+                    "the platform owns every field, so there is nothing to restore a Touch into",
+                [typeof(GameObject)] =
+                    "the record written is a name/type/instance-id for diagnostics; a scene object cannot be rebuilt from it",
+            };
+
+        /// <summary>
+        /// The <see cref="WriteOnlyConverters"/> keys, as a test case source.
+        /// </summary>
+        public static IEnumerable<Type> WriteOnlyTypes => WriteOnlyConverters.Keys;
+
+        /// <summary>
         /// One entry per converter registered in <c>Serializer.CreateNormalJsonOptions</c>. The seed is
         /// a value the converter can write; the corpus is derived from its own output.
         /// </summary>
@@ -333,15 +358,55 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         /// lifecycle management for a converter with no read path to fuzz.
         /// </remarks>
         [Test]
-        [TestCase(typeof(Touch))]
-        [TestCase(typeof(GameObject))]
+        [TestCaseSource(nameof(WriteOnlyTypes))]
         public void AWriteOnlyConverterRefusesToRead(Type type)
         {
             JsonSerializerOptions options = Serializer.CreateNormalJsonOptions();
 
             Assert.Throws<NotSupportedException>(
                 () => JsonSerializer.Deserialize("{}", type, options),
-                $"{type.Name} is write-only and must refuse a read with NotSupportedException"
+                $"{type.Name} is declared write-only ({WriteOnlyConverters[type]}) and must refuse a read with NotSupportedException"
+            );
+        }
+
+        /// <summary>
+        /// A converter that is not declared write-only must read back the value it just wrote.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="AcceptedPayloadsSurviveTheirOwnReEncoding"/> cannot make this assertion: a
+        /// payload it fails to decode is skipped, because most of its corpus is deliberately
+        /// hostile, so a converter whose <b>own seed</b> does not read back is silently passed over
+        /// rather than reported. That is precisely the shape of the <see cref="WGuid"/> defect --
+        /// a value the converter writes and then refuses -- and it is a save file that cannot be
+        /// loaded rather than a rejected attack.
+        /// </remarks>
+        [Test]
+        [TestCaseSource(nameof(Targets))]
+        public void AReadableConverterReadsBackTheValueItWrote(FuzzTarget target)
+        {
+            JsonSerializerOptions options = Serializer.CreateNormalJsonOptions();
+            string written = target.Seeds[0];
+
+            if (!target.ReadSupported)
+            {
+                Assert.Throws<NotSupportedException>(
+                    () => JsonSerializer.Deserialize(written, target.Type, options),
+                    $"{target.Name} is declared write-only and must refuse its own output too"
+                );
+                return;
+            }
+
+            object restored = null;
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    restored = JsonSerializer.Deserialize(written, target.Type, options);
+                },
+                $"{target.Name} wrote {Abbreviate(written)} and refused to read it back."
+            );
+            Assert.IsTrue(
+                restored != null,
+                $"{target.Name} wrote {Abbreviate(written)} and read it back as null."
             );
         }
 
@@ -773,7 +838,9 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                     typeof(ParticleSystem.MinMaxGradient),
                     new ParticleSystem.MinMaxGradient(Color.green)
                 ),
+#if !UNITY_DISABLE_UI
                 new(typeof(UnityEngine.UI.ColorBlock), UnityEngine.UI.ColorBlock.defaultColorBlock),
+#endif
                 new(typeof(RaycastHit), default(RaycastHit)),
                 FuzzTarget.WriteOnly(typeof(Touch), default(Touch)),
                 new(typeof(Scene), SceneManager.GetActiveScene()),

--- a/Tests/Runtime/Serialization/JsonConverterTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterTests.cs
@@ -1232,7 +1232,6 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             Assert.AreEqual(scene.name, deserialized.name);
         }
 
-#if !UNITY_DISABLE_UI
         [Test]
         public void ColorBlockConverterSerializeAndDeserializeSuccess()
         {
@@ -1255,6 +1254,5 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             Assert.AreEqual(original.colorMultiplier, deserialized.colorMultiplier);
             Assert.AreEqual(original.fadeDuration, deserialized.fadeDuration);
         }
-#endif
     }
 }

--- a/Tests/Runtime/Utils/RuntimeSingletonTests.cs
+++ b/Tests/Runtime/Utils/RuntimeSingletonTests.cs
@@ -5,12 +5,15 @@ namespace WallstopStudios.UnityHelpers.Tests.Utils
 {
     using System;
     using System.Collections;
+    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using UnityEngine;
     using UnityEngine.SceneManagement;
     using UnityEngine.TestTools;
+    using WallstopStudios.UnityHelpers.Core.Attributes;
     using WallstopStudios.UnityHelpers.Core.Extension;
+    using WallstopStudios.UnityHelpers.Core.Helper;
     using WallstopStudios.UnityHelpers.Tests.Core;
     using WallstopStudios.UnityHelpers.Utils;
     using Object = UnityEngine.Object;
@@ -33,6 +36,13 @@ namespace WallstopStudios.UnityHelpers.Tests.Utils
             DestroyAll<CustomStartSingleton>();
             DestroyAll<CustomDestroyableSingleton>();
             DestroyAll<ApplicationQuitSingleton>();
+            DestroyAll<NeverCreatedSingleton>();
+            DestroyAll<UnrecognizedPolicySingleton>();
+
+            // ClearInstance is what re-arms the once-per-type refusal warning; without it the second
+            // test in this domain to expect that warning never sees it and its LogAssert.Expect goes
+            // unconsumed, failing whichever fixture runs next.
+            NeverCreatedSingleton.ClearInstance();
 
             // Reset test flags
             CustomDestroyableSingleton.destroyWasCalled = false;
@@ -126,6 +136,30 @@ namespace WallstopStudios.UnityHelpers.Tests.Utils
                 quitWasCalled = true;
             }
         }
+
+        [SingletonCreation(SingletonCreationPolicy.NeverCreate)]
+        private sealed class NeverCreatedSingleton : RuntimeSingleton<NeverCreatedSingleton>
+        {
+            public int authoredValue = 7;
+        }
+
+        // A value this build does not recognize must not be read as a refusal: a singleton silently
+        // ceasing to exist is a worse answer to an unknown policy than creating one.
+        [SingletonCreation((SingletonCreationPolicy)200)]
+        private sealed class UnrecognizedPolicySingleton
+            : RuntimeSingleton<UnrecognizedPolicySingleton> { }
+
+        private static readonly Regex RefusalPattern = new(
+            $".*{nameof(NeverCreatedSingleton)}.*{nameof(SingletonCreationPolicy.NeverCreate)}.*"
+        );
+
+        // The refusal is a development diagnostic, so a release player logs nothing and the count
+        // this fixture expects is zero rather than one.
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        private const int ExpectedRefusalLogCount = 1;
+#else
+        private const int ExpectedRefusalLogCount = 0;
+#endif
 
         // Cleanup handled by CommonTestBase via tracking
 
@@ -942,6 +976,117 @@ namespace WallstopStudios.UnityHelpers.Tests.Utils
 
             Assert.IsFalse(TestRuntimeSingleton.HasInstance);
             Assert.IsTrue(gameObject == null);
+        }
+
+        [Test]
+        public void CreationPolicyDefaultsToCreateOnDemand()
+        {
+            Assert.AreEqual(
+                SingletonCreationPolicy.CreateOnDemand,
+                TestRuntimeSingleton.CreationPolicy
+            );
+        }
+
+        [Test]
+        public void CreationPolicyComesFromTheAttribute()
+        {
+            Assert.AreEqual(
+                SingletonCreationPolicy.NeverCreate,
+                NeverCreatedSingleton.CreationPolicy
+            );
+        }
+
+        [Test]
+        public void AnUnrecognizedCreationPolicyStillCreates()
+        {
+            Assert.AreEqual(
+                SingletonCreationPolicy.CreateOnDemand,
+                UnrecognizedPolicySingleton.CreationPolicy
+            );
+
+            UnrecognizedPolicySingleton instance = UnrecognizedPolicySingleton.Instance;
+            Track(instance.gameObject);
+
+            Assert.IsTrue(instance != null);
+        }
+
+        [Test]
+        public void InstanceReturnsNullWhenCreationIsRefused()
+        {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            LogAssert.Expect(LogType.Warning, RefusalPattern);
+#endif
+            NeverCreatedSingleton instance = NeverCreatedSingleton.Instance;
+
+            Assert.IsTrue(instance == null);
+            Assert.IsFalse(NeverCreatedSingleton.HasInstance);
+            Assert.AreEqual(
+                0,
+                UnityObjectExtensions.FindObjectsOfTypeShim<NeverCreatedSingleton>(true).Length,
+                "A refused creation must leave no GameObject behind."
+            );
+        }
+
+        [Test]
+        public void TheRefusalIsReportedOncePerTypeUntilTheInstanceIsCleared()
+        {
+            int refusals = 0;
+            Application.logMessageReceived += CountRefusal;
+            try
+            {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+                LogAssert.Expect(LogType.Warning, RefusalPattern);
+#endif
+                for (int i = 0; i < 5; ++i)
+                {
+                    Assert.IsTrue(NeverCreatedSingleton.Instance == null);
+                }
+
+                Assert.AreEqual(ExpectedRefusalLogCount, refusals);
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+                LogAssert.Expect(LogType.Warning, RefusalPattern);
+#endif
+                NeverCreatedSingleton.ClearInstance();
+                Assert.IsTrue(NeverCreatedSingleton.Instance == null);
+
+                Assert.AreEqual(ExpectedRefusalLogCount * 2, refusals);
+            }
+            finally
+            {
+                Application.logMessageReceived -= CountRefusal;
+            }
+
+            return;
+
+            void CountRefusal(string condition, string stackTrace, LogType type)
+            {
+                if (type == LogType.Warning && RefusalPattern.IsMatch(condition))
+                {
+                    refusals++;
+                }
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator AnAuthoredInstanceIsServedWhenCreationIsRefused()
+        {
+            GameObject authoredObject = Track(new GameObject("AuthoredNeverCreatedSingleton"));
+            NeverCreatedSingleton authored = authoredObject.AddComponent<NeverCreatedSingleton>();
+            authored.authoredValue = 11;
+
+            yield return null;
+
+            // Drop the cached reference without destroying anything, which is the state every
+            // scene load leaves behind: the policy governs creation, and must not stop the lookup
+            // that finds an instance the consumer authored.
+            NeverCreatedSingleton._instance = null;
+
+            NeverCreatedSingleton instance = NeverCreatedSingleton.Instance;
+
+            Assert.AreSame(authored, instance);
+            Assert.AreEqual(11, instance.authoredValue);
+            Assert.IsTrue(NeverCreatedSingleton.HasInstance);
         }
     }
 }

--- a/Tests/Runtime/Utils/RuntimeSingletonTests.cs
+++ b/Tests/Runtime/Utils/RuntimeSingletonTests.cs
@@ -1068,6 +1068,29 @@ namespace WallstopStudios.UnityHelpers.Tests.Utils
             }
         }
 
+        /// <summary>
+        /// A refusal is remembered so the scene-wide search does not repeat on every access. That is
+        /// only sound because an instance cannot appear without <c>Awake</c> assigning the cache, so
+        /// this drives exactly that sequence: refuse, then add one, then ask again.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator AnInstanceCreatedAfterARefusalIsStillServed()
+        {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            LogAssert.Expect(LogType.Warning, RefusalPattern);
+#endif
+            Assert.IsTrue(NeverCreatedSingleton.Instance == null);
+
+            GameObject lateObject = Track(new GameObject("LateNeverCreatedSingleton"));
+            NeverCreatedSingleton late = lateObject.AddComponent<NeverCreatedSingleton>();
+            late.authoredValue = 23;
+
+            yield return null;
+
+            Assert.AreSame(late, NeverCreatedSingleton.Instance);
+            Assert.AreEqual(23, NeverCreatedSingleton.Instance.authoredValue);
+        }
+
         [UnityTest]
         public IEnumerator AnAuthoredInstanceIsServedWhenCreationIsRefused()
         {

--- a/docs/features/utilities/singletons.md
+++ b/docs/features/utilities/singletons.md
@@ -116,6 +116,7 @@ Contents
 - Access via `T.Instance` (creates a new `GameObject` named `"<Type>-Singleton"` and adds `T` if none exists; otherwise finds an existing active instance).
 - `HasInstance` lets you check for an existing instance without creating one.
 - `Preserve` (virtual, default `true`) controls `DontDestroyOnLoad`.
+- `CreationPolicy` reports whether on-demand creation is allowed — see [Controlling on-demand creation](#controlling-on-demand-creation).
 - Handles duplicate detection and cleans up instance reference on destroy. Instance is cleared on domain reload before scene load.
 
 Example: Simple service
@@ -163,6 +164,52 @@ Notes:
 
 - To avoid creation during a sensitive frame, place a pre‑made instance in your bootstrap scene.
 - For scene‑local managers, override `Preserve => false`.
+
+<a id="controlling-on-demand-creation"></a>
+
+### Controlling on-demand creation
+
+On-demand creation is what makes `T.Instance` work from anywhere, and it is right for a singleton that
+holds no authored state — a coroutine host, a dispatcher. It is wrong for one that does.
+
+A created instance is a bare component: every `[SerializeField]` is left at its default. So a manager
+you authored in a boot scene, loaded from the wrong scene, hands back a stand-in with no settings that
+behaves like the real thing right up until it writes something. Annotate those:
+
+```csharp
+using WallstopStudios.UnityHelpers.Core.Attributes;
+using WallstopStudios.UnityHelpers.Core.Helper;
+using WallstopStudios.UnityHelpers.Utils;
+
+[SingletonCreation(SingletonCreationPolicy.NeverCreate)]
+public sealed class SaveManager : RuntimeSingleton<SaveManager>
+{
+    [SerializeField]
+    private SaveSettings _settings;
+}
+```
+
+`SaveManager.Instance` now returns the instance in the scene when there is one and `null` when there
+is not, logging one warning naming the type instead of substituting an empty stand-in. The policy
+governs _creation_ only — an instance you authored is still found and still served.
+
+| Policy                                   | `Instance` with no instance in any loaded scene            |
+| ---------------------------------------- | ---------------------------------------------------------- |
+| `CreateOnDemand` (default, no attribute) | Creates `"<Type>-Singleton"` and returns the new component |
+| `NeverCreate`                            | Returns `null` and logs one warning per type               |
+
+Notes:
+
+- The decision is read from the type rather than from a virtual property, because there is no instance
+  to ask when the question is whether to make one.
+- The warning is logged once per type and re-armed by `ClearInstance()`, so a per-frame access cannot
+  flood the console.
+- It is a development diagnostic: release players skip it entirely.
+- `ScriptableObjectSingleton<T>` needs no policy. It never creates an asset at runtime — a missing one
+  already returns `null` with a warning — and the editor's opt-out for asset creation is
+  `[ExcludeFromSingletonCreation]`.
+- Pairing `NeverCreate` with `[AutoLoadSingleton]` at any phase before `AfterSceneLoad` is reported in
+  the editor: the auto-load runs before any scene exists, so it can only ever find nothing.
 
 <a id="scriptableobject-singleton"></a>
 

--- a/docs/features/utilities/singletons.md
+++ b/docs/features/utilities/singletons.md
@@ -203,7 +203,11 @@ Notes:
 - The decision is read from the type rather than from a virtual property, because there is no instance
   to ask when the question is whether to make one.
 - The warning is logged once per type and re-armed by `ClearInstance()`, so a per-frame access cannot
-  flood the console.
+  flood the console. In play mode the refused lookup is remembered too, so `if (X.Instance != null)`
+  in `Update()` costs nothing after the first miss.
+- **`ClearInstance()` is not a reset for these.** It destroys every live instance, and a `NeverCreate`
+  type will not build a replacement — `Instance` stays `null` until something else creates one. Use it
+  in tests and in editor tooling that is about to reload the scene, not as a runtime reset.
 - It is a development diagnostic: release players skip it entirely.
 - `ScriptableObjectSingleton<T>` needs no policy. It never creates an asset at runtime — a missing one
   already returns `null` with a warning — and the editor's opt-out for asset creation is

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "format:csharp:check": "pwsh -NoProfile -File scripts/lint-csharp-format.ps1 -VerboseOutput",
     "format:check": "npm run format:md:check && npm run format:json:check && npm run format:yaml:check && npm run format:js:check",
     "format:fix": "npm run format:md && npm run format:json && npm run format:yaml && npm run format:js",
+    "lint:preserve-attributes": "node scripts/lint-preserve-attributes.js",
     "lint:changelog": "pwsh -NoProfile -File scripts/lint-changelog.ps1 -VerboseOutput",
     "lint:duplicate-usings": "pwsh -NoProfile -File scripts/lint-duplicate-usings.ps1 -VerboseOutput",
     "lint:yaml": "pwsh -NoProfile -File scripts/lint-yaml.ps1 -VerboseOutput",

--- a/scripts/lint-preserve-attributes.js
+++ b/scripts/lint-preserve-attributes.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Every attribute this package reads by reflection AT RUNTIME must carry
+ * [UnityEngine.Scripting.Preserve].
+ *
+ * The failure it guards against is silent and gameplay-shaped: if the IL2CPP managed linker drops
+ * such an attribute, `GetCustomAttributes` finds nothing and the code reading it falls back to its
+ * default. A [SingletonCreation(NeverCreate)] singleton starts conjuring empty stand-ins again; a
+ * [ScriptableSingletonPath] asset is looked for in the wrong folder. Nothing throws, and nothing in
+ * the editor reproduces it.
+ *
+ * The package's link.xml preserves the whole runtime assembly today, so this is defense in depth
+ * rather than a live bug. It is worth having anyway: link.xml's own comment calls the wholesale
+ * preserve a "low-maintenance choice", so a later narrowing must not silently re-open this, and
+ * [Preserve] states the requirement at the declaration where the next reader is looking.
+ *
+ * Exit codes: 0 = all annotated, 1 = at least one is missing.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const RUNTIME_ROOT = path.join(REPO_ROOT, "Runtime");
+
+/**
+ * Attribute types that are read reflectively but are NOT ours to annotate, with the reason.
+ * An entry here is a claim that the type is declared outside this package.
+ */
+const NOT_OURS = new Map([
+  ["ObsoleteAttribute", "System.ObsoleteAttribute"],
+  ["JsonConverterAttribute", "System.Text.Json.Serialization.JsonConverterAttribute"],
+  ["SerializeField", "UnityEngine.SerializeField"]
+]);
+
+function collectCsFiles(root) {
+  const out = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith(".cs")) {
+        out.push(full);
+      }
+    }
+  };
+  walk(root);
+  return out.sort();
+}
+
+/**
+ * Attribute type names used as a reflection target anywhere under Runtime/.
+ * Deliberately over-collects: a name that turns out not to be one of ours is answered by NOT_OURS
+ * or by simply having no declaration in Runtime/, both of which are quiet.
+ */
+function findReflectedAttributeNames(files) {
+  const pattern =
+    /(?:TryGetAttributeSafe|IsAttributeDefined|GetCustomAttributes?|IsDefined)\s*(?:<\s*([A-Za-z0-9_]*Attribute)\s*>)?[^;]{0,300}?(?:out\s+([A-Za-z0-9_]*Attribute)\b|typeof\(\s*([A-Za-z0-9_]*Attribute)\s*\))/gs;
+  const names = new Map();
+  for (const file of files) {
+    const text = fs.readFileSync(file, "utf8");
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+      for (const candidate of [match[1], match[2], match[3]]) {
+        if (!candidate || candidate === "TAttribute" || candidate === "Attribute") {
+          continue;
+        }
+        if (!names.has(candidate)) {
+          names.set(candidate, path.relative(REPO_ROOT, file));
+        }
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Base attribute types whose subclasses are read reflectively through a generic `TAttribute`, which
+ * the scan above cannot see: it only ever observes the type parameter's name. Each subclass is
+ * therefore required to be preserved on the strength of its base.
+ */
+const REFLECTED_THROUGH_BASE = new Map([
+  [
+    "BaseRelationalComponentAttribute",
+    "BaseRelationalComponentAttribute reads it via IsAttributeDefined<TAttribute>"
+  ]
+]);
+
+/** Where each attribute type is declared under Runtime/, and whether that declaration is annotated. */
+function findDeclarations(files) {
+  const declarations = new Map();
+  for (const file of files) {
+    const text = fs.readFileSync(file, "utf8");
+    const pattern =
+      /((?:^[ \t]*\[[^\]]*\][ \t]*\r?\n)*)^[ \t]*(?:public|internal)[^\r\n]*?\bclass\s+([A-Za-z0-9_]+Attribute)\b/gm;
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+      const declarationLine = text.slice(
+        match.index,
+        text.indexOf("\n", match.index + match[0].length)
+      );
+      const baseMatch = /:\s*([A-Za-z0-9_]+)/.exec(
+        declarationLine.slice(match[0].length - match[2].length)
+      );
+      declarations.set(match[2], {
+        file: path.relative(REPO_ROOT, file),
+        preserved: /\[\s*Preserve\s*(?:\(|\])/.test(match[1]),
+        baseType: baseMatch ? baseMatch[1] : null
+      });
+    }
+  }
+  return declarations;
+}
+
+function main() {
+  const files = collectCsFiles(RUNTIME_ROOT);
+  const reflected = findReflectedAttributeNames(files);
+  const declarations = findDeclarations(files);
+
+  const failures = [];
+  const checked = [];
+
+  // Subclasses of a base the package reflects over generically are reflected too.
+  for (const [name, declaration] of declarations) {
+    const reason = declaration.baseType ? REFLECTED_THROUGH_BASE.get(declaration.baseType) : null;
+    if (reason && !reflected.has(name)) {
+      reflected.set(name, reason);
+    }
+  }
+
+  for (const [name, usedIn] of [...reflected.entries()].sort()) {
+    const declaration = declarations.get(name);
+    if (!declaration) {
+      if (!NOT_OURS.has(name)) {
+        // Not declared under Runtime/ and not declared as foreign: say so rather than pass quietly,
+        // because a rule whose scope nobody states is a rule nobody can trust.
+        failures.push(
+          `${name} is read by reflection in ${usedIn} but is declared nowhere under Runtime/. ` +
+            `If it belongs to another library, add it to NOT_OURS in ${path.relative(REPO_ROOT, __filename)} with its full name.`
+        );
+      }
+      continue;
+    }
+
+    checked.push(name);
+    if (!declaration.preserved) {
+      failures.push(
+        `${name} (${declaration.file}) is read by reflection at runtime from ${usedIn}, but is not marked ` +
+          `[Preserve]. The IL2CPP linker may drop it, and the code reading it then silently falls back to its default.`
+      );
+    }
+  }
+
+  if (checked.length === 0) {
+    console.error(
+      "[lint-preserve-attributes] Found no runtime-reflected package attributes at all. " +
+        "That is almost certainly a broken scan rather than a clean repository."
+    );
+    process.exit(1);
+  }
+
+  for (const name of checked) {
+    console.log(`  OK   ${name}`);
+  }
+
+  if (failures.length > 0) {
+    console.error("");
+    for (const failure of failures) {
+      console.error(`  FAIL ${failure}`);
+    }
+    console.error(`\n[lint-preserve-attributes] ${failures.length} attribute(s) need [Preserve].`);
+    process.exit(1);
+  }
+
+  console.log(
+    `\n[lint-preserve-attributes] ${checked.length} runtime-reflected attribute(s) are preserved.`
+  );
+}
+
+main();

--- a/scripts/lint-preserve-attributes.js.meta
+++ b/scripts/lint-preserve-attributes.js.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c39eacdc21dc4a57b733c2d355371800
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/run-repo-lint.js
+++ b/scripts/run-repo-lint.js
@@ -125,6 +125,11 @@ const CHECKS = [
     run: "npm run lint:unity-file-naming"
   },
   {
+    id: "preserve-attributes",
+    name: "IL2CPP-preserved runtime attributes",
+    run: "node scripts/lint-preserve-attributes.js"
+  },
+  {
     id: "meta-exclusions",
     name: "Meta lint exclusions",
     run: "bash scripts/tests/test-lint-meta-exclusions.sh"

--- a/scripts/tests/test-git-staging-helpers.sh
+++ b/scripts/tests/test-git-staging-helpers.sh
@@ -69,7 +69,8 @@ if (
 
     echo "hello" > sample.txt
     git_add_with_retry sample.txt
-    git diff --cached --name-only | grep -Fxq -- sample.txt
+    staged="$(git diff --cached --name-only || true)"
+    grep -Fxq -- sample.txt <<<"$staged"
 ); then
     pass "git_add_with_retry stages file"
 else

--- a/scripts/tests/test-lint-meta-exclusions.sh
+++ b/scripts/tests/test-lint-meta-exclusions.sh
@@ -65,14 +65,25 @@ echo ""
 # Read the script content once
 SCRIPT_CONTENT="$(cat "$LINT_SCRIPT")"
 
-# Helper: check that a string appears in the excludeDirs array line
+# Each array's declaration is extracted ONCE, into a variable, and every membership question is then
+# answered with bash string matching rather than a pipeline.
+#
+# This used to be `echo "$SCRIPT_CONTENT" | grep '\$excludeDirs' | grep -qF "'obj'"`, and under
+# `set -o pipefail` that is a race: `grep -q` exits at its first match, the upstream `grep` dies of
+# SIGPIPE, and pipefail reports the pipeline as 141 even though the match succeeded. It passes
+# whenever the producer finishes writing first, which is almost always -- and lost that race once in
+# CI under Repo Lint's eight concurrent workers, failing `obj` while `bin`, on the same line of the
+# same string, passed.
+EXCLUDE_DIRS_BLOCK="$(printf '%s\n' "$SCRIPT_CONTENT" | sed -n '/\$excludeDirs *=/,/)/p')"
+EXCLUDE_FILE_PATTERNS_BLOCK="$(printf '%s\n' "$SCRIPT_CONTENT" | sed -n '/\$excludeFilePatterns/,/)/p')"
+EXCLUDE_DIR_PATTERNS_BLOCK="$(printf '%s\n' "$SCRIPT_CONTENT" | sed -n '/\$excludeDirPatterns/,/)/p')"
+
+# Helper: check that a string appears in the excludeDirs array declaration
 check_exclude_dir() {
   local entry="$1"
   local description="$2"
   run_test
-  # Match the entry inside the $excludeDirs array declaration
-  if echo "$SCRIPT_CONTENT" | grep -q "\\\$excludeDirs" && \
-     echo "$SCRIPT_CONTENT" | grep '\$excludeDirs' | grep -qF "'$entry'"; then
+  if [ -n "$EXCLUDE_DIRS_BLOCK" ] && [[ "$EXCLUDE_DIRS_BLOCK" == *"'$entry'"* ]]; then
     pass "excludeDirs contains '$entry' ($description)"
   else
     fail "excludeDirs missing '$entry' ($description)"
@@ -84,9 +95,7 @@ check_exclude_file_pattern() {
   local pattern="$1"
   local description="$2"
   run_test
-  # Match the pattern inside the $excludeFilePatterns array block
-  if echo "$SCRIPT_CONTENT" | grep -q "\\\$excludeFilePatterns" && \
-     echo "$SCRIPT_CONTENT" | sed -n '/\$excludeFilePatterns/,/)/p' | grep -qF "'$pattern'"; then
+  if [ -n "$EXCLUDE_FILE_PATTERNS_BLOCK" ] && [[ "$EXCLUDE_FILE_PATTERNS_BLOCK" == *"'$pattern'"* ]]; then
     pass "excludeFilePatterns contains '$pattern' ($description)"
   else
     fail "excludeFilePatterns missing '$pattern' ($description)"
@@ -98,8 +107,7 @@ check_exclude_dir_pattern() {
   local pattern="$1"
   local description="$2"
   run_test
-  if echo "$SCRIPT_CONTENT" | grep -q '\$excludeDirPatterns' && \
-     echo "$SCRIPT_CONTENT" | sed -n '/\$excludeDirPatterns/,/)/p' | grep -qF "'$pattern'"; then
+  if [ -n "$EXCLUDE_DIR_PATTERNS_BLOCK" ] && [[ "$EXCLUDE_DIR_PATTERNS_BLOCK" == *"'$pattern'"* ]]; then
     pass "excludeDirPatterns contains '$pattern' ($description)"
   else
     fail "excludeDirPatterns missing '$pattern' ($description)"
@@ -278,7 +286,7 @@ else
 
     if ! (cd "$ws" && git add -A >/dev/null 2>&1); then
       local status_preview=""
-      status_preview=$(cd "$ws" && git status --short 2>&1 | head -n 20)
+      status_preview=$(cd "$ws" && git status --short 2>&1 | head -n 20 || true)
       rm -rf "$ws"
       fail "$test_name" "TEST_HARNESS: git add -A failed. Workspace: $ws. Git status: ${status_preview:-<empty>}"
       return
@@ -319,7 +327,7 @@ else
 
     if ! (cd "$ws" && git add -A >/dev/null 2>&1); then
       local status_preview=""
-      status_preview=$(cd "$ws" && git status --short 2>&1 | head -n 20)
+      status_preview=$(cd "$ws" && git status --short 2>&1 | head -n 20 || true)
       rm -rf "$ws"
       fail "$test_name" "TEST_HARNESS: git add -A failed. Workspace: $ws. Git status: ${status_preview:-<empty>}"
       return

--- a/scripts/tests/test-lint-meta-exclusions.sh
+++ b/scripts/tests/test-lint-meta-exclusions.sh
@@ -74,7 +74,11 @@ SCRIPT_CONTENT="$(cat "$LINT_SCRIPT")"
 # whenever the producer finishes writing first, which is almost always -- and lost that race once in
 # CI under Repo Lint's eight concurrent workers, failing `obj` while `bin`, on the same line of the
 # same string, passed.
-EXCLUDE_DIRS_BLOCK="$(printf '%s\n' "$SCRIPT_CONTENT" | sed -n '/\$excludeDirs *=/,/)/p')"
+# `$excludeDirs` is declared on ONE line, so it is matched as one line. A `/start/,/end/` range
+# would not do: sed never closes a range on its start line, so it would run on to the closing `)` of
+# `$excludeFilePatterns` and this check would accept a directory name that had been moved into the
+# file-pattern array -- which is exactly the drift it exists to catch.
+EXCLUDE_DIRS_BLOCK="$(printf '%s\n' "$SCRIPT_CONTENT" | sed -n '/^\$excludeDirs *=/p')"
 EXCLUDE_FILE_PATTERNS_BLOCK="$(printf '%s\n' "$SCRIPT_CONTENT" | sed -n '/\$excludeFilePatterns/,/)/p')"
 EXCLUDE_DIR_PATTERNS_BLOCK="$(printf '%s\n' "$SCRIPT_CONTENT" | sed -n '/\$excludeDirPatterns/,/)/p')"
 

--- a/scripts/tests/test-normalize-container-git-config.sh
+++ b/scripts/tests/test-normalize-container-git-config.sh
@@ -177,7 +177,7 @@ rm -rf "$sandbox"
 # deferred, so a call placed after that block would silently not run.
 post_start="$REPO_ROOT/.devcontainer/post-start.sh"
 if grep -q 'normalize-container-git-config.sh' "$post_start"; then
-    normalize_line="$(grep -n 'normalize-container-git-config.sh' "$post_start" | head -1 | cut -d: -f1)"
+    normalize_line="$(grep -n 'normalize-container-git-config.sh' "$post_start" | head -1 | cut -d: -f1 || true)"
     deferred_line="$(grep -n 'retry_is_deferred' "$post_start" | tail -1 | cut -d: -f1)"
     if [ "$normalize_line" -lt "$deferred_line" ]; then
         pass "post-start.sh normalizes git config before its early exit"

--- a/scripts/tests/test-post-create.sh
+++ b/scripts/tests/test-post-create.sh
@@ -98,7 +98,7 @@ git_index_mode() {
     local rel_path
     rel_path="$(relative_path "$file_path")"
 
-    git -C "$REPO_ROOT" ls-files -s -- "$rel_path" 2>/dev/null | sed -E 's/^([0-9]+).*/\1/' | head -n 1
+    git -C "$REPO_ROOT" ls-files -s -- "$rel_path" 2>/dev/null | sed -E 's/^([0-9]+).*/\1/' | head -n 1 || true
 }
 
 permission_diagnostics() {
@@ -715,9 +715,9 @@ fi
 echo -e "${BLUE}Checking command ordering...${NC}"
 
 # Only check non-comment lines (skip lines starting with optional whitespace + #)
-CHOWN_LINE=$(grep -n 'sudo chown' "$POST_CREATE" | grep -vE '^[[:space:]]*[0-9]*:[[:space:]]*#' | head -1 | cut -d: -f1)
-DOTNET_LINE=$(grep -n 'dotnet tool restore' "$POST_CREATE" | grep -vE '^[[:space:]]*[0-9]*:[[:space:]]*#' | head -1 | cut -d: -f1)
-NPM_LINE=$(grep -nE 'npm ci|npm i ' "$POST_CREATE" | grep -vE '^[[:space:]]*[0-9]*:[[:space:]]*#' | head -1 | cut -d: -f1)
+CHOWN_LINE=$(grep -n 'sudo chown' "$POST_CREATE" | grep -vE '^[[:space:]]*[0-9]*:[[:space:]]*#' | head -1 | cut -d: -f1 || true)
+DOTNET_LINE=$(grep -n 'dotnet tool restore' "$POST_CREATE" | grep -vE '^[[:space:]]*[0-9]*:[[:space:]]*#' | head -1 | cut -d: -f1 || true)
+NPM_LINE=$(grep -nE 'npm ci|npm i ' "$POST_CREATE" | grep -vE '^[[:space:]]*[0-9]*:[[:space:]]*#' | head -1 | cut -d: -f1 || true)
 
 if [[ -n "$CHOWN_LINE" && -n "$DOTNET_LINE" ]]; then
     if [[ "$CHOWN_LINE" -lt "$DOTNET_LINE" ]]; then

--- a/scripts/tests/test-post-create.sh
+++ b/scripts/tests/test-post-create.sh
@@ -727,8 +727,15 @@ if [[ -n "$CHOWN_LINE" && -n "$DOTNET_LINE" ]]; then
             "chown on line $CHOWN_LINE, dotnet on line $DOTNET_LINE"
     fi
 else
+    # Each marker is reported by name. Before these lookups were guarded against a SIGPIPE from the
+    # short-circuiting `head`, a missing marker made the command substitution non-zero and `set -e`
+    # killed the whole suite with no message; guarding it without these branches would have traded
+    # that for a silently skipped ordering assertion, which is worse than either.
     if [[ -z "$CHOWN_LINE" ]]; then
         fail "chown command exists in post-create.sh" "No sudo chown found"
+    fi
+    if [[ -z "$DOTNET_LINE" ]]; then
+        fail "dotnet tool restore exists in post-create.sh" "No dotnet tool restore found"
     fi
 fi
 
@@ -739,6 +746,8 @@ if [[ -n "$CHOWN_LINE" && -n "$NPM_LINE" ]]; then
         fail "chown runs before npm install" \
             "chown on line $CHOWN_LINE, npm on line $NPM_LINE"
     fi
+elif [[ -z "$NPM_LINE" ]]; then
+    fail "npm install exists in post-create.sh" "No npm ci / npm i found"
 fi
 
 # ── Test 9: Script handles workspace folder detection ────────────────────────

--- a/scripts/tests/test-pre-push-changed-files.sh
+++ b/scripts/tests/test-pre-push-changed-files.sh
@@ -401,7 +401,10 @@ echo "=== Testing validation-only behavior ==="
 run_test
 # Check that the hook does not EXECUTE Prettier with --write (auto-fix)
 # Mentioning it in user-facing hints is fine.
-if grep -v '^[[:space:]]*#' "$PRE_PUSH_IMPL" | grep -Eiq '(prettier|run-prettier\.js).*--write'; then
+# Captured rather than piped into `grep -q`: under `set -o pipefail` the short-circuiting
+# consumer SIGPIPEs the producer and the pipeline reports 141 on a successful match.
+pre_push_code="$(grep -v '^[[:space:]]*#' "$PRE_PUSH_IMPL" || true)"
+if grep -Eiq '(prettier|run-prettier\.js).*--write' <<<"$pre_push_code"; then
     fail "No prettier --write execution in pre-push" "no auto-fix" "prettier --write found"
 else
     pass "No prettier --write execution in pre-push (validation-only)"
@@ -428,7 +431,7 @@ else
 fi
 
 run_test
-if grep -v '^[[:space:]]*#' "$PRE_PUSH_IMPL" | grep -Eq '(^|[[:space:]])node([[:space:]]|$)'; then
+if grep -Eq '(^|[[:space:]])node([[:space:]]|$)' <<<"$pre_push_code"; then
     fail "No direct Node execution in pre-push implementation" "no node commands" "found direct dependency"
 else
     pass "No direct Node execution in pre-push implementation"

--- a/scripts/tests/test-validate-devcontainer-urls.sh
+++ b/scripts/tests/test-validate-devcontainer-urls.sh
@@ -83,7 +83,7 @@ git_index_mode() {
     local rel_path
     rel_path="$(relative_path "$file_path")"
 
-    git -C "$REPO_ROOT" ls-files -s -- "$rel_path" 2>/dev/null | sed -E 's/^([0-9]+).*/\1/' | head -n 1
+    git -C "$REPO_ROOT" ls-files -s -- "$rel_path" 2>/dev/null | sed -E 's/^([0-9]+).*/\1/' | head -n 1 || true
 }
 
 permission_diagnostics() {

--- a/scripts/unity/run-tests.sh
+++ b/scripts/unity/run-tests.sh
@@ -265,10 +265,10 @@ except Exception as e:
         local test_run_line
         test_run_line=$(head -n 5 "${results_file}" | tr ' ' '\n' | tr '>' '\n')
 
-        total=$(echo "${test_run_line}" | sed -n 's/.*total="\([0-9]*\)".*/\1/p' | head -n 1)
-        passed=$(echo "${test_run_line}" | sed -n 's/.*passed="\([0-9]*\)".*/\1/p' | head -n 1)
-        failed=$(echo "${test_run_line}" | sed -n 's/.*failed="\([0-9]*\)".*/\1/p' | head -n 1)
-        skipped=$(echo "${test_run_line}" | sed -n 's/.*skipped="\([0-9]*\)".*/\1/p' | head -n 1)
+        total=$(echo "${test_run_line}" | sed -n 's/.*total="\([0-9]*\)".*/\1/p' | head -n 1 || true)
+        passed=$(echo "${test_run_line}" | sed -n 's/.*passed="\([0-9]*\)".*/\1/p' | head -n 1 || true)
+        failed=$(echo "${test_run_line}" | sed -n 's/.*failed="\([0-9]*\)".*/\1/p' | head -n 1 || true)
+        skipped=$(echo "${test_run_line}" | sed -n 's/.*skipped="\([0-9]*\)".*/\1/p' | head -n 1 || true)
 
         echo "    Total:   ${total:-0}"
         echo "    Passed:  ${passed:-0}"


### PR DESCRIPTION
## Two halves of the package disagreed about what a missing singleton means

`ScriptableObjectSingleton<T>.Instance` returns `null` and logs a warning when no asset exists.
`RuntimeSingleton<T>.Instance` always created a `GameObject`. So a manager authored in a boot scene,
reached from any other scene, handed back a **bare component with every `[SerializeField]` left
null** — a stand-in that behaves like the real thing right up until it writes something.

`[SingletonCreation(SingletonCreationPolicy.NeverCreate)]` (#321) is that decision made explicit.

```csharp
[SingletonCreation(SingletonCreationPolicy.NeverCreate)]
public sealed class SaveManager : RuntimeSingleton<SaveManager>
{
    [SerializeField]
    private SaveSettings _settings;
}
```

Three design points, each a measurement rather than a preference:

- **The policy is read from the type, not from a virtual property.** There is no instance to ask when
  the question is whether to make one. That is why the owner's proposal on #321 was an attribute, and
  it is the only mechanism that can work.
- **The default does not move.** `CreateOnDemand` is what a singleton with no attribute gets, because
  auto-creation is a documented headline feature and flipping it would break every consumer.
  `NeverCreate` is a denial a consumer opts into.
- **`Instance` still never throws** (critical rule 13). It returns `null` and logs **one warning per
  type**, re-armed by `ClearInstance()`, gated to editor/development builds — the same shape
  `ScriptableObjectSingleton.WarnNoInstancesFound` already shipped. An unrecognized policy value
  creates rather than refuses: a singleton silently ceasing to exist is a worse answer to a value this
  build does not know about.

The policy governs **creation only**. An instance you authored is still found and still served.

### Two annotations that compile and do nothing are now reported

Editor-side, `[SingletonCreation]` on a type that is not a `RuntimeSingleton<>` is inert, and
`NeverCreate` paired with `[AutoLoadSingleton]` at any phase before `AfterSceneLoad` is a
contradiction — those phases run before a single `GameObject` exists, so a lookup that may not create
can only ever find nothing. `AfterSceneLoad` is exempt and is the control the refusal needs.

The rule takes its attributes as **arguments** rather than reading them off the type, so its eleven
tests drive every branch without annotating a deliberately wrong type — which `TypeCache` would find
on every editor load, and this very diagnostic would then report forever. That is the technique
`RuntimeMismatchSingleton` already uses for the auto-loader's own mismatch rules.

## The JSON converter list existed three times, and nothing compared the copies (#459)

`GetNormalJsonOptions`, `GetPrettyJsonOptions` and `GetFastJsonOptions` each carried a **verbatim
copy of the same 46-entry `Converters` initializer**. A forty-seventh converter added to one and
missed on another would have changed what a value round-trips through based only on which options the
caller reached for, with nothing to report it.

One list now. The enum converter is inserted at index 4, the position it occupied in normal and
pretty, so **every registration order is byte-identical to before** — verified by extracting all three
initializers from `main` and diffing them against the shared method's emission order.

That also makes `ColorBlockConverter`'s `#if !UNITY_DISABLE_UI` guard usable for the first time. With
three unguarded references, defining the symbol compiled the converter out and then broke the runtime
assembly on the references to it — a guard that could not be used was indistinguishable from
protection that existed. Session 195 filed this as too small to raise on its own; with one call site
it is three lines.

### The contract #459 asked for

`JsonConverterCoverageTests` holds the shipped registrations and the fuzz suite to each other:

| Contract | What it catches |
| --- | --- |
| `EveryRegisteredConverterIsCoveredDeclaredOrExplicitlyNotOurs` | A converter that ships and is fuzzed by nothing |
| `EveryDeclaredExceptionStillNamesARegisteredConverter` | A declaration naming a converter nobody registers |
| `TheWriteOnlyDeclarationAgreesWithTheFuzzTargets` | The two statements of "this one cannot read" drifting apart |
| `EveryShippedConfigurationRegistersTheSameConvertersInTheSameOrder` | The three lists diverging again, and pins the one deliberate difference |

It asks each converter what it claims through `CanConvert` rather than reading its generic argument,
because six of the registrations are factories whose converted type is decided per closure.

**And `AcceptedPayloadsSurviveTheirOwnReEncoding` could not make #459's load-bearing assertion.** It
`continue`s past any payload it fails to decode — correct, since most of its corpus is deliberately
hostile — so a converter whose **own seed** does not read back is silently passed over rather than
reported. That is exactly the shape of the `WGuid.Empty` defect #458 fixed. The new
`AReadableConverterReadsBackTheValueItWrote` makes it explicit, one case per target.

## Verification

**Local, in a live Unity 6000.4.6f1 editor against this working tree** (the reflection loop from
[unity-devcontainer-testing](.llm/skills/unity-devcontainer-testing.md)):

| Fixture | Result |
| --- | --- |
| `JsonConverterCoverageTests` | 4/4 |
| `JsonConverterFuzzTests` | 303/303 (was 256; +47 round-trip cases) |
| `SingletonCreationDiagnosticsTests` | 11/11 |
| `RuntimeSingleton` policy, driven directly | `NeverCreate` → null + the exact warning; `(SingletonCreationPolicy)200` and `CoroutineHandler` → created |

**Proven able to fail.** Five mutations, each caught by the test named for it:

| Mutation | Red |
| --- | --- |
| Drop `GameObject` from the write-only declaration | `EveryRegisteredConverterIsCoveredDeclaredOrExplicitlyNotOurs` |
| Make `Touch` a readable target | `TheWriteOnlyDeclarationAgreesWithTheFuzzTargets`, `AReadableConverterReadsBackTheValueItWrote`, `MalformedPayloadsAreReportedAsJsonException` |
| Register the enum converter in every configuration | `EveryShippedConfigurationRegistersTheSameConvertersInTheSameOrder` |
| Declare a type nothing registers | `EveryDeclaredExceptionStillNamesARegisteredConverter` |
| Remove the policy check from `Instance` | `NeverCreatedSingleton.Instance` created a stand-in — the exact assertion in `InstanceReturnsNullWhenCreationIsRefused` |

**No regression from the options refactor, measured rather than assumed.** The whole
`Tests.Serialization` namespace was run under one crude harness (no `[SetUp]`, so file-IO fixtures
throw) on both heads: `main` at `ed1396cf` reported **884 cases / 32 failed**, this branch **935 / 25**.
Every failure here is present on `main` by the same name and count — a strict subset. The seven that
disappear are fixture-ordering artifacts of the same harness, not signal.

`npm run typecheck:unity` green in all six configurations (default, define-off, Odin runtime, and the
three test variants). `npm run agent:preflight` and `npm run lint:changelog` green.

## A matching `grep` reported failure (found by this PR's own CI)

`Repo Lint` went red on this branch with

```text
FAIL excludeDirs missing 'obj' (.NET build output)
PASS excludeDirs contains 'bin' (binary build output)
```

Both entries are on **the same line of the same string**, and nothing about
`scripts/lint-meta-files.ps1` changed. The check was

```bash
echo "$SCRIPT_CONTENT" | grep '\$excludeDirs' | grep -qF "'obj'"
```

and under `set -o pipefail` that is a race: `grep -q` exits at its first match, the upstream `grep`
is still writing and dies of SIGPIPE, and pipefail reports the **pipeline** as 141 — so a successful
match reads as a failed check. Measured rather than reasoned about: with a producer large enough to
still be writing, the identical pipeline returns 141 on **30 of 30** runs while every line matches.
It passes whenever the producer finishes first, which is why 26 of the previous 27 `Repo Lint` runs
were green; eight concurrent workers over one tree (#446) is the pressure that finally lost it.

Each exclusion array is extracted once and answered with bash string matching now — no pipeline to
lose — and it still discriminates: deleting `'obj'` from `lint-meta-files.ps1` reddens it.

**The sweep fixed twelve more sites where a spurious 141 would change an answer** rather than be
swallowed: an assertion that flips its branch, or a `$(...)` that aborts under `set -e` — including
`scripts/unity/run-tests.sh`, which parses the Unity result counts CI reports. The ~40 remaining
sites feed the consumer from `echo`/`printf` of a small string, where the producer finishes inside
one write; those are filed on #465 with the lint rule that would close them, because the honest
remedy there is a rule rather than forty edits.

The sentence worth keeping: **a pipeline whose consumer may stop reading early does not report
whether it matched — it reports whether the producer got to finish.**

## The JSON contract had a hole of its own

It enumerated `JsonSerializerOptions.Converters`, and **three of this package's adapters register
through a type-level `[JsonConverter]` attribute instead** (`SerializableList<T>`,
`SerializableType`, `SerializableNullable<T>`), so they never appear in that list and were invisible
to both the contract and the fuzz corpus. `EveryTypeLevelConverterIsCoveredByAFuzzTarget` covers that
second channel, and the two uncovered types have seeds now. Neither had a defect — stated because a
new gate that finds nothing is worth saying plainly rather than dressing up.

Local: `JsonConverterCoverageTests` 5/5, `JsonConverterFuzzTests` **315/315**, and the full 60-check
`Repo Lint` registry green under the same 8-worker concurrency CI uses.

## Review round — five real findings, one of them a regression this PR introduced

**The `sed` range read the wrong array.** Replacing the racing pipeline with
`sed -n '/\$excludeDirs *=/,/)/p'` widened the assertion: sed never closes a range on its start
line, and `$excludeDirs` is declared on **one** line, so the range ran on to the closing paren of
`$excludeFilePatterns` fifteen lines later. Moving `'obj'` from one array to the other then *passed*
the check written to catch exactly that drift. One line is matched as one line now, and the
moved-entry case reddens it.

**`#if !UNITY_DISABLE_UI` is deleted rather than honoured.** Honouring it was the wrong half of the
choice session 195 left open. Three other runtime files — `Partials/UI.cs`,
`MatchColliderToSprite.cs`, `EnhancedImage.cs` — name `UnityEngine.UI` with no guard at all, so
defining the symbol still breaks the assembly; all the guard bought was turning one loud compile
error into a silent fall-through to System.Text.Json's reflection path, which is the thing these
converters exist to avoid under IL2CPP. A symbol nothing defines, that three sibling files cannot
honour, is protection that does not exist. The CHANGELOG entry claiming otherwise is gone with it.

**A `NeverCreate` singleton rescanned the whole scene on every access.** `CreateOnDemand` never had
the problem — it creates one and caches it — but with nothing in the scene `_instance` stays null and
`FindAnyObjectByType` repeats forever, which is precisely what the `if (X.Instance != null)` guard
this PR's own documentation recommends does per frame.

*The first fix was wrong, and probing rather than reasoning is what caught it.* The invariant is that
nothing can appear without `Awake` assigning the cache — and **Unity does not run `Awake` outside
play mode**. `AddComponent` in the editor produced a live, active instance that the remembered
refusal then hid. It is play-mode-only now; edit mode still scans, and the probe confirms all three
states.

**CS0414 in every release player build.** `_creationRefusedWarningLogged` was assigned and never read
when neither `UNITY_EDITOR` nor `DEVELOPMENT_BUILD` is defined. The repo's `TypeCheck` project
`NoWarn`s CS0414, so no local gate would have caught it — a consumer's build has no such suppression.
The field and its uses are inside the same `#if` now.

**The editor diagnostic could not see an inherited `[SingletonCreation]`.** `TypeCache` reports only
direct annotations while the runtime resolves with `inherit: true`, so an annotated abstract base
with a concrete `[AutoLoadSingleton]` subclass — the exact contradiction the rule reports — was
invisible: the base is skipped as abstract, and the subclass carries no attribute of its own. Both
attribute sets are enumerated now.

**And two tests read stronger than they were.** `Assert.IsTrue(restored != null)` is vacuous for
every struct target (`Deserialize` boxes) and never compared the value at all — it is a re-encoding
equality now, which works regardless of a target's equality semantics and catches a converter that
reads its own output back as a *different* value. And the order test compared the three lists only to
each other, which cannot see a reorder of the one shared list; the count and
`JsonStringEnumConverter`'s index are pinned against history instead.

Re-verified: **438/438** in a live editor (`JsonConverterCoverageTests` 5, `JsonConverterFuzzTests`
315, `JsonConverterTests` 107, `SingletonCreationDiagnosticsTests` 11), six `typecheck:unity`
configurations, and **60/60** `Repo Lint` checks under the same 8-worker concurrency CI uses.

## Second review round — owner feedback and Bugbot

**"Should this utilize `[Preserve]` or similar?"** Yes, and it generalizes to a class of eight. The
failure mode is the same for every member: the IL2CPP linker drops an attribute read only by
reflection, `GetCustomAttributes` finds nothing, and the reader falls back to its default —
`NeverCreate` silently resumes conjuring stand-ins, `[ScriptableSingletonPath]` looks in the wrong
folder. Nothing throws, and no editor run reproduces it.

`SingletonCreationAttribute`, `ScriptableSingletonPathAttribute`, `RandomGeneratorMetadataAttribute`,
`EnumDisplayNameAttribute`, `WShowIfAttribute`, and the three relational attributes
(`Child`/`Parent`/`SiblingComponentAttribute`, reached only through
`IsAttributeDefined<TAttribute>`).

*Stated plainly rather than overclaimed:* `link.xml` already preserves the whole runtime assembly, so
none of these is a live bug today. It earns its place because `link.xml`'s own comment calls that
wholesale preserve a "low-maintenance choice" — a later narrowing must not silently re-open it — and
because the marker belongs at the declaration rather than in a file the next reader will not check.

*And the sweep is executable.* `scripts/lint-preserve-attributes.js` (registered as
`preserve-attributes`) requires `[Preserve]` on every attribute used as a reflection target under
`Runtime/`, covering both the direct and the generic path, and is proven discriminating in both.
Two guards against itself: a scan that finds **nothing** fails rather than passes, and an attribute
reflected but declared outside `Runtime/` must be listed as foreign with its full name.

**Bugbot: "refusal cache hides pre-Awake instances" — right that it was unsound, wrong about why.**
Scene objects *are* findable before `Awake`, but a search that finds one caches it, so that path
never refuses. The actual hole is the one the edit-mode probe had already found wearing a different
disguise: the cache assumed only `Awake` can introduce an instance, and that is false in the editor
(Unity does not run `Awake` there) *and* false for a subclass whose override forgets `base.Awake()`.

The bound is **a frame** now, which needs no invariant at all. Worst case is one search per frame —
which is exactly what a single guarded call site already cost — and every stronger claim turned out
to be wrong somewhere.

*The typecheck caught the sweep's own defect*: two of those files keep usings inside
`#if UNITY_EDITOR`, so appending after the last one put `UnityEngine.Scripting` in a block the default
configuration compiles out.

Re-verified: **438/438** in a live editor, six `typecheck:unity` configurations, **61/61** `Repo Lint`
checks.

Closes #321. Closes #459. Files #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
