### PR TITLE
Allocate what a reader may never initialize, and stop five generators inventing a seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `NextGuid()` and `NextWGuid()` throwing on any generator restored from a protobuf payload read by protobuf-net. Twelve generators were affected, so the first GUID drawn after loading a save crashed ([#492](https://github.com/Ambiguous-Interactive/unity-helpers/issues/492)).
+- Fix `IllusionFlow`, `PcgRandom`, `RomuDuo`, `XorShiftRandom` and `XoroShiroRandom` replaying a different sequence than the one saved when their whole serialized state was at its default ([#492](https://github.com/Ambiguous-Interactive/unity-helpers/issues/492)).
+- Fix a `PcgRandom` whose increment arrived as zero returning the same value forever, and `StormDropRandom`, `PhotonSpinRandom` and `SystemRandom` throwing on first use, when a payload omitted the members their internal buffers come from ([#492](https://github.com/Ambiguous-Interactive/unity-helpers/issues/492)).
 - Fix `Helpers.EnumeratePrefabs` and `EnumerateScriptableObjects` searching folders the caller never named when the asset paths were passed as anything other than a `string[]` ([#482](https://github.com/Ambiguous-Interactive/unity-helpers/issues/482)).
 - Fix `[WShowIf]` never matching a member of a `ulong`-backed enum above `long.MaxValue`, which hid the field it was meant to reveal ([#346](https://github.com/Ambiguous-Interactive/unity-helpers/issues/346)).
 - Fix a chosen text colour on a `[WButton]` or `[WEnumToggleButtons]` palette entry being overwritten whenever its red, green and blue were all zero, so opaque black was replaced by the auto-computed colour and any transparency was discarded. Existing entries keep the colour they were showing ([#476](https://github.com/Ambiguous-Interactive/unity-helpers/issues/476)).

--- a/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/DuplicateFieldContracts.cs
+++ b/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/DuplicateFieldContracts.cs
@@ -213,4 +213,31 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
         [WProtoMember(1)]
         public SeededSkipHolder Child = new SeededSkipHolder();
     }
+
+    /// <summary>
+    /// A contract that builds itself -- one <c>readonly</c> member, so every value is held in a
+    /// local and passed to a constructor at the end of the read -- whose own constructor seeds
+    /// that member.
+    /// </summary>
+    /// <remarks>
+    /// The seed exists for the oracle and not for this generator: protobuf-net assigns a
+    /// <c>readonly</c> field by reflection onto an instance it constructed, while a formatter
+    /// that constructs at the end has no instance to read a seed off. Which of the two is
+    /// correct is a question about protobuf-net, so it is measured rather than assumed.
+    /// </remarks>
+    [ProtoContract]
+    [WProtoContract]
+    public sealed partial class SeededImmutableHolder
+    {
+        /// <summary>A sub-message the constructor fills in and the read cannot assign onto.</summary>
+        [ProtoMember(1)]
+        [WProtoMember(1)]
+        public readonly DuplicateChild Child;
+
+        /// <summary>Seeds <see cref="Child"/> so a merge and a replace give different answers.</summary>
+        public SeededImmutableHolder()
+        {
+            Child = new DuplicateChild { A = 9 };
+        }
+    }
 }

--- a/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/DuplicateFieldDifferentialTests.cs
+++ b/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/DuplicateFieldDifferentialTests.cs
@@ -210,6 +210,27 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator.Tests
         }
 
         [Test]
+        public void TheOracleMergesIntoAnImmutableContractsSeed()
+        {
+            // A contract with a readonly member is built by a constructor at the end of the read,
+            // so this package has no instance to take a seed off and replaces instead. protobuf-net
+            // is under no such constraint: it constructs, merges, and then assigns the readonly
+            // field by reflection. Field 1 sets only B, so a merge keeps A == 9 and a replace does
+            // not -- and both oracle versions merge.
+            //
+            // Pinned here as the answer to the question issue #491 asked, and deliberately not
+            // asserted of this package: closing the gap means seeding every read local from a
+            // constructed instance, which runs the author's constructor on every read of an
+            // immutable contract. That is #491's remaining work, not a detail of this test.
+            const string once = "0A021002";
+
+            SeededImmutableHolder oracle = OracleDecode<SeededImmutableHolder>(once);
+
+            Assert.AreEqual(9, oracle.Child.A, once);
+            Assert.AreEqual(2, oracle.Child.B, once);
+        }
+
+        [Test]
         public void EverySeededMemberShapeAgreesWithTheOracle()
         {
             // One payload per shape, each setting the member the seed does NOT set, so "merged" and

--- a/Runtime/Core/Random/AbstractRandom.cs
+++ b/Runtime/Core/Random/AbstractRandom.cs
@@ -119,6 +119,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
         private const int MaxRejectionAttempts32 = 1 << 16;
         private const int MaxRejectionAttempts64 = 1 << 20;
         private const int MaxGaussianAttempts = 1 << 20;
+        private const int GuidByteCount = 16;
         private const int MaxDoubleBitAttempts = 1 << 20;
 
         [ProtoMember(1)]
@@ -127,7 +128,10 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         public abstract RandomState InternalState { get; }
 
-        private readonly byte[] _guidBytes = new byte[16];
+        // Allocated on first use rather than by an initializer: a formatter that allocates an
+        // uninitialized instance -- which is what SkipConstructor asks protobuf-net for -- runs no
+        // initializer at all, and a buffer that only NextGuid touches would arrive null.
+        private byte[] _guidBytes;
 
         // Bit/byte reservoirs to accelerate small requests
         // Note: included in protobuf to preserve exact generator state across round-trips
@@ -1235,16 +1239,23 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         public Guid NextGuid()
         {
-            return new Guid(GenerateGuidBytes(_guidBytes));
+            return new Guid(GenerateGuidBytes());
         }
 
         public WGuid NextWGuid()
         {
-            return new WGuid(GenerateGuidBytes(_guidBytes));
+            return new WGuid(GenerateGuidBytes());
         }
 
-        private byte[] GenerateGuidBytes(byte[] guidBytes)
+        private byte[] GenerateGuidBytes()
         {
+            byte[] guidBytes = _guidBytes;
+            if (guidBytes == null)
+            {
+                guidBytes = new byte[GuidByteCount];
+                _guidBytes = guidBytes;
+            }
+
             NextBytes(guidBytes);
             SetUuidV4Bits(guidBytes);
             return guidBytes;
@@ -1252,7 +1263,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         public static void SetUuidV4Bits(byte[] bytes)
         {
-            if (bytes == null || bytes.Length < 16)
+            if (bytes == null || bytes.Length < GuidByteCount)
             {
                 throw new ArgumentException(
                     "UUID buffer must contain at least 16 bytes.",

--- a/Runtime/Core/Random/IllusionFlow.cs
+++ b/Runtime/Core/Random/IllusionFlow.cs
@@ -76,8 +76,11 @@ namespace WallstopStudios.UnityHelpers.Core.Random
     )]
     [Serializable]
     [DataContract]
-    [ProtoContract]
-    [WProtoContract]
+    // SkipConstructor for the reason its siblings carry it: protobuf omits a member equal to its
+    // default, so an all-default state writes a payload naming none of it, and a parameterless
+    // constructor seeding from Guid.NewGuid() would invent a stream the save never held.
+    [ProtoContract(SkipConstructor = true)]
+    [WProtoContract(SkipConstructor = true)]
     public sealed partial class IllusionFlow : AbstractRandom
     {
         private const int UintByteCount = sizeof(uint) * 8;
@@ -91,8 +94,15 @@ namespace WallstopStudios.UnityHelpers.Core.Random
             {
                 ulong stateA = ((ulong)_a << UintByteCount) | _b;
                 ulong stateB = ((ulong)_c << UintByteCount) | _d;
-                BinaryPrimitives.WriteUInt32LittleEndian(_payload, _e);
-                return BuildState(stateA, stateB, payload: _payload);
+                byte[] payload = _payload;
+                if (payload == null)
+                {
+                    payload = new byte[StatePayloadLength];
+                    _payload = payload;
+                }
+
+                BinaryPrimitives.WriteUInt32LittleEndian(payload, _e);
+                return BuildState(stateA, stateB, payload: payload);
             }
         }
 
@@ -116,8 +126,10 @@ namespace WallstopStudios.UnityHelpers.Core.Random
         [WProtoMember(10)]
         private uint _e;
 
-        // Cached space for RandomState
-        private readonly byte[] _payload = new byte[StatePayloadLength];
+        // Cached space for RandomState, allocated on first use rather than by an initializer:
+        // a formatter is free to allocate an instance no constructor ever ran, and this buffer
+        // is not on the wire to be restored.
+        private byte[] _payload;
 
         public IllusionFlow()
             : this(Guid.NewGuid()) { }

--- a/Runtime/Core/Random/PcgRandom.cs
+++ b/Runtime/Core/Random/PcgRandom.cs
@@ -110,17 +110,19 @@ namespace WallstopStudios.UnityHelpers.Core.Random
     )]
     [Serializable]
     [DataContract]
-    [ProtoContract]
-    [WProtoContract]
+    [ProtoContract(SkipConstructor = true)]
+    [WProtoContract(SkipConstructor = true)]
     public sealed partial class PcgRandom
         : AbstractRandom,
             IEquatable<PcgRandom>,
             IComparable,
             IComparable<PcgRandom>
     {
+        // PCG requires an odd increment, and setting the low bit is what makes any value odd --
+        // an already-odd one is its own answer, so no branch distinguishes the two cases.
         private static ulong NormalizeIncrement(ulong increment)
         {
-            return (increment & 1UL) == 0 ? increment | 1UL : increment;
+            return increment | 1UL;
         }
 
         public static PcgRandom Instance => ThreadLocalRandom<PcgRandom>.Instance;
@@ -172,7 +174,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
             unchecked
             {
                 ulong oldState = _state;
-                _state = oldState * 6364136223846793005UL + _increment;
+                _state = oldState * 6364136223846793005UL + NormalizeIncrement(_increment);
                 uint xorShifted = (uint)(((oldState >> 18) ^ oldState) >> 27);
                 int rot = (int)(oldState >> 59);
                 return (xorShifted >> rot) | (xorShifted << (-rot & 31));

--- a/Runtime/Core/Random/PhotonSpinRandom.cs
+++ b/Runtime/Core/Random/PhotonSpinRandom.cs
@@ -82,6 +82,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
         {
             get
             {
+                EnsureElements();
                 using PooledArray<byte> payloadLease = WallstopArrayPool<byte>.Get(
                     ElementByteSize,
                     out byte[] buffer
@@ -179,6 +180,10 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         public override uint NextUint()
         {
+            // A formatter may hand back an instance no constructor ran and a payload that never
+            // named this member, so the initializer above guarantees nothing a caller can reach.
+            EnsureElements();
+
             if (!_hasPrimed)
             {
                 GenerateBlock();
@@ -223,6 +228,8 @@ namespace WallstopStudios.UnityHelpers.Core.Random
                 return false;
             }
 
+            EnsureElements();
+            other.EnsureElements();
             if (!_elements.AsSpan().SequenceEqual(other._elements))
             {
                 return false;
@@ -253,6 +260,9 @@ namespace WallstopStudios.UnityHelpers.Core.Random
             {
                 return -1;
             }
+
+            EnsureElements();
+            other.EnsureElements();
 
             int comparison = _a.CompareTo(other._a);
             if (comparison != 0)
@@ -296,12 +306,17 @@ namespace WallstopStudios.UnityHelpers.Core.Random
             return 0;
         }
 
-        private void LoadSerializedElements(byte[] payload)
+        private void EnsureElements()
         {
             if (_elements == null || _elements.Length != BlockSize)
             {
                 _elements = new uint[BlockSize];
             }
+        }
+
+        private void LoadSerializedElements(byte[] payload)
+        {
+            EnsureElements();
 
             if (payload != null && payload.Length >= ElementByteSize)
             {
@@ -335,10 +350,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         private void InitializeFromUlongs(ulong seed0, ulong seed1)
         {
-            if (_elements == null || _elements.Length != BlockSize)
-            {
-                _elements = new uint[BlockSize];
-            }
+            EnsureElements();
 
             ulong mixer = seed0 ^ (seed1 << 1) ^ 0x9E3779B97F4A7C15UL;
 

--- a/Runtime/Core/Random/RomuDuo.cs
+++ b/Runtime/Core/Random/RomuDuo.cs
@@ -61,8 +61,8 @@ namespace WallstopStudios.UnityHelpers.Core.Random
     )]
     [Serializable]
     [DataContract]
-    [ProtoContract]
-    [WProtoContract]
+    [ProtoContract(SkipConstructor = true)]
+    [WProtoContract(SkipConstructor = true)]
     public sealed partial class RomuDuo
         : AbstractRandom,
             IEquatable<RomuDuo>,

--- a/Runtime/Core/Random/StormDropRandom.cs
+++ b/Runtime/Core/Random/StormDropRandom.cs
@@ -85,6 +85,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
         {
             get
             {
+                EnsureElements();
                 using PooledArray<byte> payloadLease = WallstopArrayPool<byte>.Get(
                     ElementByteSize,
                     out byte[] buffer
@@ -146,6 +147,9 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         public override uint NextUint()
         {
+            // A formatter may hand back an instance no constructor ran and a payload that never
+            // named this member, so the initializer above guarantees nothing a caller can reach.
+            EnsureElements();
             unchecked
             {
                 uint index = _b & ElementMask;
@@ -177,6 +181,8 @@ namespace WallstopStudios.UnityHelpers.Core.Random
                 return false;
             }
 
+            EnsureElements();
+            other.EnsureElements();
             if (!_elements.AsSpan().SequenceEqual(other._elements))
             {
                 return false;
@@ -201,6 +207,9 @@ namespace WallstopStudios.UnityHelpers.Core.Random
             {
                 return -1;
             }
+
+            EnsureElements();
+            other.EnsureElements();
 
             int comparison = _a.CompareTo(other._a);
             if (comparison != 0)
@@ -252,10 +261,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         private void InitializeFromMixer(ref ulong mixer)
         {
-            if (_elements == null || _elements.Length != ElementCount)
-            {
-                _elements = new uint[ElementCount];
-            }
+            EnsureElements();
 
             for (int i = 0; i < ElementCount; ++i)
             {
@@ -271,12 +277,17 @@ namespace WallstopStudios.UnityHelpers.Core.Random
             }
         }
 
-        private void LoadSerializedElements(byte[] payload)
+        private void EnsureElements()
         {
             if (_elements == null || _elements.Length != ElementCount)
             {
                 _elements = new uint[ElementCount];
             }
+        }
+
+        private void LoadSerializedElements(byte[] payload)
+        {
+            EnsureElements();
 
             if (payload != null && payload.Length >= ElementByteSize)
             {

--- a/Runtime/Core/Random/SystemRandom.cs
+++ b/Runtime/Core/Random/SystemRandom.cs
@@ -66,12 +66,18 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         public static SystemRandom Instance => ThreadLocalRandom<SystemRandom>.Instance;
 
-        public override RandomState InternalState =>
-            BuildState(
-                unchecked((ulong)_inext),
-                unchecked((ulong)_inextp),
-                ArrayConverter.IntArrayToByteArrayBlockCopy(_seedArray)
-            );
+        public override RandomState InternalState
+        {
+            get
+            {
+                EnsureSeedArray();
+                return BuildState(
+                    unchecked((ulong)_inext),
+                    unchecked((ulong)_inextp),
+                    ArrayConverter.IntArrayToByteArrayBlockCopy(_seedArray)
+                );
+            }
+        }
 
         /*
             Copied from Random.cs source. Apparently it isn't guaranteed to be the
@@ -88,7 +94,7 @@ namespace WallstopStudios.UnityHelpers.Core.Random
 
         [ProtoMember(8)]
         [WProtoMember(8)]
-        private readonly int[] _seedArray = new int[SeedArraySize];
+        private int[] _seedArray = new int[SeedArraySize];
 
         public SystemRandom()
             : this(Guid.NewGuid().GetHashCode()) { }
@@ -136,10 +142,23 @@ namespace WallstopStudios.UnityHelpers.Core.Random
             }
             RestoreCommonState(internalState);
             _seedArray = ArrayConverter.ByteArrayToIntArrayBlockCopy(internalState._payload);
+            EnsureSeedArray();
+        }
+
+        private void EnsureSeedArray()
+        {
+            if (_seedArray == null || _seedArray.Length != SeedArraySize)
+            {
+                _seedArray = new int[SeedArraySize];
+            }
         }
 
         public override int Next()
         {
+            // A formatter may hand back an instance no constructor ran and a payload that never
+            // named this member, so the initializer above guarantees nothing a caller can reach.
+            EnsureSeedArray();
+
             int localINext = _inext;
             int localINextP = _inextp;
             int index1;

--- a/Runtime/Core/Random/XorShiftRandom.cs
+++ b/Runtime/Core/Random/XorShiftRandom.cs
@@ -67,8 +67,8 @@ namespace WallstopStudios.UnityHelpers.Core.Random
     )]
     [Serializable]
     [DataContract]
-    [ProtoContract]
-    [WProtoContract]
+    [ProtoContract(SkipConstructor = true)]
+    [WProtoContract(SkipConstructor = true)]
     public sealed partial class XorShiftRandom : AbstractRandom
     {
         public static XorShiftRandom Instance => ThreadLocalRandom<XorShiftRandom>.Instance;

--- a/Runtime/Core/Random/XoroShiroRandom.cs
+++ b/Runtime/Core/Random/XoroShiroRandom.cs
@@ -69,8 +69,8 @@ namespace WallstopStudios.UnityHelpers.Core.Random
     )]
     [Serializable]
     [DataContract]
-    [ProtoContract]
-    [WProtoContract]
+    [ProtoContract(SkipConstructor = true)]
+    [WProtoContract(SkipConstructor = true)]
     public sealed partial class XoroShiroRandom
         : AbstractRandom,
             IEquatable<XoroShiroRandom>,

--- a/Tests/Runtime/Random/RandomProtoSerializationTests.cs
+++ b/Tests/Runtime/Random/RandomProtoSerializationTests.cs
@@ -4,6 +4,8 @@
 namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
 {
     using System;
+    using System.Collections.Generic;
+    using System.IO;
     using NUnit.Framework;
     using WallstopStudios.UnityHelpers.Core.Random;
     using Serializer = WallstopStudios.UnityHelpers.Core.Serialization.Serializer;
@@ -557,6 +559,137 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             // Third roundtrip
             PcgRandom deserialized3 = SerializeDeserialize(deserialized2);
             Assert.AreEqual(deserialized2.InternalState, deserialized3.InternalState);
+        }
+
+        /// <summary>
+        /// Every generator, built the ordinary way, so one case cannot quietly drop out.
+        /// </summary>
+        private static IEnumerable<TestCaseData> EveryGenerator()
+        {
+            Guid seed = Guid.Parse("12345678-1234-1234-1234-123456789012");
+            yield return Named("DotNetRandom", new DotNetRandom(seed));
+            yield return Named("PcgRandom", new PcgRandom(seed));
+            yield return Named("XorShiftRandom", new XorShiftRandom(12345));
+            yield return Named("WyRandom", new WyRandom(seed));
+            yield return Named("XoroShiroRandom", new XoroShiroRandom(seed));
+            yield return Named("SystemRandom", new SystemRandom(12345));
+            yield return Named(
+                "LinearCongruentialGenerator",
+                new LinearCongruentialGenerator(12345)
+            );
+            yield return Named("SquirrelRandom", new SquirrelRandom(12345));
+            yield return Named("RomuDuo", new RomuDuo(seed));
+            yield return Named("SplitMix64", new SplitMix64(seed));
+            yield return Named("IllusionFlow", new IllusionFlow(seed));
+            yield return Named("FlurryBurstRandom", new FlurryBurstRandom(seed));
+            yield return Named("PhotonSpinRandom", new PhotonSpinRandom(seed));
+            yield return Named("StormDropRandom", new StormDropRandom(12345u));
+            yield return Named("BlastCircuitRandom", new BlastCircuitRandom(seed));
+            yield return Named("WaveSplatRandom", new WaveSplatRandom(0xC0FFEEUL));
+            yield return Named("WDoomRandom", new WDoomRandom(seedIndex: 7));
+        }
+
+        /// <summary>
+        /// Every generator a caller can seed so that its ENTIRE serialized state is its type's
+        /// default, which is the one state protobuf writes nothing about.
+        /// </summary>
+        /// <remarks>
+        /// Seed zero is the most ordinary seed there is, so this is not a corner reachable only
+        /// by a crafted payload -- <c>new SquirrelRandom(0)</c> is a line a game writes.
+        /// </remarks>
+        private static IEnumerable<TestCaseData> EveryAllDefaultGenerator()
+        {
+            yield return Named("BlastCircuitRandom", new BlastCircuitRandom(0UL, 0UL, 0UL, 0UL));
+            yield return Named("FlurryBurstRandom", new FlurryBurstRandom(default(RandomState)));
+            yield return Named("LinearCongruentialGenerator", new LinearCongruentialGenerator(0));
+            yield return Named("SplitMix64", new SplitMix64(0UL));
+            yield return Named("SquirrelRandom", new SquirrelRandom(0));
+            yield return Named("WaveSplatRandom", new WaveSplatRandom(0UL));
+            yield return Named("WDoomRandom", new WDoomRandom(seedIndex: 0));
+            yield return Named("WyRandom", new WyRandom(0UL));
+        }
+
+        private static TestCaseData Named(string name, IRandom random)
+        {
+            return new TestCaseData(random).SetName(name);
+        }
+
+        private static IRandom ProtobufNetRoundTrip(IRandom random)
+        {
+            using MemoryStream written = new();
+            ProtoBuf.Serializer.Serialize(written, (AbstractRandom)random);
+            using MemoryStream read = new(written.ToArray());
+            return ProtoBuf.Serializer.Deserialize<AbstractRandom>(read);
+        }
+
+        [TestCaseSource(nameof(EveryGenerator))]
+        public void ARestoredGeneratorCanStillProduceAGuid(IRandom random)
+        {
+            // The guid buffer is not on the wire, so a reader that allocates the instance without
+            // running a constructor -- which is what SkipConstructor asks protobuf-net for -- left
+            // it null, and the first NextGuid on a loaded save threw. Both readers are asked,
+            // because only one of them allocates that way.
+            foreach (IRandom restored in new[] { RoundTrip(random), ProtobufNetRoundTrip(random) })
+            {
+                Guid first = restored.NextGuid();
+                Guid second = restored.NextGuid();
+                Assert.AreNotEqual(Guid.Empty, first);
+                Assert.AreNotEqual(first, second);
+            }
+        }
+
+        [TestCaseSource(nameof(EveryAllDefaultGenerator))]
+        public void AnAllDefaultStateRestoresTheStreamItSaved(IRandom random)
+        {
+            // protobuf omits a member equal to its type's default, so this generator's payload is
+            // the include wrapper and nothing else. A constructor that seeds from Guid.NewGuid()
+            // keeps the invented value, which is a different stream on every load of the same
+            // bytes -- identical saves, a different game.
+            byte[] payload = Serializer.ProtoSerialize<IRandom>(random);
+            Assert.LessOrEqual(payload.Length, 3, "expected a payload naming no member");
+
+            uint[] expected = Draw(random);
+            CollectionAssert.AreEqual(
+                expected,
+                Draw(Serializer.ProtoDeserialize<IRandom>(payload))
+            );
+            CollectionAssert.AreEqual(
+                expected,
+                Draw(Serializer.ProtoDeserialize<IRandom>(payload))
+            );
+            CollectionAssert.AreEqual(expected, Draw(ProtobufNetRoundTrip(random)));
+        }
+
+        [Test]
+        public void APcgIncrementRestoredAsZeroStillAdvances()
+        {
+            // PCG multiplies and then adds its increment, so a zero increment leaves the state
+            // where it was and every draw is the same value. Every constructor stores an odd one,
+            // so only a payload can deliver zero -- and it must not produce a dead generator.
+            PcgRandom zeroed = new(0UL, 0UL);
+            IRandom restored = Serializer.ProtoDeserialize<IRandom>(
+                Serializer.ProtoSerialize<IRandom>(zeroed)
+            );
+
+            uint[] drawn = Draw(restored);
+            CollectionAssert.AreEqual(Draw(zeroed), drawn);
+            Assert.Greater(new HashSet<uint>(drawn).Count, 1, "a dead stream repeats one value");
+        }
+
+        private static IRandom RoundTrip(IRandom random)
+        {
+            return Serializer.ProtoDeserialize<IRandom>(Serializer.ProtoSerialize<IRandom>(random));
+        }
+
+        private static uint[] Draw(IRandom random)
+        {
+            uint[] drawn = new uint[32];
+            for (int i = 0; i < drawn.Length; ++i)
+            {
+                drawn[i] = random.NextUint();
+            }
+
+            return drawn;
         }
     }
 }

--- a/Tests/Runtime/Random/RandomProtoSerializationTests.cs
+++ b/Tests/Runtime/Random/RandomProtoSerializationTests.cs
@@ -567,26 +567,27 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
         private static IEnumerable<TestCaseData> EveryGenerator()
         {
             Guid seed = Guid.Parse("12345678-1234-1234-1234-123456789012");
-            yield return Named("DotNetRandom", new DotNetRandom(seed));
-            yield return Named("PcgRandom", new PcgRandom(seed));
-            yield return Named("XorShiftRandom", new XorShiftRandom(12345));
-            yield return Named("WyRandom", new WyRandom(seed));
-            yield return Named("XoroShiroRandom", new XoroShiroRandom(seed));
-            yield return Named("SystemRandom", new SystemRandom(12345));
+            yield return Named("Restored", "DotNetRandom", new DotNetRandom(seed));
+            yield return Named("Restored", "PcgRandom", new PcgRandom(seed));
+            yield return Named("Restored", "XorShiftRandom", new XorShiftRandom(12345));
+            yield return Named("Restored", "WyRandom", new WyRandom(seed));
+            yield return Named("Restored", "XoroShiroRandom", new XoroShiroRandom(seed));
+            yield return Named("Restored", "SystemRandom", new SystemRandom(12345));
             yield return Named(
+                "Restored",
                 "LinearCongruentialGenerator",
                 new LinearCongruentialGenerator(12345)
             );
-            yield return Named("SquirrelRandom", new SquirrelRandom(12345));
-            yield return Named("RomuDuo", new RomuDuo(seed));
-            yield return Named("SplitMix64", new SplitMix64(seed));
-            yield return Named("IllusionFlow", new IllusionFlow(seed));
-            yield return Named("FlurryBurstRandom", new FlurryBurstRandom(seed));
-            yield return Named("PhotonSpinRandom", new PhotonSpinRandom(seed));
-            yield return Named("StormDropRandom", new StormDropRandom(12345u));
-            yield return Named("BlastCircuitRandom", new BlastCircuitRandom(seed));
-            yield return Named("WaveSplatRandom", new WaveSplatRandom(0xC0FFEEUL));
-            yield return Named("WDoomRandom", new WDoomRandom(seedIndex: 7));
+            yield return Named("Restored", "SquirrelRandom", new SquirrelRandom(12345));
+            yield return Named("Restored", "RomuDuo", new RomuDuo(seed));
+            yield return Named("Restored", "SplitMix64", new SplitMix64(seed));
+            yield return Named("Restored", "IllusionFlow", new IllusionFlow(seed));
+            yield return Named("Restored", "FlurryBurstRandom", new FlurryBurstRandom(seed));
+            yield return Named("Restored", "PhotonSpinRandom", new PhotonSpinRandom(seed));
+            yield return Named("Restored", "StormDropRandom", new StormDropRandom(12345u));
+            yield return Named("Restored", "BlastCircuitRandom", new BlastCircuitRandom(seed));
+            yield return Named("Restored", "WaveSplatRandom", new WaveSplatRandom(0xC0FFEEUL));
+            yield return Named("Restored", "WDoomRandom", new WDoomRandom(seedIndex: 7));
         }
 
         /// <summary>
@@ -599,19 +600,38 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
         /// </remarks>
         private static IEnumerable<TestCaseData> EveryAllDefaultGenerator()
         {
-            yield return Named("BlastCircuitRandom", new BlastCircuitRandom(0UL, 0UL, 0UL, 0UL));
-            yield return Named("FlurryBurstRandom", new FlurryBurstRandom(default(RandomState)));
-            yield return Named("LinearCongruentialGenerator", new LinearCongruentialGenerator(0));
-            yield return Named("SplitMix64", new SplitMix64(0UL));
-            yield return Named("SquirrelRandom", new SquirrelRandom(0));
-            yield return Named("WaveSplatRandom", new WaveSplatRandom(0UL));
-            yield return Named("WDoomRandom", new WDoomRandom(seedIndex: 0));
-            yield return Named("WyRandom", new WyRandom(0UL));
+            yield return Named(
+                "AllDefault",
+                "BlastCircuitRandom",
+                new BlastCircuitRandom(0UL, 0UL, 0UL, 0UL)
+            );
+            yield return Named(
+                "AllDefault",
+                "FlurryBurstRandom",
+                new FlurryBurstRandom(default(RandomState))
+            );
+            yield return Named(
+                "AllDefault",
+                "LinearCongruentialGenerator",
+                new LinearCongruentialGenerator(0)
+            );
+            yield return Named("AllDefault", "SplitMix64", new SplitMix64(0UL));
+            yield return Named("AllDefault", "SquirrelRandom", new SquirrelRandom(0));
+            yield return Named("AllDefault", "WaveSplatRandom", new WaveSplatRandom(0UL));
+            yield return Named("AllDefault", "WDoomRandom", new WDoomRandom(seedIndex: 0));
+            yield return Named("AllDefault", "WyRandom", new WyRandom(0UL));
         }
 
-        private static TestCaseData Named(string name, IRandom random)
+        /// <summary>Names one case, uniquely across both sources.</summary>
+        /// <remarks>
+        /// <c>SetName</c> replaces the WHOLE test name, so the suite has to be part of it or the
+        /// two sources both produce a case called <c>WyRandom</c> and a failure report cannot say
+        /// which one it came from. The overload that keeps the method name is absent from the
+        /// NUnit that Unity 2021.3 ships.
+        /// </remarks>
+        private static TestCaseData Named(string suite, string name, IRandom random)
         {
-            return new TestCaseData(random).SetArgDisplayNames(name);
+            return new TestCaseData(random).SetName(suite + "-" + name);
         }
 
         private static IRandom ProtobufNetRoundTrip(IRandom random)

--- a/Tests/Runtime/Random/RandomProtoSerializationTests.cs
+++ b/Tests/Runtime/Random/RandomProtoSerializationTests.cs
@@ -611,7 +611,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
 
         private static TestCaseData Named(string name, IRandom random)
         {
-            return new TestCaseData(random).SetName(name);
+            return new TestCaseData(random).SetArgDisplayNames(name);
         }
 
         private static IRandom ProtobufNetRoundTrip(IRandom random)
@@ -648,16 +648,16 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             byte[] payload = Serializer.ProtoSerialize<IRandom>(random);
             Assert.LessOrEqual(payload.Length, 3, "expected a payload naming no member");
 
+            // Every restored generator is taken from the saved state, so they must be built
+            // before the draw below advances the original past it.
+            IRandom viaWallstopProto = Serializer.ProtoDeserialize<IRandom>(payload);
+            IRandom viaWallstopProtoAgain = Serializer.ProtoDeserialize<IRandom>(payload);
+            IRandom viaProtobufNet = ProtobufNetRoundTrip(random);
+
             uint[] expected = Draw(random);
-            CollectionAssert.AreEqual(
-                expected,
-                Draw(Serializer.ProtoDeserialize<IRandom>(payload))
-            );
-            CollectionAssert.AreEqual(
-                expected,
-                Draw(Serializer.ProtoDeserialize<IRandom>(payload))
-            );
-            CollectionAssert.AreEqual(expected, Draw(ProtobufNetRoundTrip(random)));
+            CollectionAssert.AreEqual(expected, Draw(viaWallstopProto));
+            CollectionAssert.AreEqual(expected, Draw(viaWallstopProtoAgain));
+            CollectionAssert.AreEqual(expected, Draw(viaProtobufNet));
         }
 
         [Test]

--- a/docs/features/serialization/serialization.md
+++ b/docs/features/serialization/serialization.md
@@ -1406,6 +1406,12 @@ survive IL2CPP, so the generator emits a private constructor into your type's `p
 instead. The consequence is that C# field initializers and base constructors still run, where under
 protobuf-net they do not — the object is more initialized, never less.
 
+That asymmetry is a trap worth naming, because it points the wrong way: a buffer your type needs but
+does not serialize — a scratch array, a cached hash — is guaranteed by a field initializer under this
+generator and **not** guaranteed under protobuf-net, which reads the same bytes. If the same contract
+can ever be read by protobuf-net, allocate such a buffer where you use it or rebuild it from a
+`[WProtoAfterDeserialization]` hook, rather than relying on the initializer.
+
 **No constructor is emitted into a type that declares none of its own.** There is nothing to skip
 there, and emitting one would delete the implicit parameterless constructor and stop `new Yours()`
 from compiling in your own code. The flag still governs seeding on such a type: a member of an


### PR DESCRIPTION
## What this is

Two issues. #492 asked for `SkipConstructor` on the generators that lacked it; following the flag's own meaning -- *allocate without running a constructor* -- turned up a crash that has shipped for five releases and that nobody had filed.

Closes #492. Refs #491.

## The defect nobody had filed

`AbstractRandom` holds `private readonly byte[] _guidBytes = new byte[16]`, the scratch buffer `NextGuid()` writes into. It is not a `[ProtoMember]`, so nothing on the wire restores it -- and a C# field initializer does not run when protobuf-net allocates an instance uninitialized, which is exactly what `SkipConstructor` asks it to do.

Measured in a live 6000.4.6f1 editor, round-tripping every generator through `ProtoBuf.Serializer` as `AbstractRandom`:

| | `_guidBytes` after the read | `NextGuid()` |
| --- | --- | --- |
| the 12 generators declaring `SkipConstructor` | **null** | **throws `ArgumentNullException`** |
| the 5 that did not | allocated | ok |

Five of those twelve have carried the flag since well before 3.5.1. Load a save, ask the generator for a GUID, crash.

It is invisible through `Serializer.ProtoDeserialize` today, because WallstopProto serves these types and its `SkipConstructor` emits a constructor rather than allocating raw -- so initializers *do* run. protobuf-net is still the shipped fallback and the whole of the `WALLSTOP_PROTO`-off build, which is where it bites. **A guarantee only one of two readers provides is not a guarantee.**

## The class of problem, swept

A repo-wide scan for a reference field whose only guarantee is an initializer, on a `[ProtoContract]` type, found exactly five. Each is now allocated where it is used:

| Field | Was left null by | Now |
| --- | --- | --- |
| `AbstractRandom._guidBytes` | protobuf-net's uninitialized allocation | allocated in `GenerateGuidBytes` |
| `IllusionFlow._payload` | the same, once the flag was added | allocated in `InternalState` |
| `SystemRandom._seedArray` | WallstopProto's `constructAtEnd` path (the field is `readonly`) **and** a payload omitting field 8 | `EnsureSeedArray()` at each entry point |
| `StormDropRandom._elements` | a payload omitting field 6 | `EnsureElements()` at each entry point |
| `PhotonSpinRandom._elements` | the same | `EnsureElements()` at each entry point |

`DotNetRandom` already did this -- `_random` has no initializer and `EnsureRandomInitialized()` rebuilds it from the serialized `_seed` -- and is the model the rest now follow.

An `[ProtoAfterDeserialization]` / `[WProtoAfterDeserialization]` hook was tried first and **reverted**: WallstopProto emits it, protobuf-net did not call it on these types, and the generators still threw. The guard at the point of use works under every allocator.

## "Not reachable by chance" was wrong

#492 argued the remaining generators' states were too wide to reach an all-default value by accident. Enumerating every public constructor invoked with zeros found **eight** generators that reach it from the most ordinary seed there is:

`new BlastCircuitRandom(0,0,0,0)`, `new FlurryBurstRandom(default)`, `new LinearCongruentialGenerator(0)`, `new SplitMix64(0)`, `new SquirrelRandom(0)`, `new WaveSplatRandom(0)`, `new WDoomRandom(0)`, `new WyRandom(0)`

Each serializes to a three-byte payload naming no member. They are also the fixture the new test uses, so it needs no reflection.

## `PcgRandom`'s dead stream

PCG adds its increment after multiplying, so a zero increment leaves the state where it was and every draw is identical -- measured `0,0,0,0` forever from a payload that could deliver one. `NextUint` now normalizes where it consumes, which is free: `NormalizeIncrement(x)` was already exactly `x | 1` written as a branch. Measured after: 31 distinct values in 32 draws.

## #491 -- answered, not closed

The open question was whether protobuf-net merges a sub-message into the seed an immutable (`constructAtEnd`) contract's constructor left on a `readonly` member. It does, and **both** oracle versions agree:

| | `Child.A` (constructor seeds 9; payload sets only `B`) |
| --- | --- |
| protobuf-net 3.2.56 | **9** -- merged |
| protobuf-net 2.4.9 | **9** -- merged |
| WallstopProto | 0 -- replaced |

So this package diverges for every immutable contract whose constructor fills in a sub-message. `SeededImmutableHolder` and `TheOracleMergesIntoAnImmutableContractsSeed` pin the oracle's answer. The package side is deliberately **not** asserted: closing the gap means seeding every read local from a constructed instance, which runs the author's constructor on every read of an immutable contract, across four member kinds and ~12 emission sites, and needs the shipped analyzer DLL rebuilt. That is #491's remaining work, and the issue now carries the measurement it asked for.

## Verification

- Live 6000.4.6f1 editor, all 17 generators, both readers: **0 failures of 17** on `NextGuid()` after a round trip, seeded-stream fidelity, `InternalState`, and zero-state liveness.
- `npm run typecheck:unity` + `typecheck:tests`, all six configurations (default, legacy define-off, Odin): 0 errors.
- `Generator~` differential suite: **420/420** against protobuf-net 3.2.56, **419/419** against 2.4.9.
- Unity Docker tests were **not** run: no license is configured in this container, so the MCP bridge to a licensed editor was the evidence path throughout. CI covers the Docker legs.

## Reviewer note

The three array guards (`StormDropRandom`, `PhotonSpinRandom`, `SystemRandom`) add a null-and-length check to `NextUint` / `Next`. They are reachable only from a payload that omits a member a writer always emits, so this is hardening rather than a live crash -- flagged explicitly in case the hot-path cost is judged not worth it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches save-game RNG state across both serializers and adds null checks on hot paths (`NextUint`/`Next`); behavior changes are intentional fixes but affect every restored generator after load.
> 
> **Overview**
> Fixes **save/load correctness** for serializable RNGs when protobuf-net (or `SkipConstructor`) allocates instances without running constructors or omits default-valued fields from the wire.
> 
> **`AbstractRandom`** lazily allocates the non-serialized `_guidBytes` scratch buffer in `GenerateGuidBytes`, so `NextGuid()` / `NextWGuid()` no longer throw after a protobuf-net round-trip. **`IllusionFlow`**, **`PcgRandom`**, **`RomuDuo`**, **`XorShiftRandom`**, and **`XoroShiroRandom`** gain **`SkipConstructor`** so an empty/default payload is not re-seeded from `Guid.NewGuid()` and replay diverges. **`SystemRandom`**, **`PhotonSpinRandom`**, and **`StormDropRandom`** add **`EnsureSeedArray` / `EnsureElements`** at use sites when serialized internal arrays are missing. **`PcgRandom`** normalizes a zero increment on each step so a restored dead stream cannot repeat forever.
> 
> Adds broad **proto round-trip tests** (WallstopProto and protobuf-net) for GUID generation, all-default states, and PCG increment edge cases; documents **initializer vs protobuf-net** pitfalls in serialization docs; pins protobuf-net **merge-into-readonly-seed** behavior for **#491** without changing WallstopProto yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c468b60f93cd555c5d199e78c21518a925d630fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->