### PR TITLE
ci(build-lock): pin the lock actions to v1.12.1 so a transient 503 stops reddening the matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,7 +348,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
@@ -394,7 +394,7 @@ jobs:
         id: release_unity_lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}

--- a/.github/workflows/runner-bootstrap.yml
+++ b/.github/workflows/runner-bootstrap.yml
@@ -105,7 +105,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require the selected Unity runner online
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -147,7 +147,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -270,7 +270,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -342,7 +342,7 @@ jobs:
         id: release_unity_lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -340,7 +340,7 @@ jobs:
 
       - name: Require an online Unity runner
         if: ${{ steps.credentials.outputs.present == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -392,7 +392,7 @@ jobs:
         include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include) }}
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -513,7 +513,7 @@ jobs:
 
       - name: Require current PR head before lock acquisition
         if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -522,7 +522,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -613,7 +613,7 @@ jobs:
         id: release_unity_lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -746,7 +746,7 @@ jobs:
         include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include-standalone) }}
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -867,7 +867,7 @@ jobs:
 
       - name: Require current PR head before lock acquisition
         if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -876,7 +876,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -959,7 +959,7 @@ jobs:
         id: release_unity_lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -1109,7 +1109,7 @@ jobs:
         include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include-single-threaded) }}
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1215,7 +1215,7 @@ jobs:
 
       - name: Require current PR head before lock acquisition
         if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1224,7 +1224,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1302,7 +1302,7 @@ jobs:
         id: release_unity_lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1401,7 +1401,7 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1426,7 +1426,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Require current PR head before lock acquisition
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1434,7 +1434,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
@@ -1482,7 +1482,7 @@ jobs:
         id: release_unity_lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}


### PR DESCRIPTION
Closes #483.

## Why

#483's own triage said this issue "stays open until a build-lock release contains
`954d123f`". That release now exists:
[**v1.12.1**](https://github.com/Ambiguous-Interactive/ambiguous-organization-build-lock/releases/tag/v1.12.1)
= `168b8dea`, published today. It carries three things, all of which could turn a
fully passing Unity matrix red on the final bookkeeping write:

| upstream | what it fixes |
| --- | --- |
| [#198](https://github.com/Ambiguous-Interactive/ambiguous-organization-build-lock/issues/198) / [#199](https://github.com/Ambiguous-Interactive/ambiguous-organization-build-lock/pull/199) | the release retry budget was attempt-bounded and gave up after ~15 s of a step allowed 5 minutes; it is now bounded by wall clock (default 120 s) |
| [#200](https://github.com/Ambiguous-Interactive/ambiguous-organization-build-lock/issues/200) | a `Retry-After` longer than 10 s was truncated to the backoff cap, so the lock retried *into* the throttle instead of after it |
| [#201](https://github.com/Ambiguous-Interactive/ambiguous-organization-build-lock/issues/201) | App token minting ran on a fixed three-attempt budget nested inside every call, and its exhaustion short-circuited the caller's budget entirely |

We were pinned to `v1.9.1` (`a00614a`), which has none of them.

Measured upstream against the released runtime, one lock-state `PUT` answered
`503` forever (requests made / total time spent waiting):

| Budget | No `Retry-After` | `Retry-After: 45` |
| --- | --- | --- |
| `v1.9.1` (attempt-bounded) | 5 / 17.5 s | 5 / 40 s, every retry inside the throttle window |
| `v1.12.1` (release deadline 120 s) | 16 / 120 s | 4 / 120 s, each retry after the window |

The first cell is the failure in #483: 15 seconds of retrying inside a
`timeout-minutes: 5` step.

## What changed

`acquire-build-lock`, `release-build-lock`, `check-unity-runner-availability` and
`require-current-pr-head` move from `a00614a` (v1.9.1) to `168b8dea` (v1.12.1).
No `with:` block changes: v1.12.1 adds only optional inputs, and this repository
uses none of the outputs it renamed.

`classify-unity-cleanup-evidence` and `require-confirmed-unity-cleanup` stay at
`673eb65e`. They must move together (`test-portable-cleanup-classifier.js`
resolves the classifier's expected pin from the gate's), and the newer classifier
requires a `return-log-digest` that `.github/actions/return-unity-license` does
not yet emit. That migration is **#498**, and it is why Dependabot **#489** cannot
merge as proposed. Nothing here needs it: the retry fix lives entirely in
`release-build-lock`, and the gate at `673eb65e` still fails closed on any
`cleanup-result` it does not recognise -- the correct outcome for a release that
was not recorded.

## Verification

Run locally against a checkout of the exact released commit:

```text
[validate-build-lock-action-inputs] OK: 31 call(s) across 5 file(s) match 6 pinned action version(s).
Central Unity cleanup policy parity passed (11 classifier cases, 9 gate cases).
[test-build-lock-action-input-parser] 17 assertions passed.
```

Supersedes #489, which lands one commit short of the fix on `release-build-lock`
and would fail this repository's own input-contract gate on the classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pin-only bump across CI workflows with unchanged inputs; affects lock/preflight reliability, not application code or secrets handling.
> 
> **Overview**
> Bumps **ambiguous-organization-build-lock** composite actions from **v1.9.1** (`a00614a`) to **v1.12.1** (`168b8dea`) across `release.yml`, `runner-bootstrap.yml`, `unity-benchmarks.yml`, and `unity-tests.yml`.
> 
> **Actions updated:** `acquire-build-lock`, `release-build-lock`, `check-unity-runner-availability`, and `require-current-pr-head`. No `with:` or env changes—v1.12.1 only adds optional inputs this repo does not use.
> 
> **Why:** v1.12.1 improves GitHub API retry behavior (wall-clock budgets, honoring `Retry-After`, nested app-token retries) so transient **503**s on lock release/bookkeeping are less likely to fail a green Unity matrix after tests pass.
> 
> **Unchanged:** `require-confirmed-unity-cleanup` and `classify-unity-cleanup-evidence` stay on `673eb65e` (separate migration in #498).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89fa844637cdf38a6832f427b52ab73db27af7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->