### PR TITLE
perf: harden pooled JSON reads and metamorphic coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Read cancellation-aware JSON files through a pooled scratch buffer and deserialize the pooled stream's valid segment directly. Large save files no longer allocate an extra full-payload copy before decoding ([#504](https://github.com/Ambiguous-Interactive/unity-helpers/issues/504)).
 - Speed up every pooled-buffer operation on blittable elements -- the sorts, `Shuffle`, `Fill` and the geometry helpers -- by clearing a returned array only when its element type can hold a reference. A reference element is still never left rooted in the pool ([#482](https://github.com/Ambiguous-Interactive/unity-helpers/issues/482)).
 - Speed up `ProtoSerialize`, `ProtoDeserialize`, `ProtoEquals` and `NextEnum` by resolving each one's type questions once per closed generic instead of on every call. Measured at 8.5x for that check alone on reference types ([#346](https://github.com/Ambiguous-Interactive/unity-helpers/issues/346)).
 - Every `IList<T>` sort now runs over an array rather than the list's indexer, so sorting a `T[]` is 2.5x to 5.4x faster and needs no copy. Any other list is copied through a pooled buffer and back. See [Where the Time Actually Goes](./docs/performance/ilist-sorting-performance.md#where-the-time-actually-goes) ([#463](https://github.com/Ambiguous-Interactive/unity-helpers/issues/463)).

--- a/Runtime/Core/Serialization/Serializer.cs
+++ b/Runtime/Core/Serialization/Serializer.cs
@@ -2413,6 +2413,21 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             JsonSerializerOptions options = null
         )
         {
+            return JsonDeserializeUtf8Slice<T>(data, data?.Length ?? 0, type, options);
+        }
+
+        /// <summary>
+        /// Deserializes the valid prefix of a UTF-8 buffer without copying it into an exact-sized
+        /// array. The caller must keep the buffer alive and exclusively owned until this method
+        /// returns.
+        /// </summary>
+        internal static T JsonDeserializeUtf8Slice<T>(
+            byte[] data,
+            int length,
+            Type type = null,
+            JsonSerializerOptions options = null
+        )
+        {
             if (data == null)
             {
                 SerializationFailureException.ThrowNullInput<T>(
@@ -2420,7 +2435,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                     SerializationOperation.Deserialize
                 );
             }
-            if (data.Length == 0)
+            if (length == 0)
             {
                 SerializationFailureException.ThrowEmptyInput<T>(
                     SerializationFormat.Json,
@@ -2430,7 +2445,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
             try
             {
-                ReadOnlySpan<byte> span = new(data);
+                ReadOnlySpan<byte> span = new(data, 0, length);
                 return (T)
                     JsonSerializer.Deserialize(
                         span,
@@ -2447,7 +2462,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                 SerializationFailureException.ThrowCorrupt<T>(
                     SerializationFormat.Json,
                     SerializationOperation.Deserialize,
-                    data.Length,
+                    length,
                     SerializationStage.Decode,
                     e,
                     "System.Text.Json rejected the payload."
@@ -3369,17 +3384,37 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                 4096,
                 useAsync: true
             );
+            return await ReadJsonStreamAsync<T>(fs, cancellationToken);
+        }
+
+        /// <summary>
+        /// Reads one UTF-8 JSON document from <paramref name="input"/> without materializing an
+        /// exact-sized copy of the pooled stream before decoding it.
+        /// </summary>
+        internal static async Task<T> ReadJsonStreamAsync<T>(
+            Stream input,
+            System.Threading.CancellationToken cancellationToken
+        )
+        {
             using Utils.PooledResource<PooledBufferStream> lease = PooledBufferStream.Rent(
                 out PooledBufferStream stream
             );
-            byte[] buffer = new byte[8192];
-            int read;
-            while ((read = await fs.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0)
+            using (
+                PooledArray<byte> bufferLease = SystemArrayPool<byte>.Get(8192, out byte[] buffer)
+            )
             {
-                stream.Write(buffer, 0, read);
+                int read;
+                while (
+                    (read = await input.ReadAsync(buffer, 0, bufferLease.length, cancellationToken))
+                    > 0
+                )
+                {
+                    stream.Write(buffer, 0, read);
+                }
             }
+            cancellationToken.ThrowIfCancellationRequested();
             ArraySegment<byte> seg = stream.GetWrittenSegment();
-            return JsonDeserialize<T>(seg.Array.AsSpan(0, seg.Count).ToArray());
+            return JsonDeserializeUtf8Slice<T>(seg.Array, seg.Count);
         }
 
         /// <summary>

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
@@ -6,6 +6,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
     using System;
     using System.Buffers;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Text;
     using System.Text.Json;
     using NUnit.Framework;
@@ -423,6 +424,63 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         }
 
         /// <summary>
+        /// Reordering object properties, escaping their names and adding insignificant whitespace
+        /// must not change the value a converter reads (#462).
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(Targets))]
+        public void EquivalentJsonSpellingsPreserveConverterValue(FuzzTarget target)
+        {
+            if (!target.ReadSupported)
+            {
+                return;
+            }
+
+            JsonSerializerOptions options = Serializer.CreateNormalJsonOptions();
+
+            foreach (string seed in target.Seeds)
+            {
+                using JsonDocument document = JsonDocument.Parse(seed);
+                string equivalent = BuildEquivalentJson(document.RootElement);
+                Assert.AreNotEqual(
+                    seed,
+                    equivalent,
+                    $"{target.Name}: the equivalent-spelling transform did not change {Abbreviate(seed)}."
+                );
+
+                using JsonDocument transformedDocument = JsonDocument.Parse(equivalent);
+                Assert.IsTrue(
+                    EquivalentStructureIsReversed(
+                        document.RootElement,
+                        transformedDocument.RootElement,
+                        out int propertyCount
+                    ),
+                    $"{target.Name}: property names must be case-insensitively unique and every object must be reversed in {Abbreviate(seed)}."
+                );
+                Assert.IsTrue(
+                    PropertyTokensUseOnlyUnicodeEscapes(equivalent, propertyCount),
+                    $"{target.Name}: at least one property name was not Unicode-escaped in {Abbreviate(equivalent)}."
+                );
+
+                object original = JsonSerializer.Deserialize(seed, target.Type, options);
+                object transformed = JsonSerializer.Deserialize(equivalent, target.Type, options);
+                string originalCanonical = JsonSerializer.Serialize(original, target.Type, options);
+                string transformedCanonical = JsonSerializer.Serialize(
+                    transformed,
+                    target.Type,
+                    options
+                );
+
+                Assert.AreEqual(
+                    originalCanonical,
+                    transformedCanonical,
+                    $"{target.Name}: equivalent JSON changed the decoded value. Original "
+                        + $"{Abbreviate(seed)}; transformed {Abbreviate(equivalent)}."
+                );
+            }
+        }
+
+        /// <summary>
         /// An empty <see cref="WGuid"/> is what an unset id serializes to, and it must load again.
         /// </summary>
         /// <remarks>
@@ -624,6 +682,228 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                     break;
             }
             return count;
+        }
+
+        private static bool EquivalentStructureIsReversed(
+            JsonElement original,
+            JsonElement transformed,
+            out int propertyCount
+        )
+        {
+            propertyCount = 0;
+            if (original.ValueKind != transformed.ValueKind)
+            {
+                return false;
+            }
+
+            switch (original.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    List<JsonProperty> originalProperties = new();
+                    List<JsonProperty> transformedProperties = new();
+                    foreach (JsonProperty property in original.EnumerateObject())
+                    {
+                        originalProperties.Add(property);
+                    }
+                    foreach (JsonProperty property in transformed.EnumerateObject())
+                    {
+                        transformedProperties.Add(property);
+                    }
+                    if (originalProperties.Count != transformedProperties.Count)
+                    {
+                        return false;
+                    }
+                    HashSet<string> names = new(StringComparer.OrdinalIgnoreCase);
+                    for (int index = 0; index < originalProperties.Count; index++)
+                    {
+                        if (!names.Add(originalProperties[index].Name))
+                        {
+                            return false;
+                        }
+                    }
+                    propertyCount += originalProperties.Count;
+                    for (int index = 0; index < originalProperties.Count; index++)
+                    {
+                        JsonProperty originalProperty = originalProperties[index];
+                        JsonProperty transformedProperty = transformedProperties[
+                            transformedProperties.Count - index - 1
+                        ];
+                        if (
+                            !string.Equals(
+                                originalProperty.Name,
+                                transformedProperty.Name,
+                                StringComparison.Ordinal
+                            )
+                            || !EquivalentStructureIsReversed(
+                                originalProperty.Value,
+                                transformedProperty.Value,
+                                out int nestedPropertyCount
+                            )
+                        )
+                        {
+                            return false;
+                        }
+                        propertyCount += nestedPropertyCount;
+                    }
+                    break;
+                case JsonValueKind.Array:
+                    List<JsonElement> originalItems = new();
+                    List<JsonElement> transformedItems = new();
+                    foreach (JsonElement item in original.EnumerateArray())
+                    {
+                        originalItems.Add(item);
+                    }
+                    foreach (JsonElement item in transformed.EnumerateArray())
+                    {
+                        transformedItems.Add(item);
+                    }
+                    if (originalItems.Count != transformedItems.Count)
+                    {
+                        return false;
+                    }
+                    for (int index = 0; index < originalItems.Count; index++)
+                    {
+                        if (
+                            !EquivalentStructureIsReversed(
+                                originalItems[index],
+                                transformedItems[index],
+                                out int nestedPropertyCount
+                            )
+                        )
+                        {
+                            return false;
+                        }
+                        propertyCount += nestedPropertyCount;
+                    }
+                    break;
+            }
+            return true;
+        }
+
+        private static bool PropertyTokensUseOnlyUnicodeEscapes(
+            string transformed,
+            int expectedPropertyCount
+        )
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(transformed);
+            Utf8JsonReader reader = new(utf8);
+            int propertyCount = 0;
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    continue;
+                }
+
+                propertyCount++;
+                ReadOnlySpan<byte> rawName = reader.ValueSpan;
+                if (rawName.Length == 0)
+                {
+                    continue;
+                }
+                if (rawName.Length % 6 != 0)
+                {
+                    return false;
+                }
+                for (int index = 0; index < rawName.Length; index += 6)
+                {
+                    if (rawName[index] != (byte)'\\' || rawName[index + 1] != (byte)'u')
+                    {
+                        return false;
+                    }
+                    for (int digit = 2; digit < 6; digit++)
+                    {
+                        byte value = rawName[index + digit];
+                        bool isHex =
+                            value is >= (byte)'0' and <= (byte)'9'
+                            || value is >= (byte)'a' and <= (byte)'f'
+                            || value is >= (byte)'A' and <= (byte)'F';
+                        if (!isHex)
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+            return propertyCount == expectedPropertyCount;
+        }
+
+        private static string BuildEquivalentJson(JsonElement root)
+        {
+            StringBuilder builder = new();
+            builder.Append('\n');
+            WriteEquivalentJson(builder, root, 0);
+            builder.Append('\n');
+            return builder.ToString();
+        }
+
+        private static void WriteEquivalentJson(
+            StringBuilder builder,
+            JsonElement element,
+            int depth
+        )
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    List<JsonProperty> properties = new();
+                    foreach (JsonProperty property in element.EnumerateObject())
+                    {
+                        properties.Add(property);
+                    }
+
+                    builder.Append('{');
+                    for (int index = properties.Count - 1; index >= 0; index--)
+                    {
+                        JsonProperty property = properties[index];
+                        builder.Append('\n').Append(' ', (depth + 1) * 2).Append('"');
+                        AppendEscapedPropertyName(builder, property.Name);
+                        builder.Append("\": ");
+                        WriteEquivalentJson(builder, property.Value, depth + 1);
+                        if (index > 0)
+                        {
+                            builder.Append(',');
+                        }
+                    }
+                    if (properties.Count > 0)
+                    {
+                        builder.Append('\n').Append(' ', depth * 2);
+                    }
+                    builder.Append('}');
+                    break;
+                case JsonValueKind.Array:
+                    builder.Append('[');
+                    int itemIndex = 0;
+                    foreach (JsonElement item in element.EnumerateArray())
+                    {
+                        if (itemIndex > 0)
+                        {
+                            builder.Append(',');
+                        }
+                        builder.Append('\n').Append(' ', (depth + 1) * 2);
+                        WriteEquivalentJson(builder, item, depth + 1);
+                        itemIndex++;
+                    }
+                    if (itemIndex > 0)
+                    {
+                        builder.Append('\n').Append(' ', depth * 2);
+                    }
+                    builder.Append(']');
+                    break;
+                default:
+                    builder.Append(element.GetRawText());
+                    break;
+            }
+        }
+
+        private static void AppendEscapedPropertyName(StringBuilder builder, string name)
+        {
+            for (int index = 0; index < name.Length; index++)
+            {
+                builder
+                    .Append("\\u")
+                    .Append(((int)name[index]).ToString("x4", CultureInfo.InvariantCulture));
+            }
         }
 
         private static string Rebuild(JsonElement root, Mutation mutation)

--- a/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
+++ b/Tests/Runtime/Serialization/JsonConverterFuzzTests.cs
@@ -437,9 +437,21 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             }
 
             JsonSerializerOptions options = Serializer.CreateNormalJsonOptions();
+            int acceptedSeedCount = 0;
 
             foreach (string seed in target.Seeds)
             {
+                object original = null;
+                bool originalAccepted = true;
+                try
+                {
+                    original = JsonSerializer.Deserialize(seed, target.Type, options);
+                }
+                catch (JsonException)
+                {
+                    originalAccepted = false;
+                }
+
                 using JsonDocument document = JsonDocument.Parse(seed);
                 string equivalent = BuildEquivalentJson(document.RootElement);
                 Assert.AreNotEqual(
@@ -462,7 +474,17 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                     $"{target.Name}: at least one property name was not Unicode-escaped in {Abbreviate(equivalent)}."
                 );
 
-                object original = JsonSerializer.Deserialize(seed, target.Type, options);
+                if (!originalAccepted)
+                {
+                    Assert.Throws<JsonException>(
+                        () => JsonSerializer.Deserialize(equivalent, target.Type, options),
+                        $"{target.Name}: equivalent spelling changed a rejected payload into an accepted value. "
+                            + $"Original {Abbreviate(seed)}; transformed {Abbreviate(equivalent)}."
+                    );
+                    continue;
+                }
+
+                acceptedSeedCount++;
                 object transformed = JsonSerializer.Deserialize(equivalent, target.Type, options);
                 string originalCanonical = JsonSerializer.Serialize(original, target.Type, options);
                 string transformedCanonical = JsonSerializer.Serialize(
@@ -478,6 +500,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                         + $"{Abbreviate(seed)}; transformed {Abbreviate(equivalent)}."
                 );
             }
+
+            Assert.Positive(
+                acceptedSeedCount,
+                $"{target.Name}: no accepted seed exercised the metamorphic equivalence oracle."
+            );
         }
 
         /// <summary>
@@ -1255,8 +1282,9 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             private string[] _seeds;
 
             /// <param name="alternateSeeds">
-            /// Shapes a converter accepts that it never writes -- a legacy encoding, or a second
-            /// object form. Mutating only the converter's own output leaves those branches unvisited.
+            /// Shapes that reach branches a converter's own output does not -- accepted legacy
+            /// encodings and well-formed probes that validation may reject. Mutating only the
+            /// converter's own output leaves those branches unvisited.
             /// </param>
             public FuzzTarget(Type type, object seed, params string[] alternateSeeds)
             {

--- a/Tests/Runtime/Serialization/JsonSerializationCorrectnessTests.cs
+++ b/Tests/Runtime/Serialization/JsonSerializationCorrectnessTests.cs
@@ -79,6 +79,28 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         }
 
         [Test]
+        public void Utf8SliceDeserializeIgnoresBytesOutsideDeclaredLength()
+        {
+            byte[] paddedJson =
+            {
+                (byte)'{',
+                (byte)'"',
+                (byte)'I',
+                (byte)'d',
+                (byte)'"',
+                (byte)':',
+                (byte)'7',
+                (byte)'}',
+                (byte)'x',
+            };
+
+            SimpleMessage value = Serializer.JsonDeserializeUtf8Slice<SimpleMessage>(paddedJson, 8);
+
+            Assert.NotNull(value);
+            Assert.AreEqual(7, value.Id);
+        }
+
+        [Test]
         public void RoundTripNullValues()
         {
             SimpleMessage msg = new()

--- a/Tests/Runtime/Serialization/SerializerFileIoTests.cs
+++ b/Tests/Runtime/Serialization/SerializerFileIoTests.cs
@@ -3,13 +3,18 @@
 
 namespace WallstopStudios.UnityHelpers.Tests.Serialization
 {
+    using System;
+    using System.Collections;
     using System.IO;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using UnityEngine;
+    using UnityEngine.TestTools;
     using WallstopStudios.UnityHelpers.Core.Serialization;
     using WallstopStudios.UnityHelpers.Tests.Core;
+    using WallstopStudios.UnityHelpers.Tests.TestUtils;
 
     [TestFixture]
     [NUnit.Framework.Category("Slow")]
@@ -48,6 +53,40 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         {
             public int a;
             public string b;
+        }
+
+        /// <summary>
+        /// Makes the allocation test's same-thread completion contract explicit and can cancel
+        /// precisely after EOF, after at least one chunk has already been consumed.
+        /// </summary>
+        private sealed class InlineReadStream : MemoryStream
+        {
+            private readonly CancellationTokenSource _cancelWhenExhausted;
+
+            public InlineReadStream(
+                byte[] buffer,
+                CancellationTokenSource cancelWhenExhausted = null
+            )
+                : base(buffer, writable: false)
+            {
+                _cancelWhenExhausted = cancelWhenExhausted;
+            }
+
+            public override Task<int> ReadAsync(
+                byte[] buffer,
+                int offset,
+                int count,
+                CancellationToken cancellationToken
+            )
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int read = Read(buffer, offset, count);
+                if (read == 0)
+                {
+                    _cancelWhenExhausted?.Cancel();
+                }
+                return Task.FromResult(read);
+            }
         }
 
         [Test]
@@ -92,6 +131,154 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                     .GetAwaiter()
                     .GetResult()
             );
+        }
+
+        [UnityTest]
+        public IEnumerator CancellationAwareReadHandlesPayloadLargerThanScratchBuffer()
+        {
+            string path = Path.Combine(_dir, "large-sample.json");
+            string expected = new('x', 20_000);
+            Serializer.WriteToJsonFile(new Sample { a = 17, b = expected }, path, pretty: false);
+
+            Task<Sample> readerTask = Serializer.ReadFromJsonFileAsync<Sample>(
+                path,
+                CancellationToken.None
+            );
+            while (!readerTask.IsCompleted)
+            {
+                yield return null;
+            }
+
+            Sample loaded = readerTask.Result;
+
+            Assert.NotNull(loaded);
+            Assert.AreEqual(17, loaded.a);
+            Assert.AreEqual(expected, loaded.b);
+        }
+
+        [Test]
+        public void CancellationAwareReadDoesNotAllocatePayloadSizedCopy()
+        {
+            const int whitespaceBytes = 256 * 1024;
+            const int measuredIterations = 3;
+            byte[] compactJson = Encoding.UTF8.GetBytes("{\"a\":17}");
+            byte[] paddedJson = new byte[whitespaceBytes + compactJson.Length];
+            for (int index = 0; index < whitespaceBytes; index++)
+            {
+                paddedJson[index] = (byte)' ';
+            }
+            Buffer.BlockCopy(compactJson, 0, paddedJson, whitespaceBytes, compactJson.Length);
+            using InlineReadStream compactStream = new(compactJson);
+            using InlineReadStream paddedStream = new(paddedJson);
+            Sample result = null;
+
+            GCAssert.IgnoreIfAllocationMeasurementUnavailable();
+            long calibrationBefore = GC.GetAllocatedBytesForCurrentThread();
+            byte[] forcedPayloadSizedAllocation = new byte[whitespaceBytes];
+            long calibrationBytes = GC.GetAllocatedBytesForCurrentThread() - calibrationBefore;
+            GC.KeepAlive(forcedPayloadSizedAllocation);
+            if (calibrationBytes < whitespaceBytes)
+            {
+                Assert.Inconclusive(
+                    $"The runtime reported only {calibrationBytes} bytes for a known "
+                        + $"{whitespaceBytes}-byte allocation, so its per-thread allocation "
+                        + "counter cannot prove that the JSON read avoided a payload-sized copy."
+                );
+            }
+
+            long compactAllocation = GCAssert.MeasureAllocatedBytes(
+                () =>
+                {
+                    compactStream.Position = 0;
+                    result = Serializer
+                        .ReadJsonStreamAsync<Sample>(compactStream, CancellationToken.None)
+                        .ConfigureAwait(false)
+                        .GetAwaiter()
+                        .GetResult();
+                },
+                measuredIterations: measuredIterations
+            );
+            long paddedAllocation = GCAssert.MeasureAllocatedBytes(
+                () =>
+                {
+                    paddedStream.Position = 0;
+                    result = Serializer
+                        .ReadJsonStreamAsync<Sample>(paddedStream, CancellationToken.None)
+                        .ConfigureAwait(false)
+                        .GetAwaiter()
+                        .GetResult();
+                },
+                measuredIterations: measuredIterations
+            );
+
+            Assert.NotNull(result);
+            Assert.AreEqual(17, result.a);
+            Assert.LessOrEqual(
+                paddedAllocation,
+                compactAllocation + 64 * 1024,
+                $"A {paddedJson.Length}-byte JSON document allocated {paddedAllocation} bytes "
+                    + $"versus {compactAllocation} for the same compact value. The file-read path "
+                    + "must not materialize an exact payload-sized copy before decoding."
+            );
+        }
+
+        [Test]
+        public void CancellationAfterPartialReadBeforeDecodeIsObserved()
+        {
+            byte[] compactJson = Encoding.UTF8.GetBytes("{\"a\":17}");
+            byte[] paddedJson = new byte[20_000 + compactJson.Length];
+            for (int index = 0; index < 20_000; index++)
+            {
+                paddedJson[index] = (byte)' ';
+            }
+            Buffer.BlockCopy(compactJson, 0, paddedJson, 20_000, compactJson.Length);
+            using CancellationTokenSource cts = new();
+            using InlineReadStream stream = new(paddedJson, cts);
+
+            Assert.Throws<OperationCanceledException>(() =>
+                Serializer
+                    .ReadJsonStreamAsync<Sample>(stream, cts.Token)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult()
+            );
+        }
+
+        [UnityTest]
+        public IEnumerator MalformedLargeReadWrapsFailureAndAllowsSubsequentRead()
+        {
+            string path = Path.Combine(_dir, "malformed-large.json");
+            File.WriteAllText(path, new string(' ', 20_000) + "{\"a\":");
+
+            Task<Sample> malformedTask = Serializer.ReadFromJsonFileAsync<Sample>(
+                path,
+                CancellationToken.None
+            );
+            while (!malformedTask.IsCompleted)
+            {
+                yield return null;
+            }
+
+            Assert.IsTrue(malformedTask.IsFaulted);
+            Assert.IsInstanceOf<SerializationCorruptDataException>(
+                malformedTask.Exception?.GetBaseException()
+            );
+
+            Serializer.WriteToJsonFile(new Sample { a = 23, b = "after-failure" }, path);
+            Task<Sample> validTask = Serializer.ReadFromJsonFileAsync<Sample>(
+                path,
+                CancellationToken.None
+            );
+            while (!validTask.IsCompleted)
+            {
+                yield return null;
+            }
+
+            Sample loaded = validTask.Result;
+
+            Assert.NotNull(loaded);
+            Assert.AreEqual(23, loaded.a);
+            Assert.AreEqual("after-failure", loaded.b);
         }
 
         [Test]

--- a/docs/features/serialization/serialization.md
+++ b/docs/features/serialization/serialization.md
@@ -183,6 +183,10 @@ SaveData data = await Serializer.ReadFromJsonFileAsync<SaveData>("save.json", ct
 await Serializer.WriteToJsonFileAsync(data, "save.json", pretty: true, cts.Token);
 ```
 
+The cancellation-aware reader rents its file scratch buffer and decodes the valid bytes in its
+pooled stream directly. It does not allocate an exact-sized copy of the complete file before JSON
+decoding, removing one payload-sized managed allocation and copy from large-save loads.
+
 **When to use async:**
 
 - Loading screens where you don't want to block the main thread


### PR DESCRIPTION
## Summary

- remove the cancellation-aware JSON file reader's exact payload-sized copy by decoding the valid prefix of its pooled stream backing
- pool the 8 KiB file scratch buffer, preserve Unity synchronization-context behavior, and add a final cancellation checkpoint before decode
- add deterministic metamorphic JSON converter coverage for reversed property order, Unicode-escaped property names, and insignificant whitespace
- document the user-visible allocation change

## Seven-issue audit

This session fully paginated all 36 open issues and selected seven using risk/feasibility-weighted gameplay impact.

- #504: implements the safe remaining JSON read allocation improvement. The caller-owned output-buffer rewrite was rejected because it would weaken transactional failure semantics.
- #462: adds the genuinely missing legal-equivalence JSON transformation. Existing malformed/random fuzz coverage was not duplicated; schema-aware protobuf metamorphic work remains.
- #343: fallback removal remains gated on publishing and observing one hybrid WallstopProto release; 3.5.1 predates WallstopProto.
- #399: four of six asks are already covered; the unbounded stdlib inventory and external repository survey must be split into countable, authorized scopes.
- #286: research identified TestU01 endianness/statistical-gating blockers and PractRand build/provenance requirements before scheduled workflow code is safe.
- #309: a DxMessaging-style integer map is not transferable without integrated IL2CPP evidence; direct-index DisjointSet cleanup is the proper first control.
- #505: measured pre-push itself at ~1.5 s, test lint at ~94 s, and EOL at ~12 s; naive parallelism worsened the run and introduced a race, so the exact fast-suite contract must be defined first.

None of these issues is auto-closed by this partial-progress PR.

## Verification

- `npm run typecheck:tests` — default, legacy protobuf-net, and Odin variants pass; six pre-existing WPROTO028 warnings
- `npm run lint:tests` — pass; 72 pre-existing performance advisories
- `npm run agent:preflight` — pass
- `npm run validate:prepush` — pass
- `git diff --check` — pass
- adversarial review loops for #504 and #462 — zero remaining findings

Unity MCP was available but attached to `D:/Code/Packages`, not this Linux checkout. The repository Docker Unity wrappers also stopped before project work because no usable Unity license artifact is available here. The licensed PR matrix is therefore the authoritative Unity runtime validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the save-file JSON load path and cancellation-before-decode behavior. Coverage is strong, but a slice-length or pooling bug would corrupt or leak large loads.
> 
> **Overview**
> Cancellation-aware JSON file reads no longer copy the full payload into a tight array before decode. `ReadFromJsonFileAsync` rents an 8 KiB scratch buffer, writes into a pooled stream, checks cancellation after EOF, and deserializes only the valid prefix via new `JsonDeserializeUtf8Slice`.
> 
> Public `JsonDeserialize(byte[])` now shares that slice path. Large saves drop one payload-sized allocation and copy.
> 
> Tests pin slice length, allocation vs compact JSON, cancellation after a partial read, and recovery after a malformed large file. Converter fuzz also asserts that reversed properties, Unicode-escaped names, and extra whitespace decode to the same value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c355111e24810457289fecc71d50557c835df0bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->