### PR TITLE
Keep a buffed attribute's value across a save

### DIFF
--- a/.llm/references/forbidden-patterns.md
+++ b/.llm/references/forbidden-patterns.md
@@ -74,12 +74,18 @@ for (int i = 0; i < source.Length; i++)
 
 ## Collection Iteration
 
-| Forbidden                      | Use Instead                            | Reason                      |
-| ------------------------------ | -------------------------------------- | --------------------------- |
-| `foreach` on `List<T>` (Mono)  | `for (int i = 0; i < list.Count; i++)` | Boxes enumerator (24 bytes) |
-| `foreach` on `Dictionary<K,V>` | Use struct enumerator directly         | Boxes enumerator            |
-| `foreach` on `HashSet<T>`      | Use struct enumerator directly         | Boxes enumerator            |
-| `foreach` on arrays            | OK (optimized by compiler)             | No allocation               |
+| Forbidden                             | Use Instead                        | Reason                      |
+| ------------------------------------- | ---------------------------------- | --------------------------- |
+| Forbidden                             | Use Instead                        | Reason                      |
+| ------------------------------------- | ---------------------------------- | --------------------------- |
+| `foreach` over `IEnumerable<T>`       | Iterate the concrete type          | Boxes enumerator (24 bytes) |
+| `foreach` over `IList<T>` / `ISet<T>` | Iterate the concrete type          | Boxes enumerator (24 bytes) |
+| A field or parameter typed `IList<T>` | Type it `List<T>` where you own it | The boxing is at the TYPE   |
+
+`foreach` over a **concrete** `List<T>`, `Dictionary<K,V>`, `HashSet<T>` or array does **not**
+allocate: the C# compiler binds to the type's own struct enumerator by duck typing. Measured on `6000.4.6f1`, 2,000,000 iterations, against a known allocator that moved the counter by 54.7 MB: `foreach` over a concrete `List<T>` allocates **24,576 bytes** -- the same as a `for` indexer loop, and the same as doing nothing. The identical loop over the same list typed as `IEnumerable<T>` allocates **5,709,824 bytes**.
+Do not rewrite a concrete `foreach` into a `for` loop for allocation reasons -- there is nothing to
+save, and the indexer form does not work on the non-indexable collections.
 
 ### Struct Enumerator Pattern
 

--- a/.llm/skills/avoid-allocations.md
+++ b/.llm/skills/avoid-allocations.md
@@ -137,39 +137,40 @@ Mathf.Max(Mathf.Max(a, b), c);
 
 ## Foreach Boxing on Collections
 
-Unity's old Mono compiler boxes enumerators for `List<T>` (24 bytes per loop). Arrays are optimized but Lists are not:
+The boxing is decided by the **static type being iterated**, not by `foreach`. A concrete collection
+exposes a struct enumerator and allocates nothing; an interface-typed reference forces
+`IEnumerator<T>`, which is boxed once per loop.
 
 ```csharp
-// ❌ BAD: Allocates 24 bytes on List<T>
-foreach (var item in myList) { }
+// ❌ BAD: 24 bytes per loop -- the interface forces IEnumerator<T>
+IReadOnlyList<Item> items = _items;
+foreach (Item item in items) { }
 
-// ✅ GOOD: Zero allocation
-for (int i = 0; i < myList.Count; i++)
-{
-    var item = myList[i];
-}
-
-// Note: foreach on arrays is OK (Mono optimizes this)
-foreach (var item in myArray) { }  // Zero allocation
+// ✅ GOOD: zero allocation on List<T>, Dictionary<K,V>, HashSet<T> and arrays alike
+foreach (Item item in _items) { }
 ```
 
-**For non-indexable collections (HashSet, Dictionary):**
+Measured on `6000.4.6f1`, 2,000,000 iterations, against a known allocator that moved the counter by
+54.7 MB: `List<T>` 24,576 bytes, a `for` indexer loop 24,576, `Dictionary<K,V>` 20,480, `int[]`
+12,288 -- one noise band -- against **5,709,824** for the same list typed as `IEnumerable<T>`.
+
+**Taking the enumerator by hand saves nothing**, because `foreach` over a concrete collection already
+compiles to exactly that. Measured over 2,000,000 iterations: `list.GetEnumerator()` in a `while`
+loop cost 20,480 bytes against `foreach`'s 24,576 -- the same noise band. Write the `foreach`.
+
+The hand-rolled form is still correct where you genuinely need the enumerator as a value (resuming
+it, passing it, interleaving two of them). If you write one, dispose it with `using` rather than an
+explicit call:
 
 ```csharp
-// ✅ Use struct enumerator with using statement
-using (HashSet<T>.Enumerator enumerator = hashSet.GetEnumerator())
+// A hand-held struct enumerator is disposed by `using`, never by an explicit Dispose().
+using (Dictionary<K, V>.Enumerator enumerator = dict.GetEnumerator())
 {
     while (enumerator.MoveNext())
     {
-        T element = enumerator.Current;
-        // process
+        KeyValuePair<K, V> entry = enumerator.Current;
     }
 }
-
-// ❌ NEVER use explicit Dispose - always use 'using' statement
-Dictionary<K, V>.Enumerator enumerator = dict.GetEnumerator();
-while (enumerator.MoveNext()) { }
-enumerator.Dispose();  // BAD - use 'using' instead!
 ```
 
 **IMPORTANT**: Always use `using` statements for struct enumerators, never explicit `Dispose()` calls. The `using` statement:
@@ -430,7 +431,7 @@ Before submitting code, verify:
 - [ ] No closures capturing variables in hot paths
 - [ ] No delegate assignments inside loops
 - [ ] No `params` method calls in loops (chain 2-arg overloads)
-- [ ] `foreach` uses `for` loop for `List<T>` in hot paths
+- [ ] Hot-path loops iterate the concrete collection, not an `IEnumerable<T>`/`IList<T>` reference
 - [ ] Structs implement `IEquatable<T>`
 - [ ] Enum dictionary keys use custom comparer or cast to int
 - [ ] Hash codes use `Objects.HashCode()`, not hand-rolled

--- a/.llm/skills/bash-pwsh-invocation.md
+++ b/.llm/skills/bash-pwsh-invocation.md
@@ -178,6 +178,61 @@ The rationale is required — the marker without an explanation is a maintenance
 
 ---
 
+## `Start-Process -ArgumentList` joins an array without quoting
+
+`Start-Process -FilePath pwsh -ArgumentList @('-NoProfile', '-File', $path)` concatenates the array
+with spaces and **adds no quoting**. A `$path` containing a space is split into separate arguments.
+
+The failure is not a clean error. Measured on this devcontainer with a fixture under
+`.../dir with space/probe.ps1`:
+
+```text
+exit   = 64
+stderr = The argument '/tmp/.../scratchpad/dir' is not recognized as the name of a script file.
+stdout = Usage: pwsh[.exe] [-Login] [[-File] <filePath> [args]] ...
+```
+
+**A non-zero exit and a usage banner.** Any caller asserting "the child failed" is satisfied by that,
+so a test harness reports green having launched nothing — the
+[#556](https://github.com/Ambiguous-Interactive/unity-helpers/issues/556) shape, found by Bugbot on
+PR #571 in a gate written for #556.
+
+Use `ProcessStartInfo.ArgumentList`, which escapes each argument individually:
+
+```powershell
+$startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+$startInfo.FileName = 'pwsh'
+foreach ($argument in $argumentList) { [void]$startInfo.ArgumentList.Add($argument) }
+$startInfo.WorkingDirectory = $workingDirectory
+$startInfo.RedirectStandardOutput = $true
+$startInfo.RedirectStandardError = $true
+$startInfo.UseShellExecute = $false
+$process = [System.Diagnostics.Process]::Start($startInfo)
+# Drain BOTH streams from the moment it starts, or a full pipe deadlocks against WaitForExit.
+$standardOutput = $process.StandardOutput.ReadToEndAsync()
+$standardError = $process.StandardError.ReadToEndAsync()
+$process.WaitForExit()
+```
+
+Two caveats before converting a call site:
+
+- **`Start-Process -Wait` is not `Process.WaitForExit()`.** `-Wait` also waits on descendants, which
+  matters for an installer that hands off to a child. `scripts/unity/bootstrap-windows-runner.ps1`
+  is deliberately left on `Start-Process` for that reason, and because every caller passes fixed
+  switches (`/q`, `/install`, `/quiet`, `/norestart`) with no space to truncate.
+- **A test whose fixtures live under a spaceless path cannot see this.** Put the space in the
+  fixture root so the regression cannot come back quietly:
+  `Join-Path $tempBase "my-test $(Get-Random)"`. Reverting the launch mechanism under that root
+  reddens six of nine scenarios in `test-validate-lint-error-codes.ps1`; the two that stay green are
+  the ones asserting only a non-zero exit.
+
+**Not currently linted.** `PWS006` is the obvious home and is filed as
+[#572](https://github.com/Ambiguous-Interactive/unity-helpers/issues/572); until it exists this rule
+is documentation. The repository has exactly **two** tracked `Start-Process -ArgumentList` sites --
+`scripts/tests/test-validate-lint-error-codes.ps1`, which no longer uses it, and the installer
+above -- so check with `git ls-files` rather than a working-tree grep: `scripts/run-unity*` is
+gitignored, and an untracked local copy is not a call site this repository ships.
+
 ## Quick Reference
 
 | Context                     | Correct form                                                                                                              |

--- a/.llm/skills/high-performance-csharp.md
+++ b/.llm/skills/high-performance-csharp.md
@@ -221,7 +221,7 @@ private static readonly Color HighlightColor = new Color(0.3f, 0.6f, 1f);
 | `new List<T>()`                      | Heap allocation                 | `Buffers<T>.List.Get()`             |
 | Lambda capturing locals              | Closure allocation              | Static lambda or explicit loop      |
 | Boxing (`object x = struct`)         | Heap allocation                 | Generic methods                     |
-| `foreach` on `List<T>` (Mono)        | Enumerator boxing (24 bytes)    | `for` with indexer                  |
+| `foreach` through an INTERFACE       | Enumerator boxing (24 bytes)    | Iterate the concrete type           |
 | `params` methods                     | Array allocation per call       | Chain 2-arg overloads               |
 | Reflection                           | Slow, fragile, uncached         | Direct access, interfaces, generics |
 | Hand-rolled hash codes (`* 31`, XOR) | Inconsistent, non-deterministic | `Objects.HashCode()`                |

--- a/.llm/skills/memory-allocation-traps.md
+++ b/.llm/skills/memory-allocation-traps.md
@@ -10,7 +10,7 @@
 
 | Trap                           | Bytes Per Occurrence | Risk Level |
 | ------------------------------ | -------------------- | ---------- |
-| `foreach` on `List<T>` (Mono)  | 24 bytes             | 🔴 High    |
+| `foreach` through an interface | 24 bytes             | 🔴 High    |
 | LINQ `.Where()`                | 32+ bytes            | 🔴 High    |
 | LINQ `.Select()`               | 32+ bytes            | 🔴 High    |
 | Closure capturing local        | 32+ bytes            | 🔴 High    |
@@ -23,47 +23,44 @@
 
 ---
 
-## Trap 1: foreach on List<T> (Mono)
+## Trap 1: foreach through an interface
 
-Unity's Mono compiler boxes the `List<T>` enumerator, allocating 24 bytes per loop:
-
-```csharp
-// ❌ BAD: Allocates 24 bytes
-foreach (var item in myList)
-{
-    Process(item);
-}
-
-// ✅ GOOD: Zero allocation
-for (int i = 0; i < myList.Count; i++)
-{
-    Process(myList[i]);
-}
-```
-
-**Note**: `foreach` on arrays is optimized and does NOT allocate.
+The boxing is decided by the **static type you iterate**, not by `foreach`. `foreach` binds to
+whatever `GetEnumerator()` the type exposes; on a concrete collection that is a struct and nothing is
+allocated, and through an interface it is `IEnumerator<T>`, which is boxed once per loop.
 
 ```csharp
-// ✅ OK: Arrays are optimized
-foreach (var item in myArray)  // Zero allocation
-{
-    Process(item);
-}
+// ❌ BAD: 24 bytes per loop -- the interface forces IEnumerator<T>
+IReadOnlyList<Item> items = _items;
+foreach (Item item in items) { Process(item); }
+
+// ✅ GOOD: zero allocation -- List<T>.Enumerator is a struct
+foreach (Item item in _items) { Process(item); }
 ```
 
-### Non-Indexable Collections (HashSet, Dictionary)
+Measured on `6000.4.6f1`, 2,000,000 iterations over a 4-element list, against a known allocator that
+moved the counter by 54.7 MB:
 
-```csharp
-// ❌ BAD: foreach allocates enumerator
-foreach (var item in hashSet) { }
+| iterated as                    | bytes         |
+| ------------------------------ | ------------- |
+| `int[]`                        | 12,288        |
+| `List<T>`                      | 24,576        |
+| `for` with indexer             | 24,576        |
+| `list.GetEnumerator()` by hand | 20,480        |
+| `Dictionary<K,V>`              | 20,480        |
+| `Dictionary<K,V>.Values`       | 16,384        |
+| **`IEnumerable<T>`**           | **5,709,824** |
 
-// ✅ GOOD: Use struct enumerator directly
-var enumerator = hashSet.GetEnumerator();
-while (enumerator.MoveNext())
-{
-    var element = enumerator.Current;
-}
-```
+Everything concrete is one noise band; only the interface allocates. Two consequences:
+
+- **Do not rewrite a concrete `foreach` into a `for` loop to save allocation.** There is none to
+  save, `for` does not work on `HashSet`/`Dictionary`, and the indexer form is harder to read.
+- **Taking the enumerator by hand is a no-op.** It measured 20,480 bytes against `foreach`'s 24,576 --
+  the same band, because `foreach` already does exactly that.
+
+The rule to apply instead is about **types**: a field, parameter or local typed `IEnumerable<T>` /
+`IList<T>` / `IReadOnlyList<T>` allocates on every iteration of it. Where you own the declaration and
+the hot path iterates it, declare the concrete type.
 
 ---
 

--- a/.llm/skills/refactor-to-zero-alloc.md
+++ b/.llm/skills/refactor-to-zero-alloc.md
@@ -35,7 +35,7 @@ Follow these steps in order:
 5. **Apply StringBuilder patterns** - Replace string concatenation (see [use-pooling](./use-pooling.md#stringbuilder-pooling))
 6. **Use array pools** - Replace `new T[]` (see [use-array-pool](./use-array-pool.md))
 7. **Fix struct equality** - Implement `IEquatable<T>` (see [avoid-allocations](./avoid-allocations.md#implement-iequatablet-to-avoid-boxing))
-8. **Address foreach boxing** - Replace `foreach` on `List<T>` with `for` loops
+8. **Address foreach boxing** - Iterate the concrete collection, not an interface-typed reference to it
 
 ---
 
@@ -76,7 +76,7 @@ Use this matrix to decide when to use structs vs classes:
 | String operations   | String allocation   | `string.Format`, `$"..."`, `+` in loops                              |
 | Array creation      | Heap allocation     | `new T[`, `new byte[`, `new int[`                                    |
 | Boxing              | Box allocation      | Struct assigned to `object`, non-generic interfaces                  |
-| foreach on List     | Enumerator boxing   | `foreach` on `List<T>` (Mono compiler)                               |
+| Interface iteration | Enumerator boxing   | `foreach` over `IEnumerable<T>` / `IList<T>` / `IReadOnlyList<T>`    |
 | params methods      | Array allocation    | Method calls with `params` parameters                                |
 | Enum dictionary     | Boxing per lookup   | `Dictionary<MyEnum, T>` without custom comparer                      |
 
@@ -88,7 +88,7 @@ For detailed trap descriptions, see [memory-allocation-traps](./memory-allocatio
 LINQ:       \.Where\(|\.Select\(|\.Any\(|\.First\(|\.ToList\(|\.ToArray\(
 Collections: new List<|new Dictionary<|new HashSet<
 Closures:   => .*[^static]
-foreach:    foreach.*List<
+foreach:    foreach\s*\([^)]*\bin\s+\w*([Ii]Enumerable|IList|IReadOnlyList|ISet)
 ```
 
 ---
@@ -106,7 +106,7 @@ Once allocations are identified, apply the appropriate pattern from these skills
 | String concatenation | [use-pooling](./use-pooling.md#stringbuilder-pooling)                             |
 | Boxing (IEquatable)  | [avoid-allocations](./avoid-allocations.md#implement-iequatablet-to-avoid-boxing) |
 | Enum dictionary keys | [avoid-allocations](./avoid-allocations.md#enum-dictionary-keys-cause-boxing)     |
-| foreach on List      | [avoid-allocations](./avoid-allocations.md#foreach-boxing-on-collections)         |
+| Interface iteration  | [avoid-allocations](./avoid-allocations.md#foreach-boxing-on-collections)         |
 
 ---
 

--- a/.llm/skills/unity-devcontainer-testing.md
+++ b/.llm/skills/unity-devcontainer-testing.md
@@ -212,6 +212,20 @@ limit ([#568](https://github.com/Ambiguous-Interactive/unity-helpers/issues/568)
 
 ## Limitations
 
+- **The editmode legs run 26 of the 33 test assemblies, and no editor version changes that.** Unity's
+  EditMode runner takes only assemblies flagged `EditorAssembly` -- an asmdef with
+  `"includePlatforms": ["Editor"]`. `WallstopStudios.UnityHelpers.Tests.Runtime` and its six
+  platform-neutral siblings are not, so **their fixtures run in playmode only**, whatever
+  `.github/unity-versions.json` says and whatever the editmode leg is handed. Measured on
+  `6000.4.6f1` with `CompilationPipeline.GetAssemblies(AssembliesType.Editor)`.
+
+  The consequence is a coverage hole with a specific shape: a `Runtime/` branch that only executes
+  with `Application.isPlaying` **false** has no CI coverage at all unless a `Tests/Editor/**` fixture
+  reaches it. That shipped one bug -- `Attribute.CurrentValue` discarded its cache on exactly that
+  branch, so a deserialized buff was dropped in the editor and every leg was green
+  ([#569](https://github.com/Ambiguous-Interactive/unity-helpers/issues/569)). When a change touches
+  an edit-mode branch of runtime code, the fixture belongs in an editor-only assembly.
+
 - `WaitForEndOfFrame` does not work in batch mode (PlayMode tests)
 - Xvfb provides 0 Hz virtual display - frame timing may differ from real editor
 - First run is slow (Docker image pull ~3-4 GB); subsequent runs use cached image

--- a/.llm/skills/unity-mcp-fixture-runner.md
+++ b/.llm/skills/unity-mcp-fixture-runner.md
@@ -219,3 +219,25 @@ moved. Discriminate on the console timestamps, not on how the tool call ended.
   `277 pass / 0 fail`, and the 51 methods reported unrunnable (`No log scope is available`) were
   exactly the ones asserting the error log the change touched. `0 fail` was true and answered a
   different question than the one being asked. Name the unrunnable set and say what it covered.
+
+### Three the bridge itself gets wrong (session 225)
+
+- **A run that emits a Unity WARNING is reported as `UNEXPECTED_ERROR: Command was executed
+partially, but reported warnings or errors`, with the complete result inside it.** The tool result
+  arrives as an error whose payload contains every logged line and the `result.Log` output in full.
+  Two probes this session were successes wearing that wrapper. Read the payload before concluding a
+  probe failed -- the discriminator is whether your RESULT line is present, not how the call ended.
+- **The sandbox wraps your script in `namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor`,
+  so `Unity` is an enclosing namespace and any bare type name that collides with a child of it
+  fails to resolve.** `CompilationPipeline.GetAssemblies(...)`, with `using UnityEditor.Compilation;`
+  present, compiled to `CS0234: The type or namespace name 'GetAssemblies' does not exist in the
+namespace 'Unity.CompilationPipeline'` -- the name bound to a NAMESPACE, not to the type the
+  import provides. Fully qualify (`UnityEditor.Compilation.CompilationPipeline`), which is the same
+  habit the `System.Reflection` restriction already forces.
+- **`Application.isPlaying` is FALSE here, and package code branches on it.** A fixture that is green
+  in CI's playmode legs can fail here for a reason that is neither the harness nor your change:
+  `Attribute.CurrentValue` carried an `#if UNITY_EDITOR` branch keyed on exactly that, and two
+  serialization fixtures failed under this loop for three sessions before anyone read the getter
+  ([#569](https://github.com/Ambiguous-Interactive/unity-helpers/issues/569)). Before filing such a
+  failure as an artifact OR as a regression, grep the code under test for `Application.isPlaying`.
+  It is a third category: a real defect that only this harness can see.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Applying an `Instant` effect that also defines periodic or behaviour data now warns once per effect instead of on every application, and `AttributeEffect` reports it in the Inspector too. The message used to render the whole effect to JSON, 20.5 us each time ([#567](https://github.com/Ambiguous-Interactive/unity-helpers/issues/567)).
+- An `AttributeEffect` authoring mistake -- `Instant` with periodic or behaviour data, or an unassigned cosmetic entry -- is now reported once per effect and in the Inspector, not on every application. Each report rendered the whole effect to JSON, measured at 20.5 us ([#567](https://github.com/Ambiguous-Interactive/unity-helpers/issues/567)).
 - Fix `Attribute.CurrentValue` reporting the wrong number in the editor: outside play mode it discarded the cached value, so an attribute deserialized while buffed lost the buff, and in play mode an Inspector edit to the base value left the cache stale ([#569](https://github.com/Ambiguous-Interactive/unity-helpers/issues/569)).
 - Fix a single `[SiblingComponent]` or `[ChildComponent]` field binding a disabled component when `IncludeInactive = false`. With two candidates on one object and the first disabled, the disabled one was assigned instead of the enabled one behind it ([#529](https://github.com/Ambiguous-Interactive/unity-helpers/issues/529)).
 - Fix a second `await` of the same `AsyncOperation` stopping the first one resuming. Two coroutines or tasks awaiting one `SceneManager.LoadSceneAsync` handle now both continue; previously only the last to register did.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Applying an `Instant` effect that also defines periodic or behaviour data now warns once instead of twice, and without a stack trace. Both copies rendered the whole effect to JSON, on every application ([#567](https://github.com/Ambiguous-Interactive/unity-helpers/issues/567)).
+- Applying an `Instant` effect that also defines periodic or behaviour data now warns once per effect instead of on every application, and `AttributeEffect` reports it in the Inspector too. The message used to render the whole effect to JSON, 20.5 us each time ([#567](https://github.com/Ambiguous-Interactive/unity-helpers/issues/567)).
+- Fix `Attribute.CurrentValue` reporting the wrong number in the editor: outside play mode it discarded the cached value, so an attribute deserialized while buffed lost the buff, and in play mode an Inspector edit to the base value left the cache stale ([#569](https://github.com/Ambiguous-Interactive/unity-helpers/issues/569)).
 - Fix a single `[SiblingComponent]` or `[ChildComponent]` field binding a disabled component when `IncludeInactive = false`. With two candidates on one object and the first disabled, the disabled one was assigned instead of the enabled one behind it ([#529](https://github.com/Ambiguous-Interactive/unity-helpers/issues/529)).
 - Fix a second `await` of the same `AsyncOperation` stopping the first one resuming. Two coroutines or tasks awaiting one `SceneManager.LoadSceneAsync` handle now both continue; previously only the last to register did.
 - Fix one refused protobuf surrogate registration disabling every registration after it, so `Vector3`, `Color` and `Bounds` silently encoded with different bytes. Each is now independent and names the type it could not register.

--- a/Runtime/Tags/Attribute.cs
+++ b/Runtime/Tags/Attribute.cs
@@ -56,20 +56,13 @@ namespace WallstopStudios.UnityHelpers.Tags
         {
             get
             {
-#if UNITY_EDITOR
-                /*
-                    For some reason, there's a bug with loot tables where
-                    _currentValueCalculated will be true but the current
-                    value is not calculated, so ignore the flag if we're
-                    in editor mode, where this happens
-                 */
-                if (Application.isPlaying)
-#endif
+                // Unity writes _baseValue straight into the field on every deserialization -- an
+                // Inspector edit, a prefab apply, an undo -- without running any code that could
+                // invalidate the cache. Equals rather than == so a NaN base value still matches the
+                // NaN it was calculated from instead of recalculating on every read.
+                if (_currentValueCalculated && _calculatedFromBaseValue.Equals(_baseValue))
                 {
-                    if (_currentValueCalculated)
-                    {
-                        return _currentValue;
-                    }
+                    return _currentValue;
                 }
 
                 CalculateCurrentValue();
@@ -90,6 +83,8 @@ namespace WallstopStudios.UnityHelpers.Tags
         private float _currentValue;
 
         private bool _currentValueCalculated;
+
+        private float _calculatedFromBaseValue;
 
         private readonly Dictionary<EffectHandle, List<AttributeModification>> _modifications =
             new();
@@ -127,6 +122,7 @@ namespace WallstopStudios.UnityHelpers.Tags
             _baseValue = baseValue;
             _currentValue = currentValue;
             _currentValueCalculated = true;
+            _calculatedFromBaseValue = baseValue;
         }
 
         /// <summary>
@@ -145,6 +141,7 @@ namespace WallstopStudios.UnityHelpers.Tags
 
             _currentValue = calculatedValue;
             _currentValueCalculated = true;
+            _calculatedFromBaseValue = _baseValue;
         }
 
         /// <summary>

--- a/Runtime/Tags/AttributeEffect.cs
+++ b/Runtime/Tags/AttributeEffect.cs
@@ -183,6 +183,9 @@ namespace WallstopStudios.UnityHelpers.Tags
         [NonSerialized]
         private bool _instantWithHandleDataReported;
 
+        [NonSerialized]
+        private bool _unassignedCosmeticReported;
+
         /// <summary>
         /// Gets whether this effect is <see cref="ModifierDurationType.Instant"/> yet carries
         /// periodic or behaviour data. Instant effects return no handle, so neither can ever run.
@@ -212,13 +215,61 @@ namespace WallstopStudios.UnityHelpers.Tags
             return true;
         }
 
+        /// <summary>
+        /// Gets whether <see cref="cosmeticEffects"/> holds an unassigned entry. Those entries
+        /// cannot be instanced, so they are skipped every time the effect is applied.
+        /// </summary>
+        internal bool HasUnassignedCosmeticEffect
+        {
+            get
+            {
+                for (int index = 0; index < cosmeticEffects.Count; ++index)
+                {
+                    if (cosmeticEffects[index] == null)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> the first time it is called on an effect holding an unassigned
+        /// cosmetic entry, and <c>false</c> forever after.
+        /// </summary>
+        /// <remarks>
+        /// Same shape as <see cref="ShouldReportInstantWithHandleData"/>: a static property of the
+        /// asset, previously reported once per unassigned entry per application.
+        /// </remarks>
+        internal bool ShouldReportUnassignedCosmeticEffect()
+        {
+            if (_unassignedCosmeticReported || !HasUnassignedCosmeticEffect)
+            {
+                return false;
+            }
+
+            _unassignedCosmeticReported = true;
+            return true;
+        }
+
         private void OnValidate()
         {
             _instantWithHandleDataReported = false;
+            _unassignedCosmeticReported = false;
             if (IsInstantWithHandleData)
             {
                 this.LogWarn(
                     $"Effect {name} defines periodic or behaviour data but is Instant. These features require a Duration or Infinite effect.",
+                    stackTrace: false
+                );
+            }
+
+            if (HasUnassignedCosmeticEffect)
+            {
+                this.LogWarn(
+                    $"Effect {name} has an unassigned CosmeticEffectData entry, which cannot be instanced and is skipped.",
                     stackTrace: false
                 );
             }

--- a/Runtime/Tags/AttributeEffect.cs
+++ b/Runtime/Tags/AttributeEffect.cs
@@ -223,9 +223,9 @@ namespace WallstopStudios.UnityHelpers.Tags
         {
             get
             {
-                for (int index = 0; index < cosmeticEffects.Count; ++index)
+                foreach (CosmeticEffectData cosmeticEffect in cosmeticEffects)
                 {
-                    if (cosmeticEffects[index] == null)
+                    if (cosmeticEffect == null)
                     {
                         return true;
                     }

--- a/Runtime/Tags/AttributeEffect.cs
+++ b/Runtime/Tags/AttributeEffect.cs
@@ -180,6 +180,50 @@ namespace WallstopStudios.UnityHelpers.Tags
         [JsonIgnore]
         public List<EffectBehavior> behaviors = new();
 
+        [NonSerialized]
+        private bool _instantWithHandleDataReported;
+
+        /// <summary>
+        /// Gets whether this effect is <see cref="ModifierDurationType.Instant"/> yet carries
+        /// periodic or behaviour data. Instant effects return no handle, so neither can ever run.
+        /// </summary>
+        internal bool IsInstantWithHandleData =>
+            durationType == ModifierDurationType.Instant
+            && ((periodicEffects is { Count: > 0 }) || (behaviors is { Count: > 0 }));
+
+        /// <summary>
+        /// Returns <c>true</c> the first time it is called on a misconfigured effect, and
+        /// <c>false</c> forever after.
+        /// </summary>
+        /// <remarks>
+        /// The condition is a static property of the asset, so reporting it on the per-application
+        /// path made a single authoring mistake cost a diagnostic on every hit, every tick, for the
+        /// whole session. Editing the effect re-arms the report through
+        /// <see cref="OnValidate"/>.
+        /// </remarks>
+        internal bool ShouldReportInstantWithHandleData()
+        {
+            if (_instantWithHandleDataReported || !IsInstantWithHandleData)
+            {
+                return false;
+            }
+
+            _instantWithHandleDataReported = true;
+            return true;
+        }
+
+        private void OnValidate()
+        {
+            _instantWithHandleDataReported = false;
+            if (IsInstantWithHandleData)
+            {
+                this.LogWarn(
+                    $"Effect {name} defines periodic or behaviour data but is Instant. These features require a Duration or Infinite effect.",
+                    stackTrace: false
+                );
+            }
+        }
+
         /// <summary>
         /// Determines how this effect groups stacks for stacking decisions.
         /// </summary>

--- a/Runtime/Tags/EffectHandler.cs
+++ b/Runtime/Tags/EffectHandler.cs
@@ -157,13 +157,14 @@ namespace WallstopStudios.UnityHelpers.Tags
 
             if (effect.durationType == ModifierDurationType.Instant)
             {
-                if (RequiresHandle(effect))
+                // A static property of the asset, so it is reported once per effect rather than on
+                // every application, and by name rather than by serializing the whole effect to
+                // JSON inside the interpolated string (#567). AttributeEffect.OnValidate reports
+                // the same mistake in the Inspector, where it is fixable.
+                if (effect.ShouldReportInstantWithHandleData())
                 {
-                    // Reported on every application of a misconfigured effect, so no stack trace:
-                    // it is the same path every time and costs 13.4x the log itself (#564). The
-                    // repetition and the {effect:json} render are tracked on #567.
                     this.LogWarn(
-                        $"Effect {effect:json} defines periodic or behaviour data but is Instant. These features require a Duration or Infinite effect.",
+                        $"Effect {effect.name} defines periodic or behaviour data but is Instant. These features require a Duration or Infinite effect.",
                         stackTrace: false
                     );
                 }
@@ -231,12 +232,6 @@ namespace WallstopStudios.UnityHelpers.Tags
             RegisterStackHandle(stackKey, newHandle);
             InternalApplyEffect(newHandle, currentTime);
             return newHandle;
-        }
-
-        private static bool RequiresHandle(AttributeEffect effect)
-        {
-            return (effect.periodicEffects is { Count: > 0 })
-                || (effect.behaviors is { Count: > 0 });
         }
 
         private List<EffectHandle> TryGetStackHandles(EffectStackKey stackKey)
@@ -704,10 +699,9 @@ namespace WallstopStudios.UnityHelpers.Tags
             OnEffectApplied?.Invoke(handle);
         }
 
-        // No Instant/RequiresHandle warning here. The one caller is ApplyEffect's Instant branch,
-        // which has already tested both halves and warned -- so this condition was always true and
-        // the message was always the second copy of one the console had just shown, each carrying a
-        // full JSON serialization of the effect and a stack trace capture.
+        // No Instant warning here. The one caller is ApplyEffect's Instant branch, which has
+        // already tested the condition -- so this one was always true and the message was always
+        // the second copy of one the console had just shown.
         private void InternalApplyEffect(AttributeEffect effect)
         {
             if (!_initialized && _tagHandler == null)

--- a/Runtime/Tags/EffectHandler.cs
+++ b/Runtime/Tags/EffectHandler.cs
@@ -875,9 +875,17 @@ namespace WallstopStudios.UnityHelpers.Tags
                 CosmeticEffectData cosmeticEffect = cosmeticEffectData;
                 if (cosmeticEffect == null)
                 {
-                    this.LogError(
-                        $"CosmeticEffectData is null for effect {effect:json}, cannot determine instancing scheme."
-                    );
+                    // Same static-authoring shape as the Instant diagnostic above: once per
+                    // effect, by name rather than by serializing it, and no stack trace -- the
+                    // mistake is in the asset, not on this call stack (#567).
+                    if (effect.ShouldReportUnassignedCosmeticEffect())
+                    {
+                        this.LogError(
+                            $"Effect {effect.name} has an unassigned CosmeticEffectData entry, which cannot be instanced and is skipped.",
+                            stackTrace: false
+                        );
+                    }
+
                     continue;
                 }
 
@@ -926,9 +934,14 @@ namespace WallstopStudios.UnityHelpers.Tags
             {
                 if (cosmeticEffectData == null)
                 {
-                    this.LogError(
-                        $"CosmeticEffectData is null for effect {attributeEffect:json}, cannot determine instancing scheme."
-                    );
+                    if (attributeEffect.ShouldReportUnassignedCosmeticEffect())
+                    {
+                        this.LogError(
+                            $"Effect {attributeEffect.name} has an unassigned CosmeticEffectData entry, which cannot be instanced and is skipped.",
+                            stackTrace: false
+                        );
+                    }
+
                     continue;
                 }
 

--- a/Tests/Editor/Tags/AttributeEditModeCacheTests.cs
+++ b/Tests/Editor/Tags/AttributeEditModeCacheTests.cs
@@ -1,0 +1,72 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+#if UNITY_EDITOR
+    using NUnit.Framework;
+    using Attribute = WallstopStudios.UnityHelpers.Tags.Attribute;
+    using Serializer = WallstopStudios.UnityHelpers.Core.Serialization.Serializer;
+
+    /// <summary>
+    /// Pins <see cref="Attribute.CurrentValue"/> outside play mode.
+    /// </summary>
+    /// <remarks>
+    /// The equivalent play-mode assertions live in
+    /// <c>Tests/Runtime/Tags/AttributeSerializationTests.cs</c>, and Unity's EditMode runner takes
+    /// editor-only assemblies -- so nothing in CI read this property with
+    /// <c>Application.isPlaying</c> false until this fixture existed. The getter used to discard
+    /// the cache entirely on that branch, which silently dropped every deserialized buff
+    /// (<see href="https://github.com/Ambiguous-Interactive/unity-helpers/issues/569">#569</see>).
+    /// </remarks>
+    [TestFixture]
+    [NUnit.Framework.Category("Fast")]
+    public sealed class AttributeEditModeCacheTests
+    {
+        [Test]
+        public void JsonRoundTripKeepsTheModifiedValueOutsidePlayMode()
+        {
+            Attribute attribute = new(100f);
+            attribute.Add(25f);
+
+            string json = Serializer.JsonStringify(attribute);
+            Attribute deserialized = Serializer.JsonDeserialize<Attribute>(json);
+
+            Assert.IsTrue(deserialized != null);
+            Assert.AreEqual(100f, deserialized.BaseValue);
+            Assert.AreEqual(125f, deserialized.CurrentValue);
+        }
+
+        [Test]
+        public void ClearCacheAfterJsonRoundTripFallsBackToTheBaseValueOutsidePlayMode()
+        {
+            Attribute attribute = new(100f);
+            attribute.Add(25f);
+
+            Attribute deserialized = Serializer.JsonDeserialize<Attribute>(
+                Serializer.JsonStringify(attribute)
+            );
+
+            Assert.IsTrue(deserialized != null);
+            Assert.AreEqual(125f, deserialized.CurrentValue);
+
+            deserialized.ClearCache();
+            Assert.AreEqual(100f, deserialized.CurrentValue);
+        }
+
+        [Test]
+        public void WritingTheBaseValueBehindTheCacheInvalidatesItOutsidePlayMode()
+        {
+            Attribute attribute = new(100f);
+            attribute.Add(25f);
+            Assert.AreEqual(125f, attribute.CurrentValue);
+
+            // Exactly what Unity's serializer does to a [SerializeField] on an Inspector edit, a
+            // prefab apply or an undo: assign the field, run nothing that could clear the cache.
+            attribute._baseValue = 200f;
+
+            Assert.AreEqual(225f, attribute.CurrentValue);
+        }
+    }
+#endif
+}

--- a/Tests/Editor/Tags/AttributeEditModeCacheTests.cs.meta
+++ b/Tests/Editor/Tags/AttributeEditModeCacheTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9f9a1b1b7512e0ebe0007d6ac277544
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/Tags/AttributeEffectValidationTests.cs
+++ b/Tests/Editor/Tags/AttributeEffectValidationTests.cs
@@ -80,6 +80,54 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.IsFalse(_effect.ShouldReportInstantWithHandleData());
         }
 
+        [TestCase(0, 0, false)]
+        [TestCase(1, 0, false)]
+        [TestCase(0, 1, true)]
+        [TestCase(2, 1, true)]
+        public void AnUnassignedCosmeticEntryIsDetectedWhereverItSits(
+            int assignedBefore,
+            int unassigned,
+            bool expected
+        )
+        {
+            for (int index = 0; index < assignedBefore; ++index)
+            {
+                GameObject host = Track(new GameObject($"CosmeticHost{index}"));
+                _effect.cosmeticEffects.Add(host.AddComponent<CosmeticEffectData>());
+            }
+
+            for (int index = 0; index < unassigned; ++index)
+            {
+                _effect.cosmeticEffects.Add(null);
+            }
+
+            Assert.AreEqual(expected, _effect.HasUnassignedCosmeticEffect);
+        }
+
+        [Test]
+        public void TheUnassignedCosmeticReportIsArmedOncePerEffectNotPerEntry()
+        {
+            _effect.cosmeticEffects.Add(null);
+            _effect.cosmeticEffects.Add(null);
+            _effect.cosmeticEffects.Add(null);
+
+            Assert.IsTrue(_effect.ShouldReportUnassignedCosmeticEffect());
+            Assert.IsFalse(_effect.ShouldReportUnassignedCosmeticEffect());
+            Assert.IsFalse(_effect.ShouldReportUnassignedCosmeticEffect());
+        }
+
+        [Test]
+        public void TheTwoAuthoringReportsAreIndependent()
+        {
+            _effect.durationType = ModifierDurationType.Instant;
+            _effect.periodicEffects.Add(new PeriodicEffectDefinition());
+            _effect.cosmeticEffects.Add(null);
+
+            // Arming one must not consume the other: a single effect can carry both mistakes.
+            Assert.IsTrue(_effect.ShouldReportInstantWithHandleData());
+            Assert.IsTrue(_effect.ShouldReportUnassignedCosmeticEffect());
+        }
+
         [Test]
         public void EditingTheEffectReArmsTheApplyPathReport()
         {
@@ -88,12 +136,17 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.IsTrue(_effect.ShouldReportInstantWithHandleData());
             Assert.IsFalse(_effect.ShouldReportInstantWithHandleData());
 
+            _effect.cosmeticEffects.Add(null);
+            Assert.IsTrue(_effect.ShouldReportUnassignedCosmeticEffect());
+            Assert.IsFalse(_effect.ShouldReportUnassignedCosmeticEffect());
+
             SerializedObject serialized = new(_effect);
             serialized.FindProperty(nameof(AttributeEffect.duration)).floatValue = 3f;
             Assert.IsTrue(serialized.ApplyModifiedPropertiesWithoutUndo());
 
             // ApplyModifiedProperties runs OnValidate, which is where the author sees the mistake.
             Assert.IsTrue(_effect.ShouldReportInstantWithHandleData());
+            Assert.IsTrue(_effect.ShouldReportUnassignedCosmeticEffect());
         }
     }
 #endif

--- a/Tests/Editor/Tags/AttributeEffectValidationTests.cs
+++ b/Tests/Editor/Tags/AttributeEffectValidationTests.cs
@@ -1,0 +1,100 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+#if UNITY_EDITOR
+    using NUnit.Framework;
+    using UnityEditor;
+    using UnityEngine;
+    using WallstopStudios.UnityHelpers.Tags;
+    using WallstopStudios.UnityHelpers.Tests.Core;
+
+    /// <summary>
+    /// Pins where a misconfigured Instant effect is reported.
+    /// </summary>
+    /// <remarks>
+    /// The condition depends only on the asset, so it belongs in the Inspector and on the apply
+    /// path at most once -- it used to be reported on every application, rendering the whole effect
+    /// to JSON inside the interpolated string each time
+    /// (<see href="https://github.com/Ambiguous-Interactive/unity-helpers/issues/567">#567</see>).
+    /// </remarks>
+    [TestFixture]
+    [NUnit.Framework.Category("Fast")]
+    public sealed class AttributeEffectValidationTests : CommonTestBase
+    {
+        private AttributeEffect _effect;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _effect = Track(ScriptableObject.CreateInstance<AttributeEffect>());
+            _effect.name = "ValidationProbe";
+        }
+
+        [TestCase(ModifierDurationType.Instant, true, false, true)]
+        [TestCase(ModifierDurationType.Instant, false, true, true)]
+        [TestCase(ModifierDurationType.Instant, true, true, true)]
+        [TestCase(ModifierDurationType.Instant, false, false, false)]
+        [TestCase(ModifierDurationType.Duration, true, true, false)]
+        [TestCase(ModifierDurationType.Infinite, true, true, false)]
+        public void HandleDataIsOnlyAMistakeWhenTheEffectIsInstant(
+            ModifierDurationType durationType,
+            bool withPeriodic,
+            bool withBehavior,
+            bool expected
+        )
+        {
+            _effect.durationType = durationType;
+            if (withPeriodic)
+            {
+                _effect.periodicEffects.Add(new PeriodicEffectDefinition());
+            }
+
+            if (withBehavior)
+            {
+                // A null entry still makes the list non-empty, which is the whole condition.
+                _effect.behaviors.Add(null);
+            }
+
+            Assert.AreEqual(expected, _effect.IsInstantWithHandleData);
+        }
+
+        [Test]
+        public void TheApplyPathReportIsArmedExactlyOnce()
+        {
+            _effect.durationType = ModifierDurationType.Instant;
+            _effect.periodicEffects.Add(new PeriodicEffectDefinition());
+
+            Assert.IsTrue(_effect.ShouldReportInstantWithHandleData());
+            Assert.IsFalse(_effect.ShouldReportInstantWithHandleData());
+            Assert.IsFalse(_effect.ShouldReportInstantWithHandleData());
+        }
+
+        [Test]
+        public void ASoundEffectNeverArmsTheApplyPathReport()
+        {
+            _effect.durationType = ModifierDurationType.Duration;
+            _effect.periodicEffects.Add(new PeriodicEffectDefinition());
+
+            Assert.IsFalse(_effect.ShouldReportInstantWithHandleData());
+        }
+
+        [Test]
+        public void EditingTheEffectReArmsTheApplyPathReport()
+        {
+            _effect.durationType = ModifierDurationType.Instant;
+            _effect.periodicEffects.Add(new PeriodicEffectDefinition());
+            Assert.IsTrue(_effect.ShouldReportInstantWithHandleData());
+            Assert.IsFalse(_effect.ShouldReportInstantWithHandleData());
+
+            SerializedObject serialized = new(_effect);
+            serialized.FindProperty(nameof(AttributeEffect.duration)).floatValue = 3f;
+            Assert.IsTrue(serialized.ApplyModifiedPropertiesWithoutUndo());
+
+            // ApplyModifiedProperties runs OnValidate, which is where the author sees the mistake.
+            Assert.IsTrue(_effect.ShouldReportInstantWithHandleData());
+        }
+    }
+#endif
+}

--- a/Tests/Editor/Tags/AttributeEffectValidationTests.cs.meta
+++ b/Tests/Editor/Tags/AttributeEffectValidationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9fc2488214ea008c6d2e4abc089e170
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/Tags/WallstopStudios.UnityHelpers.Tests.Editor.Tags.asmdef
+++ b/Tests/Editor/Tags/WallstopStudios.UnityHelpers.Tests.Editor.Tags.asmdef
@@ -13,7 +13,11 @@
   "excludePlatforms": [],
   "allowUnsafeCode": false,
   "overrideReferences": true,
-  "precompiledReferences": ["nunit.framework.dll", "Sirenix.Serialization.dll"],
+  "precompiledReferences": [
+    "nunit.framework.dll",
+    "System.Text.Json.dll",
+    "Sirenix.Serialization.dll"
+  ],
   "autoReferenced": false,
   "defineConstraints": ["UNITY_INCLUDE_TESTS"],
   "versionDefines": [],

--- a/Tests/Runtime/Tags/AttributeSerializationTests.cs
+++ b/Tests/Runtime/Tags/AttributeSerializationTests.cs
@@ -63,6 +63,20 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
         }
 
         [Test]
+        public void WritingTheBaseValueBehindTheCacheInvalidatesIt()
+        {
+            Attribute attribute = new(100f);
+            attribute.Add(25f);
+            Assert.AreEqual(125f, attribute.CurrentValue);
+
+            // Exactly what Unity's serializer does to a [SerializeField] on an Inspector edit, a
+            // prefab apply or an undo: assign the field, run nothing that could clear the cache.
+            attribute._baseValue = 200f;
+
+            Assert.AreEqual(225f, attribute.CurrentValue);
+        }
+
+        [Test]
         public void JsonRoundTripOfAnUnmodifiedAttributePreservesBothValues()
         {
             Attribute attribute = new(42.5f);

--- a/Tests/Runtime/Tags/EffectHandlerTests.cs
+++ b/Tests/Runtime/Tags/EffectHandlerTests.cs
@@ -1161,11 +1161,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 new Regex("defines periodic or behaviour data but is Instant")
             );
 
-            // Counted, not just expected. ApplyEffect used to warn and then call InternalApplyEffect,
-            // which tested the same two conditions and warned again -- so one misconfigured effect
-            // produced two identical messages, each rendering the whole effect to JSON. A single
-            // LogAssert expectation matches one of them and an unexpected WARNING does not fail a
-            // Unity test, which is why the duplicate survived.
+            // Counted, not just expected, and counted across FOUR applications. The condition is
+            // a static property of the asset, so it used to be reported on every application --
+            // each one rendering the whole effect to JSON inside the interpolated string. A single
+            // LogAssert expectation matches one message of any number, and an unexpected WARNING
+            // does not fail a Unity test, which is why the repetition survived.
             int warnings = 0;
             void CountWarning(string condition, string stackTrace, LogType type)
             {
@@ -1179,10 +1179,13 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             }
 
             Application.logMessageReceived += CountWarning;
-            EffectHandle? handle;
+            EffectHandle? handle = null;
             try
             {
-                handle = handler.ApplyEffect(effect);
+                for (int application = 0; application < 4; ++application)
+                {
+                    handle = handler.ApplyEffect(effect);
+                }
             }
             finally
             {
@@ -1192,7 +1195,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.IsFalse(handle.HasValue);
             if (WallstopLoggingCompiledIn)
             {
-                Assert.AreEqual(1, warnings, "The Instant warning must be emitted exactly once.");
+                Assert.AreEqual(
+                    1,
+                    warnings,
+                    "The Instant warning must be emitted once per effect, not once per application."
+                );
             }
 
             int ticks = handler.ProcessPeriodicEffectsForTesting(

--- a/docs/features/effects/effects-system.md
+++ b/docs/features/effects/effects-system.md
@@ -272,6 +272,25 @@ void ApplyHealthBuff()
 - **Quest progress, Level** - progression state
 - **Input state, UI state** - transient application state
 
+### Saving and Loading an Attribute
+
+Only `BaseValue` and `CurrentValue` are serialized -- the active modifications are not -- so the two
+restore paths deliberately differ:
+
+- **JSON** (`Serializer.JsonStringify` / `JsonDeserialize`) keeps the `CurrentValue` that was
+  written. An attribute saved while buffed loads with the buff still in the number, because
+  recalculating from a base value with no modifications would silently drop it.
+- **Unity serialization** (a `[SerializeField]` on a `MonoBehaviour` or `ScriptableObject`)
+  recalculates from the base value on the first read, because the modifications that produced the
+  saved number belong to a session that has ended.
+
+Call `ClearCache()` after a JSON load if you intend to rebuild the modifications yourself and want
+the value to follow them.
+
+The cache also follows the base value. Writing `BaseValue` through the Inspector, a prefab apply or
+an undo assigns the field without running any code, so `CurrentValue` recalculates on the next read
+rather than reporting a number computed from the old base.
+
 ### Why This Matters
 
 When you use Attributes for frequently mutated "current" values:
@@ -1313,6 +1332,16 @@ Q: How do I query tag counts or check multiple tags at once?
 - Duration didn’t refresh on reapplication
   - Set `resetDurationOnReapplication = true` on the `AttributeEffect`.
 
+- "defines periodic or behaviour data but is Instant"
+  - An `Instant` effect returns no handle, so its `periodicEffects` and `behaviors` can never run.
+    Either give the effect a `Duration`/`Infinite` duration type or clear those lists. The message
+    appears in the Inspector when the effect is edited, and once per effect on the first
+    application.
+
+- A saved attribute loads without its buff
+  - JSON keeps the written `CurrentValue`; Unity serialization recalculates from the base value.
+    See [Saving and Loading an Attribute](#saving-and-loading-an-attribute).
+
 ## Advanced Scenarios: Beyond Buffs and Debuffs
 
 While the Effects System handles traditional buff/debuff mechanics well, it can also be used to build **robust capability systems** that drive complex gameplay decisions across your entire codebase. This section explores advanced patterns that use tags extensively for architectural purposes.
@@ -2207,6 +2236,8 @@ public class DebugConsole : MonoBehaviour
 - Attribute field discovery is cached (and can be precomputed by the Attribute Metadata Cache generator).
 - Tag queries provide overloads for lists to minimize allocations; prefer `IReadOnlyList<string>` overloads in hot paths.
 - Cosmetics can be a significant cost; prefer shared presenters when possible.
+- A misconfigured `Instant` effect is reported once per effect, not once per application. The message
+  used to render the whole effect to JSON, measured at 20.5 us each time on `6000.4.6f1`.
 
 ---
 

--- a/docs/features/effects/effects-system.md
+++ b/docs/features/effects/effects-system.md
@@ -1338,6 +1338,10 @@ Q: How do I query tag counts or check multiple tags at once?
     appears in the Inspector when the effect is edited, and once per effect on the first
     application.
 
+- "has an unassigned CosmeticEffectData entry"
+  - A slot in the effect's `Cosmetic Effects` list is empty. Empty slots cannot be instanced and are
+    skipped; remove the slot or assign a prefab.
+
 - A saved attribute loads without its buff
   - JSON keeps the written `CurrentValue`; Unity serialization recalculates from the base value.
     See [Saving and Loading an Attribute](#saving-and-loading-an-attribute).
@@ -2236,8 +2240,8 @@ public class DebugConsole : MonoBehaviour
 - Attribute field discovery is cached (and can be precomputed by the Attribute Metadata Cache generator).
 - Tag queries provide overloads for lists to minimize allocations; prefer `IReadOnlyList<string>` overloads in hot paths.
 - Cosmetics can be a significant cost; prefer shared presenters when possible.
-- A misconfigured `Instant` effect is reported once per effect, not once per application. The message
-  used to render the whole effect to JSON, measured at 20.5 us each time on `6000.4.6f1`.
+- An `AttributeEffect` authoring mistake is reported once per effect, not once per application. Each
+  report used to render the whole effect to JSON, measured at 20.5 us on `6000.4.6f1`.
 
 ---
 

--- a/scripts/lint-tests.ps1
+++ b/scripts/lint-tests.ps1
@@ -435,6 +435,20 @@ function Test-AssemblyReferenceEditorOnly([string]$asmrefPath) {
   }
 }
 
+function Get-FirstFileByName([string]$directory, [string]$pattern) {
+  $first = $null
+  foreach ($candidate in [System.IO.Directory]::EnumerateFiles($directory, $pattern)) {
+    if ($null -eq $first -or [string]::CompareOrdinal(
+        [System.IO.Path]::GetFileName($candidate),
+        [System.IO.Path]::GetFileName($first)
+      ) -lt 0) {
+      $first = $candidate
+    }
+  }
+
+  return $first
+}
+
 function Test-EditorOnlyAssemblyDefinition([string]$filePath, [string]$relPath) {
   $root = [System.IO.Path]::GetFullPath((Get-Location).Path).TrimEnd(
     [System.IO.Path]::DirectorySeparatorChar,
@@ -442,26 +456,33 @@ function Test-EditorOnlyAssemblyDefinition([string]$filePath, [string]$relPath) 
   )
   $directory = [System.IO.Path]::GetDirectoryName([System.IO.Path]::GetFullPath($filePath))
 
+  # A directory with no asmdef/asmref of its own answers whatever its nearest ancestor answers, so
+  # every directory walked past is cached with the resolved value. Caching only the directory that
+  # SUPPLIES the answer left each leaf uncached forever, and this runs once per test file: the leaf
+  # was re-enumerated 1,121 times. Cost is the same reason the file scan uses EnumerateFiles below --
+  # Get-ChildItem measured 28.5 s against 0.8 s over this repository's C# files on the 9p mount.
+  $walked = [System.Collections.Generic.List[string]]::new()
+
   while (-not [string]::IsNullOrWhiteSpace($directory)) {
     if ($assemblyDefinitionEditorOnlyCache.ContainsKey($directory)) {
-      return $assemblyDefinitionEditorOnlyCache[$directory]
+      $cached = $assemblyDefinitionEditorOnlyCache[$directory]
+      foreach ($seen in $walked) { $assemblyDefinitionEditorOnlyCache[$seen] = $cached }
+      return $cached
     }
 
-    $asmref = Get-ChildItem -LiteralPath $directory -Filter '*.asmref' -File -ErrorAction SilentlyContinue |
-      Sort-Object -Property Name |
-      Select-Object -First 1
+    $walked.Add($directory)
+
+    $asmref = Get-FirstFileByName $directory '*.asmref'
     if ($null -ne $asmref) {
-      $editorOnly = Test-AssemblyReferenceEditorOnly $asmref.FullName
-      $assemblyDefinitionEditorOnlyCache[$directory] = $editorOnly
+      $editorOnly = Test-AssemblyReferenceEditorOnly $asmref
+      foreach ($seen in $walked) { $assemblyDefinitionEditorOnlyCache[$seen] = $editorOnly }
       return $editorOnly
     }
 
-    $asmdef = Get-ChildItem -LiteralPath $directory -Filter '*.asmdef' -File -ErrorAction SilentlyContinue |
-      Sort-Object -Property Name |
-      Select-Object -First 1
+    $asmdef = Get-FirstFileByName $directory '*.asmdef'
     if ($null -ne $asmdef) {
-      $editorOnly = Test-AssemblyDefinitionEditorOnly $asmdef.FullName
-      $assemblyDefinitionEditorOnlyCache[$directory] = $editorOnly
+      $editorOnly = Test-AssemblyDefinitionEditorOnly $asmdef
+      foreach ($seen in $walked) { $assemblyDefinitionEditorOnlyCache[$seen] = $editorOnly }
       return $editorOnly
     }
 

--- a/scripts/tests/test-validate-lint-error-codes.ps1
+++ b/scripts/tests/test-validate-lint-error-codes.ps1
@@ -118,218 +118,215 @@ function New-FixtureRoot {
 
     return $root
 }
-
-function Invoke-ValidatorInFixture {
-    param([string]$FixtureRoot)
-    $validatorCopy = Join-Path $FixtureRoot 'scripts/validate-lint-error-codes.ps1'
-    # The validator calls scripts/run-node-bin.js relative to its repo root.
-    # Switching the working directory is not enough; cspell resolves the
-    # nearest cspell.json from the CWD, which is what we want.
-    Push-Location $FixtureRoot
-    try {
-        $output = & pwsh -NoProfile -File $validatorCopy -VerboseOutput *>&1
-        $exitCode = $LASTEXITCODE
-    }
-    finally {
-        Pop-Location
-    }
-    return @{ Output = ($output | Out-String); ExitCode = $exitCode }
-}
-
-# ── Test 1: Real repo must pass ──────────────────────────────────────────────
-# This is the single most important guard: it asserts that the checked-in
-# cspell.json already covers every prefix emitted by the real lint scripts.
-# Any new lint-error-code family that ships without a cspell entry breaks this
-# test before it can break a pre-push hook.
-Write-Host "`n  Section: Real repository sanity" -ForegroundColor White
-try {
-    Push-Location $repoRoot
-    try {
-        $realOutput = & pwsh -NoProfile -File $validatorPath *>&1
-        $realExit = $LASTEXITCODE
-    }
-    finally {
-        Pop-Location
-    }
-    Write-TestResult "RealRepo.ValidatorPasses" ($realExit -eq 0) "Exit: $realExit. Output: $($realOutput | Out-String)"
-} catch {
-    Write-TestResult "RealRepo.ValidatorPasses" $false "Exception: $_"
-}
-
-# ── Test 2: Fixture with only known prefixes passes ──────────────────────────
-Write-Host "`n  Section: Fixture with registered prefix" -ForegroundColor White
-try {
-    $fixture = New-FixtureRoot
-    @"
+# ── Scenarios ────────────────────────────────────────────────────────────────
+# Every scenario is the same shape -- seed a fixture, run the validator in it,
+# assert on the exit code and the output -- so they are declared as data and
+# executed by one loop rather than written out nine times.
+#
+# The validator's cost is almost entirely cspell's start-up: measured on this
+# devcontainer, `cspell --version` is 7.9 s against 8.5 s for real work, and the
+# nine runs were 81.3 s of the contract suite's wall clock. They are independent
+# processes over independent fixtures, so they are started together and waited
+# for afterwards ([#540](https://github.com/Ambiguous-Interactive/unity-helpers/issues/540)).
+$scenarios = @(
+    @{
+        # The single most important guard: the checked-in cspell.json already
+        # covers every prefix the real lint scripts emit. A new lint-error-code
+        # family shipped without a cspell entry breaks this before it can break
+        # a pre-push hook.
+        Name           = 'RealRepo.ValidatorPasses'
+        UseRealRepo    = $true
+        ExpectExitZero = $true
+    },
+    @{
+        Name           = 'Fixture.OnlyKnownPrefix.Passes'
+        Files          = [ordered]@{
+            'scripts/lint-fake-good.ps1' = @"
 # Synthetic lint script using only UNH (registered).
 # UNH001 - example code
 Write-Host "UNH001: something"
-"@ | Set-Content -LiteralPath (Join-Path $fixture 'scripts/lint-fake-good.ps1')
-
-    $r = Invoke-ValidatorInFixture -FixtureRoot $fixture
-    Write-TestResult "Fixture.OnlyKnownPrefix.Passes" ($r.ExitCode -eq 0) "Exit: $($r.ExitCode). Output: $($r.Output)"
-} catch {
-    Write-TestResult "Fixture.OnlyKnownPrefix.Passes" $false "Exception: $_"
-}
-
-# ── Test 3: Fixture with unregistered prefix fails AND prints patch ──────────
-Write-Host "`n  Section: Fixture with unregistered prefix" -ForegroundColor White
-try {
-    $fixture = New-FixtureRoot
-    # XYZ is never a real English word; cspell will not accept it via compound
-    # splitting. Using a synthetic prefix guarantees the test fails for the
-    # right reason (missing cspell registration) rather than false positives.
-    @"
+"@
+        }
+        ExpectExitZero = $true
+    },
+    @{
+        # XYZ is never a real English word; cspell will not accept it via
+        # compound splitting. A synthetic prefix guarantees the failure is for
+        # the right reason (missing cspell registration), not a false positive.
+        Name           = 'Fixture.UnregisteredPrefix.Fails'
+        Files          = [ordered]@{
+            'scripts/lint-fake-novel.ps1' = @"
 # Synthetic lint script emitting a novel XYZ-family code.
 Write-Host "XYZ001: unregistered prefix should fail the validator"
-"@ | Set-Content -LiteralPath (Join-Path $fixture 'scripts/lint-fake-novel.ps1')
-
-    $r = Invoke-ValidatorInFixture -FixtureRoot $fixture
-    $failed = ($r.ExitCode -ne 0)
-    $mentionsXyz = ($r.Output -match '\bXYZ\b')
-    $emitsPatch = ($r.Output -match 'add_to_root_words')
-    $emitsSourceLine = ($r.Output -match 'lint-fake-novel\.ps1:')
-    $allPassed = $failed -and $mentionsXyz -and $emitsPatch -and $emitsSourceLine
-
-    Write-TestResult "Fixture.UnregisteredPrefix.Fails" $allPassed "Exit: $($r.ExitCode), mentionsXyz=$mentionsXyz, emitsPatch=$emitsPatch, emitsSourceLine=$emitsSourceLine. Output: $($r.Output)"
-} catch {
-    Write-TestResult "Fixture.UnregisteredPrefix.Fails" $false "Exception: $_"
-}
-
-# ── Test 4: Fixture with no lint scripts at all exits 1 (layout guard) ───────
-# The validator treats an empty lint-*.{ps1,js} glob as a repo-layout error,
-# not a silent pass. This guards against someone renaming the whole family
-# and silently disabling the check.
-Write-Host "`n  Section: Fixture with no lint scripts" -ForegroundColor White
-try {
-    $fixture = New-FixtureRoot
-    # Intentionally no lint-*.ps1 files.
-    $r = Invoke-ValidatorInFixture -FixtureRoot $fixture
-    Write-TestResult "Fixture.NoLintScripts.FailsLoudly" ($r.ExitCode -ne 0) "Exit: $($r.ExitCode). Output: $($r.Output)"
-} catch {
-    Write-TestResult "Fixture.NoLintScripts.FailsLoudly" $false "Exception: $_"
-}
-
-# ── Test 5: Fixture with lint script emitting no codes passes ────────────────
-Write-Host "`n  Section: Fixture with lint script emitting no codes" -ForegroundColor White
-try {
-    $fixture = New-FixtureRoot
-    @"
+"@
+        }
+        ExpectExitZero = $false
+        MustMatch      = @('\bXYZ\b', 'add_to_root_words', 'lint-fake-novel\.ps1:')
+    },
+    @{
+        # An empty lint-*.{ps1,js} glob is a repo-layout error, not a silent
+        # pass: renaming the whole family must not disable the check.
+        Name           = 'Fixture.NoLintScripts.FailsLoudly'
+        Files          = [ordered]@{}
+        ExpectExitZero = $false
+    },
+    @{
+        Name           = 'Fixture.LintScriptWithNoCodes.Passes'
+        Files          = [ordered]@{
+            'scripts/lint-fake-silent.ps1' = @"
 # Synthetic lint script with no lint codes at all (emits prose only).
 Write-Host "All good."
-"@ | Set-Content -LiteralPath (Join-Path $fixture 'scripts/lint-fake-silent.ps1')
-
-    $r = Invoke-ValidatorInFixture -FixtureRoot $fixture
-    Write-TestResult "Fixture.LintScriptWithNoCodes.Passes" ($r.ExitCode -eq 0) "Exit: $($r.ExitCode). Output: $($r.Output)"
-} catch {
-    Write-TestResult "Fixture.LintScriptWithNoCodes.Passes" $false "Exception: $_"
-}
-
-# ── Test 6: .js lint scripts are scanned too ─────────────────────────────────
-Write-Host "`n  Section: Fixture with .js lint script" -ForegroundColor White
-try {
-    $fixture = New-FixtureRoot
-    @"
+"@
+        }
+        ExpectExitZero = $true
+    },
+    @{
+        # ABC is in cspell's default dictionary, so ABC001 splits and is
+        # accepted. This is a positive control for reading .js at all, and its
+        # exit code is deliberately not asserted.
+        Name           = 'Fixture.JsLintScriptIsScanned'
+        Files          = [ordered]@{
+            'scripts/lint-fake-js.js' = @"
 // Synthetic JS lint script emitting a novel ABC-family code.
 console.log('ABC001: unregistered prefix should fail the validator');
-"@ | Set-Content -LiteralPath (Join-Path $fixture 'scripts/lint-fake-js.js')
-
-    $r = Invoke-ValidatorInFixture -FixtureRoot $fixture
-    # ABC is an English word in cspell's default dictionary, but the token
-    # ABC001 splits to "ABC" and "001" and ABC is accepted. This test is
-    # therefore a positive control — a .js file is scanned without crashing.
-    # The pass/fail hinges on the validator's ability to read .js files at all,
-    # not on ABC being unknown.
-    $noCrash = ($r.Output -notmatch 'FullyQualifiedErrorId')
-    Write-TestResult "Fixture.JsLintScriptIsScanned" $noCrash "Exit: $($r.ExitCode). Output: $($r.Output)"
-} catch {
-    Write-TestResult "Fixture.JsLintScriptIsScanned" $false "Exception: $_"
-}
-
-# ── Test 7: Prefix emitted ONLY in .githooks/ is harvested (P1-2) ────────────
-# Hook error messages frequently cite lint-error-code families (e.g. UNH004 in
-# pre-commit's failure block). A novel prefix emitted from a hook but never
-# from a lint script must still be caught by the validator.
-Write-Host "`n  Section: Prefix emitted only in .githooks/" -ForegroundColor White
-try {
-    $fixture = New-FixtureRoot
-    # Seed a lint script with nothing interesting (forces harvester to rely on
-    # the .githooks/ scan for the novel prefix).
-    @"
-# Silent lint script — emits no codes.
+"@
+        }
+        IgnoreExitCode = $true
+        MustNotMatch   = @('FullyQualifiedErrorId')
+    },
+    @{
+        # Hook error messages cite lint-error-code families. A novel prefix
+        # emitted from a hook but never from a lint script must still be caught,
+        # so the lint script here deliberately emits nothing.
+        Name           = 'Fixture.PrefixOnlyInGithooks.Detected'
+        Files          = [ordered]@{
+            'scripts/lint-silent.ps1' = @"
+# Silent lint script -- emits no codes.
 Write-Host 'All good.'
-"@ | Set-Content -LiteralPath (Join-Path $fixture 'scripts/lint-silent.ps1')
-
-    @"
+"@
+            '.githooks/pre-commit'    = @"
 #!/usr/bin/env bash
-# pre-commit emits HOK001 as a failure code — unregistered with cspell.
+# pre-commit emits HOK001 as a failure code -- unregistered with cspell.
 echo 'HOK001: hook-emitted code that must be harvested'
-"@ | Set-Content -LiteralPath (Join-Path $fixture '.githooks/pre-commit')
-
-    $r = Invoke-ValidatorInFixture -FixtureRoot $fixture
-    $failed = ($r.ExitCode -ne 0)
-    $mentionsHok = ($r.Output -match '\bHOK\b')
-    $emitsSourceLine = ($r.Output -match '\.githooks/pre-commit:')
-    $allPassed = $failed -and $mentionsHok -and $emitsSourceLine
-    Write-TestResult "Fixture.PrefixOnlyInGithooks.Detected" $allPassed "Exit: $($r.ExitCode), mentionsHok=$mentionsHok, emitsSourceLine=$emitsSourceLine. Output: $($r.Output)"
-} catch {
-    Write-TestResult "Fixture.PrefixOnlyInGithooks.Detected" $false "Exception: $_"
-}
-
-# ── Test 8: Prefix emitted ONLY in scripts/tests/ is harvested (P1-2) ────────
-# Test assertions frequently reference error codes (e.g. "Assert -match
-# 'UNH005'"). The validator must see tests/ files too, otherwise a code used
-# only in tests would appear valid to cspell but missing from the contract.
-Write-Host "`n  Section: Prefix emitted only in scripts/tests/" -ForegroundColor White
-try {
-    $fixture = New-FixtureRoot
-    @"
+"@
+        }
+        ExpectExitZero = $false
+        MustMatch      = @('\bHOK\b', '\.githooks/pre-commit:')
+    },
+    @{
+        # Test assertions reference error codes, so a code used only in tests
+        # would otherwise look valid to cspell but be missing from the contract.
+        Name           = 'Fixture.PrefixOnlyInTests.Detected'
+        Files          = [ordered]@{
+            'scripts/lint-silent.ps1'             = @"
 # Silent lint script.
 Write-Host 'silent'
-"@ | Set-Content -LiteralPath (Join-Path $fixture 'scripts/lint-silent.ps1')
-
-    @"
-# A test file that asserts TST001 is emitted — the prefix is introduced here,
+"@
+            'scripts/tests/test-lint-novel.ps1' = @"
+# A test file that asserts TST001 is emitted -- the prefix is introduced here,
 # not in any lint-*.ps1, and must still be flagged.
 Write-Host 'TST001: test-only prefix'
-"@ | Set-Content -LiteralPath (Join-Path $fixture 'scripts/tests/test-lint-novel.ps1')
-
-    $r = Invoke-ValidatorInFixture -FixtureRoot $fixture
-    $failed = ($r.ExitCode -ne 0)
-    $mentionsTst = ($r.Output -match '\bTST\b')
-    $emitsSourceLine = ($r.Output -match 'test-lint-novel\.ps1:')
-    $allPassed = $failed -and $mentionsTst -and $emitsSourceLine
-    Write-TestResult "Fixture.PrefixOnlyInTests.Detected" $allPassed "Exit: $($r.ExitCode), mentionsTst=$mentionsTst, emitsSourceLine=$emitsSourceLine. Output: $($r.Output)"
-} catch {
-    Write-TestResult "Fixture.PrefixOnlyInTests.Detected" $false "Exception: $_"
-}
-
-# ── Test 9: Upstream-rule allowlist skips SC2016 et al. (P1-7) ───────────────
-# `# shellcheck disable=SC2016` is a common and legitimate reference in our
-# scripts. The harvester must not demand cspell registration for the SC
-# family — that's an upstream linter, not a code we own.
-Write-Host "`n  Section: Upstream-rule allowlist (SC/MD/CS/SA)" -ForegroundColor White
-try {
-    $fixture = New-FixtureRoot
-    @"
+"@
+        }
+        ExpectExitZero = $false
+        MustMatch      = @('\bTST\b', 'test-lint-novel\.ps1:')
+    },
+    @{
+        # `# shellcheck disable=SC2016` is a legitimate reference in our scripts.
+        # The harvester must not demand cspell registration for an upstream
+        # linter's family.
+        Name           = 'Fixture.UpstreamRuleAllowlist.SkipsSCandMD'
+        Files          = [ordered]@{
+            'scripts/lint-upstream-refs.ps1' = @"
 # Synthetic lint script that references SC2016 in a comment disable tag,
 # and MD025 in a markdownlint rule reference. Neither should cause the
 # validator to flag SC or MD as missing from cspell.
 # shellcheck disable=SC2016
 # See MD025 (markdownlint) upstream.
 Write-Host 'nothing emitted'
-"@ | Set-Content -LiteralPath (Join-Path $fixture 'scripts/lint-upstream-refs.ps1')
+"@
+        }
+        ExpectExitZero = $true
+        MustNotMatch   = @('(?m)^\s+SC\b', '(?m)^\s+MD\b')
+    }
+)
 
-    $r = Invoke-ValidatorInFixture -FixtureRoot $fixture
-    $passed = ($r.ExitCode -eq 0)
-    # The output SHOULD NOT claim SC or MD is unregistered.
-    $noSpuriousSc = ($r.Output -notmatch '(?m)^\s+SC\b')
-    $noSpuriousMd = ($r.Output -notmatch '(?m)^\s+MD\b')
-    $allPassed = $passed -and $noSpuriousSc -and $noSpuriousMd
-    Write-TestResult "Fixture.UpstreamRuleAllowlist.SkipsSCandMD" $allPassed "Exit: $($r.ExitCode), noSpuriousSc=$noSpuriousSc, noSpuriousMd=$noSpuriousMd. Output: $($r.Output)"
-} catch {
-    Write-TestResult "Fixture.UpstreamRuleAllowlist.SkipsSCandMD" $false "Exception: $_"
+# ── Phase 1: seed every fixture and start every validator ────────────────────
+$running = @()
+foreach ($scenario in $scenarios) {
+    $useRealRepo = $scenario.Contains('UseRealRepo') -and $scenario.UseRealRepo
+    if ($useRealRepo) {
+        $workingDirectory = $repoRoot
+        $scriptPath = $validatorPath
+        $argumentList = @('-NoProfile', '-File', $scriptPath)
+    }
+    else {
+        $workingDirectory = New-FixtureRoot
+        foreach ($relativePath in $scenario.Files.Keys) {
+            $destination = Join-Path $workingDirectory $relativePath
+            Set-Content -LiteralPath $destination -Value $scenario.Files[$relativePath]
+        }
+        $scriptPath = Join-Path $workingDirectory 'scripts/validate-lint-error-codes.ps1'
+        $argumentList = @('-NoProfile', '-File', $scriptPath, '-VerboseOutput')
+    }
+
+    $outputPath = Join-Path $tempRoot "$($scenario.Name).out"
+    $errorPath = Join-Path $tempRoot "$($scenario.Name).err"
+    Write-Info "Starting $($scenario.Name) in $workingDirectory"
+    $process = Start-Process -FilePath 'pwsh' -ArgumentList $argumentList `
+        -WorkingDirectory $workingDirectory -PassThru -NoNewWindow `
+        -RedirectStandardOutput $outputPath -RedirectStandardError $errorPath
+    $running += @{
+        Scenario   = $scenario
+        Process    = $process
+        OutputPath = $outputPath
+        ErrorPath  = $errorPath
+    }
 }
+
+# ── Phase 2: wait, then assert in declaration order ──────────────────────────
+function Read-IfPresent {
+    param([string]$Path)
+    if (Test-Path -LiteralPath $Path) {
+        return (Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue)
+    }
+    return ''
+}
+
+foreach ($entry in $running) {
+    $scenario = $entry.Scenario
+    Write-Host "`n  Section: $($scenario.Name)" -ForegroundColor White
+    try {
+        $entry.Process.WaitForExit()
+        $exitCode = $entry.Process.ExitCode
+        $output = (Read-IfPresent $entry.OutputPath) + (Read-IfPresent $entry.ErrorPath)
+
+        $reasons = @()
+        if (-not ($scenario.Contains('IgnoreExitCode') -and $scenario.IgnoreExitCode)) {
+            $exitOk = if ($scenario.ExpectExitZero) { $exitCode -eq 0 } else { $exitCode -ne 0 }
+            if (-not $exitOk) {
+                $expectation = if ($scenario.ExpectExitZero) { 'zero' } else { 'non-zero' }
+                $reasons += "expected $expectation exit, got $exitCode"
+            }
+        }
+        if ($scenario.Contains('MustMatch')) {
+            foreach ($pattern in $scenario.MustMatch) {
+                if ($output -notmatch $pattern) { $reasons += "output did not match /$pattern/" }
+            }
+        }
+        if ($scenario.Contains('MustNotMatch')) {
+            foreach ($pattern in $scenario.MustNotMatch) {
+                if ($output -match $pattern) { $reasons += "output unexpectedly matched /$pattern/" }
+            }
+        }
+
+        Write-TestResult $scenario.Name ($reasons.Count -eq 0) "$($reasons -join '; '). Exit: $exitCode. Output: $output"
+    }
+    catch {
+        Write-TestResult $scenario.Name $false "Exception: $_"
+    }
+}
+
 
 # ── Cleanup ──────────────────────────────────────────────────────────────────
 if (Test-Path -LiteralPath $tempRoot) {

--- a/scripts/tests/test-validate-lint-error-codes.ps1
+++ b/scripts/tests/test-validate-lint-error-codes.ps1
@@ -62,7 +62,12 @@ $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $validatorPath = Join-Path $repoRoot 'scripts/validate-lint-error-codes.ps1'
 
 $tempBase = if ($env:TEMP) { $env:TEMP } elseif ($env:TMPDIR) { $env:TMPDIR } else { '/tmp' }
-$tempRoot = Join-Path $tempBase "test-validate-lint-error-codes-$(Get-Random)"
+# The space is deliberate and load-bearing. `Start-Process -ArgumentList <array>` joins the array
+# WITHOUT quoting, so a spaced path silently truncates at the space and pwsh answers its usage banner
+# with exit 64 -- which reads as "the validator failed" and would keep the four failure-asserting
+# scenarios green while measuring nothing. Every fixture lives under a spaced path so that regression
+# cannot come back quietly.
+$tempRoot = Join-Path $tempBase "test-validate-lint-error-codes $(Get-Random)"
 New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
 
 # Build a synthetic repo that mimics the real layout: scripts/lint-*.ps1 files
@@ -270,36 +275,35 @@ foreach ($scenario in $scenarios) {
         $argumentList = @('-NoProfile', '-File', $scriptPath, '-VerboseOutput')
     }
 
-    $outputPath = Join-Path $tempRoot "$($scenario.Name).out"
-    $errorPath = Join-Path $tempRoot "$($scenario.Name).err"
     Write-Info "Starting $($scenario.Name) in $workingDirectory"
-    $process = Start-Process -FilePath 'pwsh' -ArgumentList $argumentList `
-        -WorkingDirectory $workingDirectory -PassThru -NoNewWindow `
-        -RedirectStandardOutput $outputPath -RedirectStandardError $errorPath
+    # ProcessStartInfo.ArgumentList escapes each argument individually; Start-Process's -ArgumentList
+    # does not. Both streams are drained asynchronously from the moment the process starts, so a
+    # scenario that fills a pipe cannot deadlock against the WaitForExit below.
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = 'pwsh'
+    foreach ($argument in $argumentList) { [void]$startInfo.ArgumentList.Add($argument) }
+    $startInfo.WorkingDirectory = $workingDirectory
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.UseShellExecute = $false
+    $process = [System.Diagnostics.Process]::Start($startInfo)
     $running += @{
-        Scenario   = $scenario
-        Process    = $process
-        OutputPath = $outputPath
-        ErrorPath  = $errorPath
+        Scenario       = $scenario
+        Process        = $process
+        StandardOutput = $process.StandardOutput.ReadToEndAsync()
+        StandardError  = $process.StandardError.ReadToEndAsync()
     }
 }
 
 # ── Phase 2: wait, then assert in declaration order ──────────────────────────
-function Read-IfPresent {
-    param([string]$Path)
-    if (Test-Path -LiteralPath $Path) {
-        return (Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue)
-    }
-    return ''
-}
-
 foreach ($entry in $running) {
     $scenario = $entry.Scenario
     Write-Host "`n  Section: $($scenario.Name)" -ForegroundColor White
     try {
         $entry.Process.WaitForExit()
         $exitCode = $entry.Process.ExitCode
-        $output = (Read-IfPresent $entry.OutputPath) + (Read-IfPresent $entry.ErrorPath)
+        $output = $entry.StandardOutput.GetAwaiter().GetResult() +
+            $entry.StandardError.GetAwaiter().GetResult()
 
         $reasons = @()
         if (-not ($scenario.Contains('IgnoreExitCode') -and $scenario.IgnoreExitCode)) {

--- a/scripts/unity/bootstrap-windows-runner.ps1
+++ b/scripts/unity/bootstrap-windows-runner.ps1
@@ -283,6 +283,10 @@ function Invoke-RunnerInstaller {
         Assert-RunnerMicrosoftAuthenticodeSignature -Path $installerPath
 
         Write-RunnerBootstrapInfo "Running $FileName $($Arguments -join ' ')"
+        # -ArgumentList joins an array without quoting, so a value containing a space would
+        # truncate. Safe here and deliberately left alone: every caller passes fixed switches
+        # (/q, /install, /quiet, /norestart) and -Wait waits for installer descendants in a way
+        # Process.WaitForExit does not.
         $process = Start-Process -FilePath $installerPath -ArgumentList $Arguments -Wait -PassThru
         if ($process.ExitCode -ne 0 -and $process.ExitCode -ne 3010) {
             throw "$FileName exited with code $($process.ExitCode)."


### PR DESCRIPTION
**Why:** An attribute deserialized while buffed reported its base value in the editor, and a single effect-authoring mistake was re-reported on every application.

**What:**

- `Attribute.CurrentValue` keys its cache on the base value it was calculated from, instead of discarding the cache whenever `Application.isPlaying` is false.
- An `AttributeEffect` authoring mistake is reported in the Inspector and once per effect, not once per application — three sites, each of which rendered the whole effect to JSON at 20.5 us.
- New EditMode fixtures live in an editor-only assembly, which is the only kind Unity's EditMode runner executes.
- `validate-lint-error-codes` starts its nine scenarios together: 81.3 s -> 16.2 s.
- `lint-tests` caches the directories it walks looking for an asmdef: 92.0 s -> 25.7 s, byte-identical output.

Fixes #569
Fixes #567

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core attribute caching and effect-application logging paths used in editor and runtime; behavior is covered by new EditMode tests but affects saved/deserialized attribute values.
> 
> **Overview**
> Fixes **`Attribute.CurrentValue`** so edit mode no longer throws away the cache whenever `Application.isPlaying` is false. The getter now reuses the cache only when `_calculatedFromBaseValue` still matches `_baseValue`, so JSON round-trips keep a buffed value and direct `_baseValue` writes (Inspector / prefab / undo) trigger recalculation. EditMode tests were added because Unity’s EditMode runner only runs editor-only assemblies.
> 
> **`AttributeEffect` / `EffectHandler`** misconfiguration is reported once per asset instead of on every apply: Instant effects with periodic/behavior data and unassigned cosmetic slots warn in **`OnValidate`** and at most once at runtime, using effect **names** instead of `{effect:json}` (and the duplicate Instant warning in `InternalApplyEffect` is removed).
> 
> Supporting changes: LLM skills/docs now say **`foreach` boxing comes from interface-typed iteration**, not concrete `List<T>`; **`test-validate-lint-error-codes.ps1`** runs nine scenarios in parallel via **`ProcessStartInfo.ArgumentList`** with space-bearing temp paths; **`lint-tests.ps1`** caches asmdef walks and uses **`EnumerateFiles`** for speed; effects docs and CHANGELOG entries for #567 / #569.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683adfa443886b11424ffdc21aa3aa20b129db5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->