### PR TITLE
Stop naming assemblies Unity will not run in EditMode

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -44,8 +44,16 @@ jobs:
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
 
+      # uv resolves and installs by hard-linking from its cache instead of unpacking wheels.
+      # Measured on this repository's requirements-docs.txt into a fresh environment, both with a
+      # warm cache: pip 5.20 s best of three, uv 0.06 s -- and this step is 11 s of a 31 s job
+      # (#338). pip installs uv itself in ~2 s, which keeps setup-python's cache doing the
+      # downloading and adds no new action to pin.
       - name: Install dependencies
-        run: pip install -r requirements-docs.txt
+        run: |
+          set -euo pipefail
+          pip install uv==0.12.6
+          uv pip install --system -r requirements-docs.txt
 
       - name: Build with MkDocs
         run: mkdocs build --strict

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -70,30 +70,32 @@ jobs:
           const performanceAssembly = "WallstopStudios.UnityHelpers.Tests.Runtime.Performance";
           const randomAssembly = "WallstopStudios.UnityHelpers.Tests.Runtime.Random";
 
+          // PlayMode only. Both benchmark assemblies are platform-neutral, and Unity's EditMode
+          // runner takes only assemblies flagged EditorAssembly -- so the four editmode legs
+          // were handed two assembly names, ran zero tests, and failed "Verify tests actually
+          // ran" on every scheduled run. Measured: the 2021.3.45f1 editmode leg's log mentions
+          // Tests.Runtime.Random three times (the echoed list) against 2,375 in playmode
+          // (#570). The thorough Random sweep the editmode leg was configured for moves here,
+          // which is the only mode that can execute it.
           function benchmarkProfile(target) {
             const discovered = discovery.defaultIncludeAssemblies(process.cwd(), {
               includePerf: true,
               target
             });
-            if (!discovered.includes(performanceAssembly)) {
-              throw new Error(`The ${target} benchmark profile did not discover ${performanceAssembly}.`);
+            for (const required of [performanceAssembly, randomAssembly]) {
+              if (!discovered.includes(required)) {
+                throw new Error(`The ${target} benchmark profile did not discover ${required}.`);
+              }
             }
-            if (target === "editmode" && !discovered.includes(randomAssembly)) {
-              throw new Error(`The editmode benchmark profile did not discover ${randomAssembly}.`);
-            }
-            const assemblies = target === "editmode"
-              ? [performanceAssembly, randomAssembly]
-              : [performanceAssembly];
-            return assemblies.join(";");
+            return [performanceAssembly, randomAssembly].join(";");
           }
 
           const profiles = {
-            editmode: benchmarkProfile("editmode"),
             playmode: benchmarkProfile("playmode")
           };
           const include = [];
           for (const version of versions) {
-            for (const mode of ["editmode", "playmode"]) {
+            for (const mode of ["playmode"]) {
               include.push({
                 "unity-version": version,
                 "test-mode": mode,
@@ -289,19 +291,18 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          # EditMode also owns the thorough Random sweep. Selecting both its
+          # This leg also owns the thorough Random sweep. Selecting both its
           # assembly and Fast category folds that sweep into this one Unity
           # launch while the explicit assembly list prevents unrelated Fast
           # tests from entering the benchmark lane.
           UH_BENCHMARK_ASSEMBLIES: ${{ matrix.assemblies }}
-          UH_UNITY_TEST_CATEGORY: >-
-            ${{ matrix.test-mode == 'editmode' && 'Performance;Stress;Fast' || 'Performance;Stress' }}
-          UH_RANDOM_SAMPLE_COUNT: ${{ matrix.test-mode == 'editmode' && '12750000' || '' }}
-          UH_RANDOM_NOISE_MAP_ITERATIONS: ${{ matrix.test-mode == 'editmode' && '1000' || '' }}
-          # The combined EditMode pass previously had two independent 80-minute
-          # watchdog budgets. Keep deliberate combined headroom while leaving
-          # ten minutes for cleanup before this step's 120-minute hard limit.
-          UH_EDITOR_TEST_TIMEOUT_SECONDS: ${{ matrix.test-mode == 'editmode' && '6600' || '' }}
+          UH_UNITY_TEST_CATEGORY: "Performance;Stress;Fast"
+          UH_RANDOM_SAMPLE_COUNT: "12750000"
+          UH_RANDOM_NOISE_MAP_ITERATIONS: "1000"
+          # The combined pass previously had two independent 80-minute watchdog
+          # budgets. Keep deliberate combined headroom while leaving ten minutes
+          # for cleanup before this step's 120-minute hard limit.
+          UH_EDITOR_TEST_TIMEOUT_SECONDS: "6600"
           UH_PERF_COMMIT: ${{ github.sha }}
         run: |
           # Release (not Debug) code optimization for the editmode/playmode perf

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -606,14 +606,22 @@ jobs:
       # git-auto-commit-action is a no-op when there is no diff, so a run that
       # produced no new results does not create an empty commit.
       #
-      # TODO(unity-helpers): if the default branch is protected such that the
-      # built-in GITHUB_TOKEN cannot push (branch protection / required reviews),
-      # this direct commit will be REJECTED. DxMessaging's perf-numbers.yml hit
-      # exactly this and switched to a GitHub App installation token
-      # (actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1) that opens an auto-merge PR instead.
-      # If that happens here, provision an App token and mirror that rationale;
-      # the default below is the simplest path that works on an UNprotected
-      # default branch.
+      # A direct push to main is permitted today, and that was measured rather than
+      # assumed (#515). `"protected": true` on the branch object is set by ANY
+      # ruleset, including ones that allow pushes: GET /branches/main/protection
+      # returns 404 "Branch not protected", and the only rules on main come from
+      # ruleset 15358326 -- deletion, non_fast_forward and copilot_code_review.
+      # None of those blocks a fast-forward push, there is no pull_request rule
+      # and no required_status_checks rule, and 10 of the last 100 commits on main
+      # were pushed by bots.
+      #
+      # The moment a pull_request or required_status_checks rule is added, this
+      # push starts failing on the following Sunday. The fallback is DxMessaging's
+      # perf-numbers.yml: a GitHub App installation token
+      # (actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1)
+      # that opens an auto-merge PR. It has to be an App token, not the built-in
+      # one -- a pull request opened with GITHUB_TOKEN does not trigger workflows,
+      # so its required checks never start and auto-merge stalls forever.
       - name: Commit perf results
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d
         with:

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -50,8 +50,16 @@ jobs:
           cache: pip
           cache-dependency-path: requirements-docs.txt
 
+      # uv resolves and installs by hard-linking from its cache instead of unpacking wheels.
+      # Measured on this repository's requirements-docs.txt into a fresh environment, both with a
+      # warm cache: pip 5.20 s best of three, uv 0.06 s -- and this step is 11 s of a 31 s job
+      # (#338). pip installs uv itself in ~2 s, which keeps setup-python's cache doing the
+      # downloading and adds no new action to pin.
       - name: Install dependencies
-        run: pip install -r requirements-docs.txt
+        run: |
+          set -euo pipefail
+          pip install uv==0.12.6
+          uv pip install --system -r requirements-docs.txt
 
       - name: Build MkDocs site
         run: mkdocs build --strict

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -66,7 +66,7 @@ See [create-csharp-file](./skills/create-csharp-file.md) for detailed C# rules.
 3. Explicit types over `var`
 4. **NEVER use `#region` or `#endregion`** (see [no-regions](./skills/no-regions.md))
 5. NEVER use nullable reference types (`string?`)
-6. One file per MonoBehaviour/ScriptableObject (production AND tests)
+6. One file per MonoBehaviour/ScriptableObject (production AND tests); a nested type goes at the END of its containing type or in its own file, never between members (backlog [#575](https://github.com/Ambiguous-Interactive/unity-helpers/issues/575))
 7. NEVER use `?.`, `??`, `??=` on UnityEngine.Object types
 8. Minimal comments -- only explain **why**, never **what**
 9. Generate `.meta` files after creating ANY file/folder (see [create-unity-meta](./skills/create-unity-meta.md)); exception: no `.meta` for dot folders (`.llm/`, `.github/`, `.git/`, `.vscode/`). Use `./scripts/generate-meta.sh <path>` for new or empty folders, then run `npm run agent:preflight:fix` for changed-file `.meta` recovery.

--- a/.llm/skills/bash-pwsh-invocation.md
+++ b/.llm/skills/bash-pwsh-invocation.md
@@ -27,7 +27,7 @@ pwsh -NoProfile -File scripts/lint-foo.ps1 -Paths "${FILES[@]}"
 
 These rules are enforced by:
 
-1. `scripts/lint-pwsh-invocations.ps1` — scans `*.sh`, `.githooks/*`, `.github/workflows/*.yml`, `scripts/**/*.ps1`, and `package.json` for `-File`/`-f <script> --` (code `PWS001`) and extensionless hook `-File`/`-f` targets (code `PWS004`).
+1. `scripts/lint-pwsh-invocations.ps1` — scans `*.sh`, `.githooks/*`, `.github/workflows/*.yml`, `scripts/**/*.ps1`, and `package.json` for `-File`/`-f <script> --` (code `PWS001`) and extensionless hook `-File`/`-f` targets (code `PWS004`), and reads `scripts/**/*.ps1` plus `.githooks/*.ps1` as an AST for `PWS005` and `PWS006`.
 2. `.github/workflows/pwsh-invocations-lint.yml` — runs the lint on every PR that touches hook/workflow/script files.
 3. `scripts/tests/test-precommit-integration.sh` — smoke-tests that each pwsh-invoked hook branch works.
 4. `scripts/validate-lint-error-codes.ps1` — enforces that the `PWS` prefix (and any other lint-error-code prefix introduced by a new lint script) is registered in `cspell.json`, so the skill/doc tokens `PWS001`/`PWS002` do not trip the spell checker.
@@ -136,6 +136,14 @@ very script. The failure is silent -- `-Paths a b c` lints `a`, skips `b` and `c
 - `PWS002`: `& <script-var-or-path>.ps1 --` in `scripts/tests/*.ps1`.
 - `PWS003`: top-level `scripts/*.ps1` invokes `pwsh[.exe]|powershell[.exe] -File|-f <sibling>`. Nested scripts and tests are excluded for this rule.
 - `PWS004`: `pwsh[.exe]|powershell[.exe] -File|-f .githooks/<extensionless-hook>` in `*.sh`, `.githooks/*`, workflows, `scripts/**/*.ps1`, and `package.json`.
+- `PWS005`: a script-level array parameter without BOTH a `ValueFromRemainingArguments` sibling and `[CmdletBinding(PositionalBinding = $false)]`.
+- `PWS006`: `Start-Process -ArgumentList|-Args <array|@()|variable>`.
+
+`PWS005` and `PWS006` are AST rules rather than line scans, and they read `scripts/**/*.ps1` plus
+`.githooks/*.ps1`. Both skip files `git` reports as ignored: CI checks out tracked content only, so
+a violation in a developer's scratch script is one the repository cannot fix and CI can never see.
+An untracked file that is NOT ignored is still scanned -- a new script you forgot to stage is
+exactly the one a rule should catch -- and where `git` cannot answer, nothing is excluded.
 
 Detection beyond a single physical line:
 
@@ -223,15 +231,26 @@ Two caveats before converting a call site:
 - **A test whose fixtures live under a spaceless path cannot see this.** Put the space in the
   fixture root so the regression cannot come back quietly:
   `Join-Path $tempBase "my-test $(Get-Random)"`. Reverting the launch mechanism under that root
-  reddens six of nine scenarios in `test-validate-lint-error-codes.ps1`; the two that stay green are
-  the ones asserting only a non-zero exit.
+  reddens six of nine scenarios in `test-validate-lint-error-codes.ps1`; the three that stay green
+  are the ones asserting only a non-zero exit or the absence of a crash marker.
 
-**Not currently linted.** `PWS006` is the obvious home and is filed as
-[#572](https://github.com/Ambiguous-Interactive/unity-helpers/issues/572); until it exists this rule
-is documentation. The repository has exactly **two** tracked `Start-Process -ArgumentList` sites --
-`scripts/tests/test-validate-lint-error-codes.ps1`, which no longer uses it, and the installer
-above -- so check with `git ls-files` rather than a working-tree grep: `scripts/run-unity*` is
-gitignored, and an untracked local copy is not a call site this repository ships.
+**`PWS006` enforces this** (#572). It matches the command and its `-ArgumentList` as one thing in
+the AST -- matching them independently over the file is the mistake #556's CSS gate made -- and
+reports only the three shapes that can hold more than one argument: an array literal, an `@()`
+expression, and a variable, whose contents the linter cannot know. A string literal is quoted by
+its author and is left alone.
+
+Opt out **per site**, not per file, when the arguments really are fixed switches:
+
+```powershell
+# lint-pwsh-invocations: allow-start-process-argument-list every caller passes fixed switches
+# and -Wait waits on installer descendants in a way Process.WaitForExit does not.
+$process = Start-Process -FilePath $installerPath -ArgumentList $Arguments -Wait -PassThru
+```
+
+The marker may be a trailing comment on the invocation or a line of the comment block directly
+above it; a blank line ends that block, and a marker with no rationale is not an opt-out. The
+installer above is the one live site that carries it.
 
 ## Quick Reference
 

--- a/.llm/skills/create-csharp-file.md
+++ b/.llm/skills/create-csharp-file.md
@@ -125,6 +125,32 @@ if (condition)
 - Organize code through class structure and file organization instead
 - See [no-regions](./no-regions.md) for alternatives
 
+### 5b. Nested Types Go LAST
+
+A nested `class`, `struct`, `enum`, `interface` or `record` belongs at the **end** of its
+containing type, or in its own file. Never between members.
+
+```csharp
+public sealed class Attribute
+{
+    public float CurrentValue => ...;
+
+    private RemainingActions ApplyModificationsInOrder(...) { ... }
+
+    // ✅ every member first, the nested type last
+    private readonly struct RemainingActions
+    {
+        public readonly bool hasMultiplication;
+    }
+}
+```
+
+A reader scrolling for a method should not have to step over a type declaration to find it, and a
+nested type in the middle reads as the start of a new file's worth of content. Owner review, PR
+\#574. The existing backlog -- 249 sites across 178 files when the rule was written -- is tracked
+on [#575](https://github.com/Ambiguous-Interactive/unity-helpers/issues/575); it is not a licence
+to add more.
+
 ### 6. NEVER Use Nullable Reference Types
 
 - ❌ `string?`, `object?`, `List<string>?`, `MyClass?`

--- a/.llm/skills/unity-devcontainer-testing.md
+++ b/.llm/skills/unity-devcontainer-testing.md
@@ -226,6 +226,23 @@ limit ([#568](https://github.com/Ambiguous-Interactive/unity-helpers/issues/568)
   ([#569](https://github.com/Ambiguous-Interactive/unity-helpers/issues/569)). When a change touches
   an edit-mode branch of runtime code, the fixture belongs in an editor-only assembly.
 
+  The seven, named so nobody has to re-measure them:
+  `Tests.Core`, `Tests.Runtime`, `Tests.Runtime.Performance`, `Tests.Runtime.Random`,
+  `Tests.Runtime.Reflex`, `Tests.Runtime.VContainer` and `Tests.Runtime.Zenject`, all under the
+  `WallstopStudios.UnityHelpers.` prefix. `scripts/tests/test-asmdef-discovery.js` holds that list
+  and fails if an eighth appears, and `defaultIncludeAssemblies({ target: "editmode" })` no longer
+  returns any of them -- the list CI hands the editmode legs used to be a superset of what Unity
+  would run, which is what made the gap invisible
+  ([#570](https://github.com/Ambiguous-Interactive/unity-helpers/issues/570)).
+
+  It also cost a whole workflow. `unity-benchmarks.yml` gave its EditMode legs
+  `Tests.Runtime.Performance` and `Tests.Runtime.Random`; both are platform-neutral, so those four
+  legs ran **zero** tests and failed `Verify tests actually ran` on every scheduled run. Confirmed
+  in CI rather than inferred: the `2021.3.45f1` editmode leg's log mentions `Tests.Runtime.Random`
+  three times -- the assembly list being echoed -- against **2,375** times in the playmode leg, and
+  `PoolLifecycleHooksTests` runs 94 times in playmode and 0 times in editmode. The benchmark matrix
+  is playmode-only now, carrying the thorough Random configuration with it.
+
 - `WaitForEndOfFrame` does not work in batch mode (PlayMode tests)
 - Xvfb provides 0 Hz virtual display - frame timing may differ from real editor
 - First run is slow (Docker image pull ~3-4 GB); subsequent runs use cached image

--- a/.llm/skills/unity-mcp-fixture-runner.md
+++ b/.llm/skills/unity-mcp-fixture-runner.md
@@ -92,6 +92,14 @@ executed partially`. `SerializableDictionary<,>.Add` and `Serializer.JsonSeriali
   Arity matching avoids both failure modes, but only if the arity is the _right_ one: selecting
   `JsonSerialize` on `ps.Length >= 1` picked a five-parameter overload and cost a round to
   `TargetParameterCountException`. Pin the return type too when overloads differ by it.
+- **The sandbox wraps your class in `Unity.AI.Assistant.Agent.Dynamic.Extension.Editor`, so a
+  `using UnityEditor.Compilation;` does not make `CompilationPipeline` resolve.** C# searches
+  enclosing namespaces before imports, `Unity.CompilationPipeline` exists, and it wins -- the error
+  is `CS0234: The type or namespace name 'GetAssemblies' does not exist in the namespace
+'Unity.CompilationPipeline'`, which reads as a missing assembly reference rather than a name
+  collision. Fully qualify (`UnityEditor.Compilation.CompilationPipeline`) and the same call
+  compiles unchanged. Anything under a `Unity.*` namespace is exposed to this; the returned
+  `localFixedCode` shows the wrapper, so read it before believing a reference is missing.
 - **A second edit in the same session may not auto-compile, and the refresh that forces it kills its
   own command.** The first write of a session was picked up on its own within ~90 s; a later one was
   still not compiled after ~110 s with `IsCompiling: false`. A `RunCommand` whose whole body is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- An attribute with only additive modifications recalculates 2.85x faster: 0.4563 us before, 0.1600 us now, measured on `6000.4.6f1`. Addition, Multiplication and Override each got a full pass over every modification whether or not any carried that action ([#529](https://github.com/Ambiguous-Interactive/unity-helpers/issues/529)).
 - A relational field that finds nothing is ~15x cheaper to assign: 366-431 us before, 25.1 us now, measured on `6000.4.6f1` against a control that did not move. Unity captured a stack trace for the error log on every assignment, and for a collection field finding nothing is a normal state ([#564](https://github.com/Ambiguous-Interactive/unity-helpers/issues/564), [#529](https://github.com/Ambiguous-Interactive/unity-helpers/issues/529)).
 - **`RomuDuo` now implements published romuDuo, so a given seed produces a different sequence than in 3.5.1.** No saved seed or `RandomState` carries a sequence across this change; pin a generator whose stream is unchanged if you need one to ([#509](https://github.com/Ambiguous-Interactive/unity-helpers/issues/509)).
 - `DisjointSet.TryGetAllSets()` is 2.4x-3.2x faster and allocates no temporary lists. It gathered every element into a per-root scratch list and then copied all of them a second time; elements now go straight into their result list, found through a dense index rather than a hash lookup ([#309](https://github.com/Ambiguous-Interactive/unity-helpers/issues/309)).

--- a/Generator~/Directory.Build.props
+++ b/Generator~/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project>
+  <!--
+    Compiler warnings are errors here, at the maximum warning level, for every project under
+    Generator~ (including TypeCheck and TestCheck, which compile the real Runtime/, Editor/ and
+    Tests/ sources against the Unity reference assemblies). Measured before turning it on: at
+    WarningLevel 9999 those trees produce ZERO CS warnings, so this locks in a property the
+    repository already has rather than starting a cleanup (#378).
+
+    The .NET analyzer suite is deliberately NOT enabled. Measured on the same build with
+    EnableNETAnalyzers=true and AnalysisLevel=latest-recommended: 756 findings across 35 rules and
+    119 files, dominated by CA1815, CA1508, CA1000 and CA1715. That is a project, and mostly
+    opinion, where the compiler half is free. The inventory is recorded on #378.
+  -->
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningLevel>9999</WarningLevel>
+  </PropertyGroup>
+</Project>

--- a/Generator~/WallstopStudios.UnityHelpers.Analyzers.Tests/WallstopStudios.UnityHelpers.Analyzers.Tests.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.Analyzers.Tests/WallstopStudios.UnityHelpers.Analyzers.Tests.csproj
@@ -11,6 +11,13 @@
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
+    <!--
+      Warnings are NOT errors here, unlike everywhere else under Generator~. Two reasons, both
+      about what this project compiles: its fixtures deliberately trigger the generator's own
+      WPROTO diagnostics (that is the test data), and it pulls in Runtime/ sources under a net9.0
+      TFM, where the .NET CA analyzers are on by default and report the inventory recorded on #378.
+    -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <AssemblyName>WallstopStudios.UnityHelpers.Analyzers.Tests</AssemblyName>

--- a/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/WallstopStudios.UnityHelpers.Proto.Generator.Tests.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/WallstopStudios.UnityHelpers.Proto.Generator.Tests.csproj
@@ -3,6 +3,13 @@
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
+    <!--
+      Warnings are NOT errors here, unlike everywhere else under Generator~. Two reasons, both
+      about what this project compiles: its fixtures deliberately trigger the generator's own
+      WPROTO diagnostics (that is the test data), and it pulls in Runtime/ sources under a net9.0
+      TFM, where the .NET CA analyzers are on by default and report the inventory recorded on #378.
+    -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <!-- Compiled from the repository root so the generator sees the same sources Unity does. -->

--- a/Generator~/WallstopStudios.UnityHelpers.Proto.Generator/WProtoGenerator.cs
+++ b/Generator~/WallstopStudios.UnityHelpers.Proto.Generator/WProtoGenerator.cs
@@ -1093,8 +1093,12 @@ namespace WallstopStudios.UnityHelpers.Proto.Generator
                 // uninitialized allocation leaves at its default, so the property it belongs to is
                 // what the developer has to be pointed at. Its own attributes are the ones that
                 // matter, including the [WProtoMember] that would put it on the wire.
+                // ReferenceEquals, not `!=`: the question is identity -- did the null-coalesce
+                // above hand back the associated property rather than the field itself -- and
+                // RS1024 rejects `==`/`!=` on symbols because it cannot tell that apart from a
+                // value comparison across compilations.
                 ISymbol declared = field.AssociatedSymbol ?? field;
-                if (declared != field && HasAttribute(declared, MemberAttribute))
+                if (!ReferenceEquals(declared, field) && HasAttribute(declared, MemberAttribute))
                 {
                     continue;
                 }

--- a/Runtime/Tags/Attribute.cs
+++ b/Runtime/Tags/Attribute.cs
@@ -134,9 +134,40 @@ namespace WallstopStudios.UnityHelpers.Tags
             float calculatedValue = _baseValue;
             if (0 < _modifications.Count)
             {
-                ApplyModificationsInOrder(ModificationAction.Addition, ref calculatedValue);
-                ApplyModificationsInOrder(ModificationAction.Multiplication, ref calculatedValue);
-                ApplyModificationsInOrder(ModificationAction.Override, ref calculatedValue);
+                // The Addition pass has to visit every modification anyway, so it reports which
+                // other actions are present and the other two passes are skipped when they would
+                // find nothing. Most effects use one action, so this is usually one traversal
+                // rather than three: measured 0.464 us -> 0.171 us for three handles of two
+                // additions, on 6000.4.6f1 (#529).
+                //
+                // The passes stay separate and in this order. Addition, Multiplication and
+                // Override are not interchangeable, and a single pass accumulating them would
+                // also change the ORDER of the float additions, which changes their result.
+                ApplyModificationsInOrder(
+                    ModificationAction.Addition,
+                    ref calculatedValue,
+                    out bool hasMultiplication,
+                    out bool hasOverride
+                );
+                if (hasMultiplication)
+                {
+                    ApplyModificationsInOrder(
+                        ModificationAction.Multiplication,
+                        ref calculatedValue,
+                        out _,
+                        out _
+                    );
+                }
+
+                if (hasOverride)
+                {
+                    ApplyModificationsInOrder(
+                        ModificationAction.Override,
+                        ref calculatedValue,
+                        out _,
+                        out _
+                    );
+                }
             }
 
             _currentValue = calculatedValue;
@@ -283,8 +314,15 @@ namespace WallstopStudios.UnityHelpers.Tags
             _currentValueCalculated = false;
         }
 
-        private void ApplyModificationsInOrder(ModificationAction action, ref float value)
+        private void ApplyModificationsInOrder(
+            ModificationAction action,
+            ref float value,
+            out bool hasMultiplication,
+            out bool hasOverride
+        )
         {
+            hasMultiplication = false;
+            hasOverride = false;
             foreach (
                 KeyValuePair<EffectHandle, List<AttributeModification>> entry in _modifications
             )
@@ -293,9 +331,25 @@ namespace WallstopStudios.UnityHelpers.Tags
                 for (int index = 0; index < modifications.Count; index++)
                 {
                     AttributeModification modification = modifications[index];
-                    if (modification.action == action)
+                    ModificationAction modificationAction = modification.action;
+                    if (modificationAction == action)
                     {
                         ApplyAttributeModification(modification, ref value);
+                        continue;
+                    }
+
+                    switch (modificationAction)
+                    {
+                        case ModificationAction.Multiplication:
+                        {
+                            hasMultiplication = true;
+                            break;
+                        }
+                        case ModificationAction.Override:
+                        {
+                            hasOverride = true;
+                            break;
+                        }
                     }
                 }
             }

--- a/Runtime/Tags/Attribute.cs
+++ b/Runtime/Tags/Attribute.cs
@@ -305,21 +305,6 @@ namespace WallstopStudios.UnityHelpers.Tags
             _currentValueCalculated = false;
         }
 
-        // Returned rather than reported through `out` parameters: these accumulate across the
-        // whole traversal, and an `out` assigned anywhere but immediately before the return is the
-        // shape that lets a later path forget to write it.
-        private readonly struct RemainingActions
-        {
-            public readonly bool hasMultiplication;
-            public readonly bool hasOverride;
-
-            public RemainingActions(bool hasMultiplication, bool hasOverride)
-            {
-                this.hasMultiplication = hasMultiplication;
-                this.hasOverride = hasOverride;
-            }
-        }
-
         private RemainingActions ApplyModificationsInOrder(
             ModificationAction action,
             ref float value
@@ -581,6 +566,21 @@ namespace WallstopStudios.UnityHelpers.Tags
         public override string ToString()
         {
             return ((float)this).ToString(CultureInfo.InvariantCulture);
+        }
+
+        // Returned rather than reported through `out` parameters: these accumulate across the
+        // whole traversal, and an `out` assigned anywhere but immediately before the return is the
+        // shape that lets a later path forget to write it.
+        private readonly struct RemainingActions
+        {
+            public readonly bool hasMultiplication;
+            public readonly bool hasOverride;
+
+            public RemainingActions(bool hasMultiplication, bool hasOverride)
+            {
+                this.hasMultiplication = hasMultiplication;
+                this.hasOverride = hasOverride;
+            }
         }
     }
 }

--- a/Runtime/Tags/Attribute.cs
+++ b/Runtime/Tags/Attribute.cs
@@ -143,30 +143,21 @@ namespace WallstopStudios.UnityHelpers.Tags
                 // The passes stay separate and in this order. Addition, Multiplication and
                 // Override are not interchangeable, and a single pass accumulating them would
                 // also change the ORDER of the float additions, which changes their result.
-                ApplyModificationsInOrder(
+                RemainingActions remaining = ApplyModificationsInOrder(
                     ModificationAction.Addition,
-                    ref calculatedValue,
-                    out bool hasMultiplication,
-                    out bool hasOverride
+                    ref calculatedValue
                 );
-                if (hasMultiplication)
+                if (remaining.hasMultiplication)
                 {
-                    ApplyModificationsInOrder(
+                    _ = ApplyModificationsInOrder(
                         ModificationAction.Multiplication,
-                        ref calculatedValue,
-                        out _,
-                        out _
+                        ref calculatedValue
                     );
                 }
 
-                if (hasOverride)
+                if (remaining.hasOverride)
                 {
-                    ApplyModificationsInOrder(
-                        ModificationAction.Override,
-                        ref calculatedValue,
-                        out _,
-                        out _
-                    );
+                    _ = ApplyModificationsInOrder(ModificationAction.Override, ref calculatedValue);
                 }
             }
 
@@ -314,15 +305,28 @@ namespace WallstopStudios.UnityHelpers.Tags
             _currentValueCalculated = false;
         }
 
-        private void ApplyModificationsInOrder(
+        // Returned rather than reported through `out` parameters: these accumulate across the
+        // whole traversal, and an `out` assigned anywhere but immediately before the return is the
+        // shape that lets a later path forget to write it.
+        private readonly struct RemainingActions
+        {
+            public readonly bool hasMultiplication;
+            public readonly bool hasOverride;
+
+            public RemainingActions(bool hasMultiplication, bool hasOverride)
+            {
+                this.hasMultiplication = hasMultiplication;
+                this.hasOverride = hasOverride;
+            }
+        }
+
+        private RemainingActions ApplyModificationsInOrder(
             ModificationAction action,
-            ref float value,
-            out bool hasMultiplication,
-            out bool hasOverride
+            ref float value
         )
         {
-            hasMultiplication = false;
-            hasOverride = false;
+            bool hasMultiplication = false;
+            bool hasOverride = false;
             foreach (
                 KeyValuePair<EffectHandle, List<AttributeModification>> entry in _modifications
             )
@@ -353,6 +357,8 @@ namespace WallstopStudios.UnityHelpers.Tags
                     }
                 }
             }
+
+            return new RemainingActions(hasMultiplication, hasOverride);
         }
 
         private static void ValidateInput(float value, [CallerMemberName] string caller = null)

--- a/Runtime/Tags/EffectHandler.cs
+++ b/Runtime/Tags/EffectHandler.cs
@@ -215,12 +215,22 @@ namespace WallstopStudios.UnityHelpers.Tags
                 }
                 case EffectStackingMode.Stack:
                 {
-                    if (existingHandles is { Count: > 0 } && 0 < effect.maximumStacks)
+                    if (0 < effect.maximumStacks)
                     {
-                        while (effect.maximumStacks <= existingHandles.Count)
+                        // Re-resolved every iteration, never held across RemoveEffect. Removing
+                        // the last handle for a stack key returns that list to the shared buffer
+                        // pool, and RemoveEffect also invokes OnEffectRemoved -- so a subscriber
+                        // that applies an effect, or rents a list of its own, can be handed the
+                        // very list this loop was reading. Replace, three cases up, copies for
+                        // the same reason.
+                        List<EffectHandle> stackHandles = existingHandles;
+                        while (
+                            stackHandles is { Count: > 0 }
+                            && effect.maximumStacks <= stackHandles.Count
+                        )
                         {
-                            EffectHandle oldestHandle = existingHandles[0];
-                            RemoveEffect(oldestHandle);
+                            RemoveEffect(stackHandles[0]);
+                            stackHandles = TryGetStackHandles(stackKey);
                         }
                     }
 

--- a/Tests/Runtime/DataStructures/FastOneOfTests.cs
+++ b/Tests/Runtime/DataStructures/FastOneOfTests.cs
@@ -817,18 +817,19 @@ namespace WallstopStudios.UnityHelpers.Tests.DataStructures
     [NUnit.Framework.Category("Fast")]
     public sealed class NoneTests
     {
+        // `Assert.IsTrue(none != null)` was here twice, and `None` is a struct: the comparison
+        // lifts to `None?` and the compiler proves it always true (CS8073). Neither test could
+        // fail. What they were reaching for -- that `default` and `None.Default` are the same
+        // value -- is asserted below by NoneEqualsDefaultSingleton and
+        // NoneEqualityOperatorReturnsTrue, so this is what they leave behind.
         [Test]
-        public void DefaultNoneIsValid()
+        public void DefaultNoneRoundTripsThroughItsMembers()
         {
             None none = default;
-            Assert.IsTrue(none != null);
-        }
 
-        [Test]
-        public void NoneDefaultSingletonIsValid()
-        {
-            None none = None.Default;
-            Assert.IsTrue(none != null);
+            Assert.AreEqual(None.Default, none);
+            Assert.AreEqual(0, none.GetHashCode());
+            Assert.AreEqual("None", none.ToString());
         }
 
         [Test]

--- a/Tests/Runtime/Pool/PoolSizeAwarePoliciesTests.cs
+++ b/Tests/Runtime/Pool/PoolSizeAwarePoliciesTests.cs
@@ -850,9 +850,34 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Pool
                 }
             );
 
-            // Pool should be created with size-aware effective options
+            // `Assert.IsTrue(stats != null)` was here, and PoolStatistics is a struct: the
+            // compiler proves that always true (CS8073), so the test's only assertion could not
+            // fail. Assert what its name claims instead -- the threshold above makes SmallClass a
+            // large object, so the size-aware options must differ from the base ones in the three
+            // ways GetSizeAwareEffectiveOptions documents.
+            PoolPurgeEffectiveOptions baseOptions =
+                PoolPurgeSettings.GetEffectiveOptions<SmallClass>();
+            PoolPurgeEffectiveOptions sizeAware =
+                PoolPurgeSettings.GetSizeAwareEffectiveOptions<SmallClass>();
+
+            Assert.AreEqual(
+                PoolPurgeSettings.LargeObjectWarmRetainCount,
+                sizeAware.WarmRetainCount,
+                "A large object keeps the large-object warm count"
+            );
+            Assert.LessOrEqual(
+                sizeAware.BufferMultiplier,
+                baseOptions.BufferMultiplier,
+                "A large object never buffers more than the base policy"
+            );
+            Assert.LessOrEqual(
+                sizeAware.IdleTimeoutSeconds,
+                baseOptions.IdleTimeoutSeconds,
+                "A large object is never held idle longer than the base policy"
+            );
+
             PoolStatistics stats = pool.GetStatistics();
-            Assert.IsTrue(stats != null, "Pool statistics should not be null");
+            Assert.AreEqual(0, stats.CurrentSize, "Nothing has been returned to the pool yet");
         }
 
         [Test]

--- a/Tests/Runtime/Tags/AttributeTests.cs
+++ b/Tests/Runtime/Tags/AttributeTests.cs
@@ -182,6 +182,106 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.Throws<ArgumentException>(() => attribute.Divide(0f));
         }
 
+        // Addition, Multiplication and Override each get their own pass, and a pass is skipped
+        // when the first one reports that nothing in the attribute carries that action. Every
+        // combination is driven, from both authoring orders and across two handles, because a
+        // pass skipped when it should not be produces a plausible number rather than an error.
+        [TestCase("A", 15f)]
+        [TestCase("M", 20f)]
+        [TestCase("O", 42f)]
+        [TestCase("AA", 20f)]
+        [TestCase("MM", 40f)]
+        [TestCase("AM", 30f)]
+        [TestCase("MA", 30f)]
+        [TestCase("AAM", 40f)]
+        [TestCase("AO", 42f)]
+        [TestCase("OA", 42f)]
+        [TestCase("MO", 42f)]
+        [TestCase("OM", 42f)]
+        [TestCase("AMO", 42f)]
+        [TestCase("OMA", 42f)]
+        public void CurrentValueAppliesEveryActionRegardlessOfAuthoringOrder(
+            string actions,
+            float expected
+        )
+        {
+            foreach (bool splitAcrossHandles in new[] { false, true })
+            {
+                Attribute attribute = new(10f);
+                AttributeEffect effect = Track(ScriptableObject.CreateInstance<AttributeEffect>());
+                effect.name = "Combination";
+                EffectHandle sharedHandle = EffectHandle.CreateInstance(effect);
+
+                for (int index = 0; index < actions.Length; index++)
+                {
+                    EffectHandle handle = splitAcrossHandles
+                        ? EffectHandle.CreateInstance(effect)
+                        : sharedHandle;
+                    attribute.ApplyAttributeModification(
+                        new AttributeModification
+                        {
+                            attribute = "health",
+                            action = ActionFor(actions[index]),
+                            value = ValueFor(actions[index]),
+                        },
+                        handle
+                    );
+                }
+
+                Assert.AreEqual(
+                    expected,
+                    attribute.CurrentValue,
+                    $"actions={actions} splitAcrossHandles={splitAcrossHandles}"
+                );
+            }
+        }
+
+        private static ModificationAction ActionFor(char action)
+        {
+            switch (action)
+            {
+                case 'A':
+                {
+                    return ModificationAction.Addition;
+                }
+                case 'M':
+                {
+                    return ModificationAction.Multiplication;
+                }
+                case 'O':
+                {
+                    return ModificationAction.Override;
+                }
+                default:
+                {
+                    throw new ArgumentOutOfRangeException(nameof(action), action, null);
+                }
+            }
+        }
+
+        private static float ValueFor(char action)
+        {
+            switch (action)
+            {
+                case 'A':
+                {
+                    return 5f;
+                }
+                case 'M':
+                {
+                    return 2f;
+                }
+                case 'O':
+                {
+                    return 42f;
+                }
+                default:
+                {
+                    throw new ArgumentOutOfRangeException(nameof(action), action, null);
+                }
+            }
+        }
+
         [Test]
         public void ArithmeticHelpersThrowWhenValueIsNotFinite()
         {

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "test:lint-workflow-run-expression-length": "pwsh -NoProfile -File scripts/tests/test-lint-workflow-run-expression-length.ps1 -VerboseOutput",
     "test:pr-workflow-concurrency": "pwsh -NoProfile -File scripts/tests/test-pr-workflow-concurrency.ps1 -VerboseOutput",
     "test:workflow-repository-guard": "pwsh -NoProfile -File scripts/tests/test-workflow-repository-guard.ps1 -VerboseOutput",
+    "test:asmdef-discovery": "node scripts/tests/test-asmdef-discovery.js",
     "test:unity-workflow-matrix-contract": "pwsh -NoProfile -File scripts/tests/test-unity-workflow-matrix-contract.ps1 -VerboseOutput",
     "test:perf-tools": "node scripts/unity/lib/extract-perf-metrics.js --self-test && node scripts/unity/lib/evaluate-perf-refresh.js --self-test && node scripts/unity/lib/render-perf-deltas.js --self-test",
     "test:git-path-helpers": "pwsh -NoProfile -File scripts/tests/test-git-path-helpers.ps1 -VerboseOutput",

--- a/scripts/lint-pwsh-invocations.ps1
+++ b/scripts/lint-pwsh-invocations.ps1
@@ -32,6 +32,18 @@
                PowerShell -File targets must be .ps1 files on every supported
                host; run the extensionless hook directly or invoke the
                companion `.githooks/<hook>.ps1` implementation.
+      PWS005 - A script declares an array parameter without BOTH a
+               `[Parameter(ValueFromRemainingArguments = $true)]` sibling and
+               `[CmdletBinding(PositionalBinding = $false)]`, so
+               `pwsh -File <script> -Paths a b` binds only 'a' and puts 'b' on
+               whichever parameter is positionally next -- silently.
+      PWS006 - `Start-Process -ArgumentList <array|variable>`. Start-Process
+               joins the array with spaces and adds NO quoting, so an argument
+               containing a space is split into separate arguments. Use
+               `System.Diagnostics.ProcessStartInfo.ArgumentList`, which quotes
+               each element. Opt-out per site: a comment marker
+               `# lint-pwsh-invocations: allow-start-process-argument-list <rationale>`
+               on the invocation's line or in the comment block directly above.
 
     Scanned paths:
       - *.sh
@@ -169,6 +181,13 @@ $pws004JoinPathVariableAssignmentPattern = '(?:^|[;\s])(?:\[[^\]]+\]\s*)?\$(?<na
 # should explain WHY subprocess isolation is needed — e.g. the called script
 # uses `exit` heavily, or it must run in a fresh PS session).
 $pws003AllowMarker = '^\s*#\s*lint-pwsh-invocations:\s*allow-subprocess-pwsh\s+\S+'
+
+# PWS006 opt-out marker. Per SITE rather than per file: a script may legitimately
+# launch one fixed-switch installer and still be wrong to hand a path to another.
+# Not anchored to the start of a line, so it may be a trailing comment on the
+# invocation itself or a line of the comment block directly above it. A rationale
+# is required, as it is for PWS003.
+$pws006AllowMarker = '#\s*lint-pwsh-invocations:\s*allow-start-process-argument-list\s+\S+'
 
 # Strips PowerShell string literals (double-quoted and single-quoted) from a
 # line, replacing each literal with a same-length sequence of spaces so that
@@ -974,7 +993,50 @@ foreach ($file in $targets) {
 # silently put 'b' in -InstallRoot. So the script must ALSO declare
 # [CmdletBinding(PositionalBinding = $false)], which is what routes every stray value to the
 # catch-all. Requiring only the sibling institutionalised a non-fix.
-foreach ($scriptPath in (Get-ChildItem -LiteralPath (Join-Path $repoRoot 'scripts') -Filter '*.ps1' -Recurse -File)) {
+# The PowerShell files this repository OWNS: everything under scripts/, plus the four
+# .githooks/<hook>.ps1 implementations, which are scripts that take arguments like any other.
+#
+# Ignored files are dropped. CI checks out tracked content only, so a gate that scans a
+# developer's gitignored scratch script reports a violation the repository cannot fix and CI
+# can never see -- and this container has one (`scripts/run-unity*` is in .gitignore).
+# Untracked-but-not-ignored files are still scanned: a new script you forgot to stage is
+# exactly the one a rule should catch. `git` failing (a fixture root is not a repository)
+# excludes nothing.
+function Get-OwnedPowerShellScript {
+    $candidates = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
+    foreach ($scriptDirectory in @('scripts', '.githooks')) {
+        $absolute = Join-Path $repoRoot $scriptDirectory
+        if (-not (Test-Path -LiteralPath $absolute -PathType Container)) { continue }
+        foreach ($file in (Get-ChildItem -LiteralPath $absolute -Filter '*.ps1' -Recurse -File)) {
+            $candidates.Add($file) | Out-Null
+        }
+    }
+
+    $ignored = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    try {
+        $listed = & git -C $repoRoot ls-files --others --ignored --exclude-standard -- 'scripts' '.githooks' 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            foreach ($ignoredPath in @($listed)) {
+                if (-not [string]::IsNullOrWhiteSpace($ignoredPath)) {
+                    $ignored.Add($ignoredPath.Replace('\', '/')) | Out-Null
+                }
+            }
+        }
+    } catch {
+        # No git, or no repository. Scan everything rather than nothing.
+    }
+
+    $owned = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
+    foreach ($candidate in $candidates) {
+        $candidateRelative = [System.IO.Path]::GetRelativePath($repoRoot, $candidate.FullName).Replace('\', '/')
+        if ($ignored.Contains($candidateRelative)) { continue }
+        $owned.Add($candidate) | Out-Null
+    }
+
+    return $owned
+}
+
+foreach ($scriptPath in (Get-OwnedPowerShellScript)) {
     # '\' not '\\': in a PowerShell single-quoted string the latter is TWO backslashes, so a
     # Windows separator from GetRelativePath would pass through unchanged and the self-exclusion
     # against $selfRel would never match (Bugbot, PR #555).
@@ -995,6 +1057,87 @@ foreach ($scriptPath in (Get-ChildItem -LiteralPath (Join-Path $repoRoot 'script
         }) | Out-Null
         continue
     }
+    # PWS006: `Start-Process -ArgumentList <array>` joins the array with spaces and adds no
+    # quoting, so an argument containing a space is split into separate arguments. What makes it
+    # worth a rule rather than three fixes is the failure SHAPE: pwsh answers its usage banner and
+    # exits 64, so a caller asserting "the child failed" is satisfied by a child that never ran.
+    # Measured on #571's harness -- reverting one converted site under a spaced fixture root
+    # reddened six of nine scenarios and left three green (#572).
+    #
+    # Checked from the AST, not a regex: the parameter and its value have to be matched as ONE
+    # thing, and matching them independently over the file is the mistake #556's CSS gate made.
+    #
+    # Deliberately narrow. Only the three shapes that can hold more than one argument are
+    # reported -- an array literal, an @() expression, and a variable, whose contents this script
+    # cannot know. A string literal is quoted by its author and is left alone.
+    $startProcessAsts = $ast.FindAll(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.CommandAst]
+        },
+        $true
+    )
+    $scriptLines = $null
+    foreach ($startProcessAst in $startProcessAsts) {
+        $commandName = $startProcessAst.GetCommandName()
+        if ([string]::IsNullOrEmpty($commandName)) { continue }
+        # `saps` is the shipped alias. `start` is one too, but it is also an ordinary word, and a
+        # rule that reports `start` reports things that are not Start-Process.
+        if ($commandName -notmatch '^(?:Start-Process|saps)$') { continue }
+
+        $elements = $startProcessAst.CommandElements
+        for ($elementIndex = 1; $elementIndex -lt $elements.Count; $elementIndex++) {
+            $element = $elements[$elementIndex]
+            if ($element -isnot [System.Management.Automation.Language.CommandParameterAst]) { continue }
+            # PowerShell binds any unambiguous prefix, so -Arg, -Args, -ArgumentL and
+            # -ArgumentList are all the same parameter. Start-Process has no other -Arg* one.
+            if ($element.ParameterName -notmatch '^(?i:arg)') { continue }
+
+            # `-ArgumentList:$values` puts the value on the parameter; `-ArgumentList $values`
+            # puts it in the next element.
+            $argumentValue = $element.Argument
+            if ($null -eq $argumentValue -and ($elementIndex + 1) -lt $elements.Count) {
+                $argumentValue = $elements[$elementIndex + 1]
+            }
+            if ($null -eq $argumentValue) { continue }
+
+            $isJoinedShape = (
+                $argumentValue -is [System.Management.Automation.Language.ArrayLiteralAst] -or
+                $argumentValue -is [System.Management.Automation.Language.ArrayExpressionAst] -or
+                $argumentValue -is [System.Management.Automation.Language.VariableExpressionAst]
+            )
+            if (-not $isJoinedShape) { continue }
+
+            $siteLine = $startProcessAst.Extent.StartLineNumber
+            if ($null -eq $scriptLines) {
+                $scriptLines = [System.IO.File]::ReadAllLines($scriptPath.FullName)
+            }
+
+            # The marker may be a trailing comment on the invocation itself, or a line of the
+            # comment block directly above it. A blank line ends the block: a rationale three
+            # paragraphs up is not attached to this call.
+            $isAllowed = $false
+            if ($siteLine -le $scriptLines.Length -and $scriptLines[$siteLine - 1] -match $pws006AllowMarker) {
+                $isAllowed = $true
+            }
+            for ($above = $siteLine - 2; 0 -le $above -and -not $isAllowed; $above--) {
+                $aboveLine = $scriptLines[$above]
+                if ($aboveLine -notmatch '^\s*#') { break }
+                if ($aboveLine -match $pws006AllowMarker) { $isAllowed = $true }
+            }
+            if ($isAllowed) { continue }
+
+            $violations.Add(@{
+                Path = $rel
+                Line = $siteLine
+                Code = 'PWS006'
+                Message = "Start-Process -$($element.ParameterName) is handed an array or a variable, which it joins with spaces and does NOT quote, so any element containing a space is split into separate arguments -- and the failure is a non-zero exit with a usage banner, which reads exactly like the child running and failing. Use System.Diagnostics.ProcessStartInfo.ArgumentList, which quotes each element. The conversion is not always mechanical: Start-Process -Wait also waits on the child's descendants, which Process.WaitForExit() does not. If the arguments are genuinely fixed switches, opt out on this site with a comment '# lint-pwsh-invocations: allow-start-process-argument-list <rationale>'. See .llm/skills/bash-pwsh-invocation.md."
+                Content = $startProcessAst.Extent.Text.Split("`n")[0].Trim()
+            }) | Out-Null
+            break
+        }
+    }
+
     # The SCRIPT's own param block, not a nested function's: a function parameter is bound in
     # process and never goes through -File argument binding.
     $paramBlock = $ast.ParamBlock

--- a/scripts/run-contract-tests.js
+++ b/scripts/run-contract-tests.js
@@ -208,6 +208,11 @@ const CHECKS = [
     run: "npm run test:workflow-repository-guard"
   },
   {
+    id: "asmdef-discovery",
+    name: "Asmdef discovery classification",
+    run: "npm run test:asmdef-discovery"
+  },
+  {
     id: "unity-workflow-matrix-contract",
     name: "Unity workflow matrix contract",
     run: "npm run test:unity-workflow-matrix-contract"

--- a/scripts/tests/test-asmdef-discovery.js
+++ b/scripts/tests/test-asmdef-discovery.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * @file test-asmdef-discovery.js
+ *
+ * Contract test for scripts/unity/lib/asmdef-discovery.js.
+ *
+ * The property under test is the one #570 is about: a test assembly is run in EditMode by Unity
+ * ONLY when it is flagged `EditorAssembly`, which means an asmdef whose only platform is Editor.
+ * An asmdef with no `includePlatforms` compiles for every platform, is not flagged, and is
+ * silently dropped from an EditMode run that names it -- so a discovery list that includes one
+ * reads as coverage that does not exist.
+ *
+ * Two halves, both asserted:
+ *   1. Synthetic fixtures, where the classifier is driven in both directions.
+ *   2. This repository, where the seven platform-neutral test assemblies are named so the next
+ *      reader does not have to re-measure them, and so an eighth cannot appear unnoticed.
+ */
+
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const discovery = require(path.join(repoRoot, "scripts", "unity", "lib", "asmdef-discovery.js"));
+
+/**
+ * Measured on 6000.4.6f1 through the MCP bridge:
+ * `CompilationPipeline.GetAssemblies(AssembliesType.Editor)` flags 26 of the 33 test assemblies
+ * the editor compiles, and the seven it does not are exactly these. Confirmed independently in
+ * CI: the 2021.3.45f1 editmode leg's log mentions `Tests.Runtime.Random` three times -- the
+ * assembly list being echoed -- against 2,375 times in the playmode leg.
+ *
+ * A fixture for an edit-mode branch of runtime code belongs in an editor-only assembly. Adding a
+ * name here is a decision to give up EditMode coverage for everything in it.
+ */
+const PLAYMODE_ONLY_TEST_ASSEMBLIES = [
+  "WallstopStudios.UnityHelpers.Tests.Core",
+  "WallstopStudios.UnityHelpers.Tests.Runtime",
+  "WallstopStudios.UnityHelpers.Tests.Runtime.Performance",
+  "WallstopStudios.UnityHelpers.Tests.Runtime.Random",
+  "WallstopStudios.UnityHelpers.Tests.Runtime.Reflex",
+  "WallstopStudios.UnityHelpers.Tests.Runtime.VContainer",
+  "WallstopStudios.UnityHelpers.Tests.Runtime.Zenject"
+];
+
+let failures = 0;
+
+/**
+ * @param {string} name
+ * @param {() => void} body
+ */
+function test(name, body) {
+  try {
+    body();
+    process.stdout.write(`  [PASS] ${name}\n`);
+  } catch (error) {
+    failures++;
+    process.stdout.write(`  [FAIL] ${name}\n         ${error.message}\n`);
+  }
+}
+
+/**
+ * Build a throwaway repository containing only asmdefs, so the classifier is driven by the
+ * fixture rather than by whatever this repository happens to hold today.
+ *
+ * @param {Array<{ name: string, includePlatforms?: string[], excludePlatforms?: string[] }>} asmdefs
+ * @returns {string} Absolute fixture root
+ */
+function writeFixture(asmdefs) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "asmdef-discovery-"));
+  const testsDirectory = path.join(root, "Tests");
+  fs.mkdirSync(testsDirectory, { recursive: true });
+  for (const asmdef of asmdefs) {
+    fs.writeFileSync(
+      path.join(testsDirectory, `${asmdef.name}.asmdef`),
+      JSON.stringify({
+        name: asmdef.name,
+        includePlatforms: asmdef.includePlatforms || [],
+        excludePlatforms: asmdef.excludePlatforms || []
+      }),
+      "utf8"
+    );
+  }
+  return root;
+}
+
+const fixtureRoots = [];
+
+/**
+ * @param {Array<{ name: string, includePlatforms?: string[], excludePlatforms?: string[] }>} asmdefs
+ * @returns {string}
+ */
+function fixture(asmdefs) {
+  const root = writeFixture(asmdefs);
+  fixtureRoots.push(root);
+  return root;
+}
+
+process.stdout.write("Testing asmdef-discovery.js...\n\n  Section: EditMode means editor-only\n");
+
+const EDITOR_ONLY = "WallstopStudios.UnityHelpers.Tests.Editor.Probe";
+const PLATFORM_NEUTRAL = "WallstopStudios.UnityHelpers.Tests.Runtime.Probe";
+
+test("EditorOnlyAsmdefIsDiscoveredForEditmode", () => {
+  const root = fixture([{ name: EDITOR_ONLY, includePlatforms: ["Editor"] }]);
+  assert.deepStrictEqual(discovery.defaultIncludeAssemblies(root, { target: "editmode" }), [
+    EDITOR_ONLY
+  ]);
+});
+
+test("PlatformNeutralAsmdefIsNotDiscoveredForEditmode", () => {
+  const root = fixture([{ name: PLATFORM_NEUTRAL }]);
+  assert.deepStrictEqual(discovery.defaultIncludeAssemblies(root, { target: "editmode" }), []);
+});
+
+test("PlatformNeutralAsmdefIsDiscoveredForPlaymode", () => {
+  const root = fixture([{ name: PLATFORM_NEUTRAL }]);
+  assert.deepStrictEqual(discovery.defaultIncludeAssemblies(root, { target: "playmode" }), [
+    PLATFORM_NEUTRAL
+  ]);
+});
+
+test("EditorOnlyAsmdefIsNotDiscoveredForPlaymode", () => {
+  const root = fixture([{ name: EDITOR_ONLY, includePlatforms: ["Editor"] }]);
+  assert.deepStrictEqual(discovery.defaultIncludeAssemblies(root, { target: "playmode" }), []);
+});
+
+test("EditorPlusStandaloneAsmdefIsNotDiscoveredForEditmode", () => {
+  // Unity flags EditorAssembly for an editor-ONLY assembly. Naming Editor alongside a player
+  // platform produces an assembly the EditMode runner will not take either.
+  const root = fixture([
+    { name: PLATFORM_NEUTRAL, includePlatforms: ["Editor", "LinuxStandalone64"] }
+  ]);
+  assert.deepStrictEqual(discovery.defaultIncludeAssemblies(root, { target: "editmode" }), []);
+});
+
+process.stdout.write("\n  Section: this repository\n");
+
+test("EveryEditmodeAssemblyIsEditorOnly", () => {
+  const editmode = discovery.defaultIncludeAssemblies(repoRoot, {
+    target: "editmode",
+    includePerf: true,
+    includeIntegrations: true
+  });
+  const notEditorOnly = editmode.filter((name) => PLAYMODE_ONLY_TEST_ASSEMBLIES.includes(name));
+  assert.deepStrictEqual(
+    notEditorOnly,
+    [],
+    `EditMode discovery returned assemblies Unity will not run: ${notEditorOnly.join(", ")}`
+  );
+});
+
+test("PlaymodeOnlyAssembliesAreExactlyTheDeclaredSeven", () => {
+  const playmode = discovery.defaultIncludeAssemblies(repoRoot, {
+    target: "playmode",
+    includePerf: true,
+    includeIntegrations: true
+  });
+  assert.deepStrictEqual(
+    playmode.slice().sort(),
+    PLAYMODE_ONLY_TEST_ASSEMBLIES.slice().sort(),
+    "The set of test assemblies Unity runs in PlayMode only has changed. A fixture for an " +
+      "edit-mode branch of runtime code cannot run in any of them; update " +
+      "PLAYMODE_ONLY_TEST_ASSEMBLIES and .llm/skills/unity-devcontainer-testing.md deliberately."
+  );
+});
+
+test("BenchmarkAssembliesRunInPlaymode", () => {
+  // unity-benchmarks.yml names both, and its matrix is playmode-only because of it (#570).
+  const playmode = discovery.defaultIncludeAssemblies(repoRoot, {
+    target: "playmode",
+    includePerf: true
+  });
+  for (const required of [
+    "WallstopStudios.UnityHelpers.Tests.Runtime.Performance",
+    "WallstopStudios.UnityHelpers.Tests.Runtime.Random"
+  ]) {
+    assert.ok(playmode.includes(required), `${required} must be discoverable for playmode`);
+  }
+});
+
+for (const root of fixtureRoots) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+process.stdout.write(`\nTests failed: ${failures}\n`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/tests/test-asmdef-discovery.js.meta
+++ b/scripts/tests/test-asmdef-discovery.js.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c8ae92e4971a002bf0a6daeb95871040
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/tests/test-lint-pwsh-invocations.ps1
+++ b/scripts/tests/test-lint-pwsh-invocations.ps1
@@ -1267,6 +1267,156 @@ Write-Host $Path
     $result = Invoke-LintInFixture $root
     Write-TestResult "Pass_Pws005ScalarStringNotFlagged" ($result.ExitCode -eq 0) "Expected exit 0 for a scalar [string] parameter. Exit: $($result.ExitCode). Output: $($result.Output)"
 
+    Write-Host "`n  Section: PWS006 (Start-Process -ArgumentList joins without quoting)" -ForegroundColor White
+
+    # PWS006 exists because the failure is INDISTINGUISHABLE from a real one: pwsh answers its
+    # usage banner and exits 64, so a caller asserting "the child failed" is satisfied by a child
+    # that never ran (#572). Every fixture below launches `installer.exe` rather than pwsh, so
+    # nothing here can be attributed to PWS001/PWS003 instead.
+
+    # --- Fail_Pws006ArrayLiteralArgumentList ---
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-array.ps1') -Value @'
+Set-StrictMode -Version Latest
+$target = "/tmp/dir with space/probe.txt"
+$process = Start-Process -FilePath 'installer.exe' -ArgumentList @('--input', $target) -Wait -PassThru
+Write-Host $process.ExitCode
+'@
+    $result = Invoke-LintInFixture $root
+    $hasPws006 = $result.Output -match 'PWS006' -and $result.Output -match 'launch-array\.ps1'
+    Write-TestResult "Fail_Pws006ArrayLiteralArgumentList" ($result.ExitCode -ne 0 -and $hasPws006) "Expected exit != 0 + PWS006 for an array literal -ArgumentList. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Fail_Pws006VariableArgumentList ---
+    # A variable is the shape all three live sites had. The script cannot know what is in it, so
+    # it is reported.
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-variable.ps1') -Value @'
+Set-StrictMode -Version Latest
+$arguments = @('--input', "/tmp/dir with space/probe.txt")
+$process = Start-Process -FilePath 'installer.exe' -ArgumentList $arguments -Wait -PassThru
+Write-Host $process.ExitCode
+'@
+    $result = Invoke-LintInFixture $root
+    $hasPws006 = $result.Output -match 'PWS006' -and $result.Output -match 'launch-variable\.ps1'
+    Write-TestResult "Fail_Pws006VariableArgumentList" ($result.ExitCode -ne 0 -and $hasPws006) "Expected exit != 0 + PWS006 for a variable -ArgumentList. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Fail_Pws006ArgsAliasCovered ---
+    # -Args is the shipped alias, and PowerShell binds any unambiguous prefix, so a rule that
+    # only matched the full parameter name would miss it.
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-alias.ps1') -Value @'
+Set-StrictMode -Version Latest
+$arguments = @('--input', 'probe.txt')
+$process = Start-Process -FilePath 'installer.exe' -Args $arguments -Wait -PassThru
+Write-Host $process.ExitCode
+'@
+    $result = Invoke-LintInFixture $root
+    $hasPws006 = $result.Output -match 'PWS006' -and $result.Output -match 'launch-alias\.ps1'
+    Write-TestResult "Fail_Pws006ArgsAliasCovered" ($result.ExitCode -ne 0 -and $hasPws006) "Expected exit != 0 + PWS006 for the -Args alias. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Fail_Pws006NoParamBlockStillScanned ---
+    # PWS005 skips a script with no param block. PWS006 must not: a launcher is exactly the kind
+    # of script that takes no parameters of its own.
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-no-params.ps1') -Value @'
+Start-Process -FilePath 'installer.exe' -ArgumentList @('/q') -Wait
+'@
+    $result = Invoke-LintInFixture $root
+    $hasPws006 = $result.Output -match 'PWS006' -and $result.Output -match 'launch-no-params\.ps1'
+    Write-TestResult "Fail_Pws006NoParamBlockStillScanned" ($result.ExitCode -ne 0 -and $hasPws006) "Expected exit != 0 + PWS006 in a script with no param block. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Fail_Pws006MarkerWithoutRationaleStillReported ---
+    # The marker requires a rationale, exactly as PWS003's does. A bare marker is not an opt-out.
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-bare-marker.ps1') -Value @'
+# lint-pwsh-invocations: allow-start-process-argument-list
+Start-Process -FilePath 'installer.exe' -ArgumentList @('/q') -Wait
+'@
+    $result = Invoke-LintInFixture $root
+    $hasPws006 = $result.Output -match 'PWS006' -and $result.Output -match 'launch-bare-marker\.ps1'
+    Write-TestResult "Fail_Pws006MarkerWithoutRationaleStillReported" ($result.ExitCode -ne 0 -and $hasPws006) "Expected exit != 0 + PWS006 for a marker with no rationale. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Fail_Pws006DetachedMarkerStillReported ---
+    # A blank line ends the comment block, so a rationale further up is not attached to this call.
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-detached-marker.ps1') -Value @'
+# lint-pwsh-invocations: allow-start-process-argument-list fixed switches only
+
+Start-Process -FilePath 'installer.exe' -ArgumentList @('/q') -Wait
+'@
+    $result = Invoke-LintInFixture $root
+    $hasPws006 = $result.Output -match 'PWS006' -and $result.Output -match 'launch-detached-marker\.ps1'
+    Write-TestResult "Fail_Pws006DetachedMarkerStillReported" ($result.ExitCode -ne 0 -and $hasPws006) "Expected exit != 0 + PWS006 for a marker detached by a blank line. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Pass_Pws006MarkerInCommentBlockAbove ---
+    # The live opt-out shape: scripts/unity/bootstrap-windows-runner.ps1.
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-marked.ps1') -Value @'
+# lint-pwsh-invocations: allow-start-process-argument-list every caller passes fixed switches
+# and -Wait waits on installer descendants in a way Process.WaitForExit does not.
+Start-Process -FilePath 'installer.exe' -ArgumentList @('/q', '/norestart') -Wait
+'@
+    $result = Invoke-LintInFixture $root
+    Write-TestResult "Pass_Pws006MarkerInCommentBlockAbove" ($result.ExitCode -eq 0) "Expected exit 0 for an opted-out site. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Pass_Pws006TrailingMarkerOnSite ---
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-marked-trailing.ps1') -Value @'
+Start-Process -FilePath 'installer.exe' -ArgumentList @('/q') -Wait # lint-pwsh-invocations: allow-start-process-argument-list fixed switches only
+'@
+    $result = Invoke-LintInFixture $root
+    Write-TestResult "Pass_Pws006TrailingMarkerOnSite" ($result.ExitCode -eq 0) "Expected exit 0 for a trailing marker on the invocation. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Pass_Pws006StringArgumentNotFlagged ---
+    # A single string literal is quoted by its author; the rule is about the join.
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-string.ps1') -Value @'
+Start-Process -FilePath 'installer.exe' -ArgumentList '/q /norestart' -Wait
+'@
+    $result = Invoke-LintInFixture $root
+    Write-TestResult "Pass_Pws006StringArgumentNotFlagged" ($result.ExitCode -eq 0) "Expected exit 0 for a string -ArgumentList. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Pass_Pws006ProcessStartInfoNotFlagged ---
+    # The fix the message names must itself be clean, or the rule cannot be complied with.
+    $root = New-FixtureRoot
+    Set-Content -LiteralPath (Join-Path $root 'scripts/launch-psi.ps1') -Value @'
+Set-StrictMode -Version Latest
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = 'installer.exe'
+[void]$psi.ArgumentList.Add('/q')
+[void]$psi.ArgumentList.Add('/tmp/dir with space/log.txt')
+$process = [System.Diagnostics.Process]::Start($psi)
+$process.WaitForExit()
+'@
+    $result = Invoke-LintInFixture $root
+    Write-TestResult "Pass_Pws006ProcessStartInfoNotFlagged" ($result.ExitCode -eq 0) "Expected exit 0 for the ProcessStartInfo form. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    Write-Host "`n  Section: scan set (gitignored scripts are not the repository's)" -ForegroundColor White
+
+    # CI checks out tracked content only, so a gate that scans a developer's gitignored scratch
+    # script reports a violation the repository cannot fix and CI can never see. This container
+    # has one. Both halves are asserted: the same file, ignored and not ignored.
+
+    # --- Fail_UnignoredScriptIsScanned ---
+    $root = New-FixtureRoot
+    & git -C $root init --quiet 2>&1 | Out-Null
+    Set-Content -LiteralPath (Join-Path $root 'scripts/local-tool.ps1') -Value @'
+Start-Process -FilePath 'installer.exe' -ArgumentList @('/q') -Wait
+'@
+    $result = Invoke-LintInFixture $root
+    $hasPws006 = $result.Output -match 'PWS006' -and $result.Output -match 'local-tool\.ps1'
+    Write-TestResult "Fail_UnignoredScriptIsScanned" ($result.ExitCode -ne 0 -and $hasPws006) "Expected exit != 0 + PWS006 for an untracked but unignored script. Exit: $($result.ExitCode). Output: $($result.Output)"
+
+    # --- Pass_GitignoredScriptIsNotScanned ---
+    $root = New-FixtureRoot
+    & git -C $root init --quiet 2>&1 | Out-Null
+    Set-Content -LiteralPath (Join-Path $root '.gitignore') -Value 'scripts/local-*.ps1'
+    Set-Content -LiteralPath (Join-Path $root 'scripts/local-tool.ps1') -Value @'
+Start-Process -FilePath 'installer.exe' -ArgumentList @('/q') -Wait
+'@
+    $result = Invoke-LintInFixture $root
+    Write-TestResult "Pass_GitignoredScriptIsNotScanned" ($result.ExitCode -eq 0) "Expected exit 0 — a gitignored script is not the repository's to fix. Exit: $($result.ExitCode). Output: $($result.Output)"
+
 } finally {
     Remove-Item -Recurse -Force $tempRoot -ErrorAction SilentlyContinue
 }

--- a/scripts/tests/test-shell-portability.sh
+++ b/scripts/tests/test-shell-portability.sh
@@ -340,9 +340,9 @@ echo "--- B3: Unity package export project stays below an allowed root ---"
 
 run_test
 unity_export_package="$REPO_ROOT/scripts/unity/export-unitypackage.sh"
-root_guard_line=$(first_match_line -F '"${PROJECT_DIR}" != "${allowed_root}"' "$unity_export_package")
-outside_guard_line=$(first_match_line -F '"${PROJECT_DIR}" == "${allowed_root}/"*' "$unity_export_package")
-allowed_roots_line=$(first_match_line -F 'for allowed_root in "${ARTIFACTS_ROOT}" "${TEMP_ROOT}"' "$unity_export_package")
+root_guard_line=$(first_match_line -F '"${PROJECT_DIR}" != "${ARTIFACTS_ROOT}"' "$unity_export_package")
+outside_guard_line=$(first_match_line -F '"${PROJECT_DIR}" == "${ARTIFACTS_ROOT}/"*' "$unity_export_package")
+allowed_roots_line=$(first_match_line -F '"${RESOLVED_REPO_ROOT}" != "${PROJECT_DIR}/"*' "$unity_export_package")
 delete_line=$(first_match_line -F 'rm -rf "${PROJECT_DIR}"' "$unity_export_package")
 if [[ -z "$root_guard_line" || -z "$outside_guard_line" || -z "$allowed_roots_line" || -z "$delete_line" ]]; then
     fail "Unity package export project guard is missing expected structure" \
@@ -365,6 +365,25 @@ for refused_dir in "$REPO_ROOT/.artifacts" "$REPO_ROOT" "/"; do
         guard_refusals+=("$refused_dir")
     fi
 done
+
+# A checkout can live UNDER the temp root -- a CI runner working directory, a container whose
+# workspace is a temp mount -- and then "a subdirectory of the temp root" would accept the
+# repository itself and delete it. Driven from a copy of the script inside a fake checkout under
+# the temp root, so the layout is real rather than argued: the script derives its own repo root
+# from its location.
+guard_fake_root="$(mktemp -d)"
+mkdir -p "$guard_fake_root/scripts/unity" "$guard_fake_root/.github"
+cp "$unity_export_package" "$guard_fake_root/scripts/unity/export-unitypackage.sh"
+cp "$REPO_ROOT/package.json" "$guard_fake_root/package.json"
+cp "$REPO_ROOT/.github/unity-versions.json" "$guard_fake_root/.github/unity-versions.json"
+for refused_dir in "$guard_fake_root" "$guard_fake_root/scripts" "$(dirname "$guard_fake_root")"; do
+    guard_output="$(bash "$guard_fake_root/scripts/unity/export-unitypackage.sh" \
+        --stage-only --project-dir "$refused_dir" 2>&1 || true)"
+    if ! grep -Fq 'Refusing to create the export project' <<<"$guard_output"; then
+        guard_refusals+=("under-temp-root:$refused_dir")
+    fi
+done
+rm -rf "$guard_fake_root"
 # The accepting half is B5 below, which stages into a strict subdirectory of the temp root and
 # asserts what lands there. Running an accepting case here too would pay for a second `npm pack`
 # (4.4 s) to learn the same thing.

--- a/scripts/tests/test-shell-portability.sh
+++ b/scripts/tests/test-shell-portability.sh
@@ -336,21 +336,43 @@ else
 fi
 
 echo ""
-echo "--- B3: Unity package export project stays below artifacts root ---"
+echo "--- B3: Unity package export project stays below an allowed root ---"
 
 run_test
 unity_export_package="$REPO_ROOT/scripts/unity/export-unitypackage.sh"
-root_guard_line=$(first_match_line -F '"${PROJECT_DIR}" == "${ARTIFACTS_ROOT}"' "$unity_export_package")
-outside_guard_line=$(first_match_line -F '"${PROJECT_DIR}" != "${ARTIFACTS_ROOT}/"*' "$unity_export_package")
+root_guard_line=$(first_match_line -F '"${PROJECT_DIR}" != "${allowed_root}"' "$unity_export_package")
+outside_guard_line=$(first_match_line -F '"${PROJECT_DIR}" == "${allowed_root}/"*' "$unity_export_package")
+allowed_roots_line=$(first_match_line -F 'for allowed_root in "${ARTIFACTS_ROOT}" "${TEMP_ROOT}"' "$unity_export_package")
 delete_line=$(first_match_line -F 'rm -rf "${PROJECT_DIR}"' "$unity_export_package")
-if [[ -z "$root_guard_line" || -z "$outside_guard_line" || -z "$delete_line" ]]; then
+if [[ -z "$root_guard_line" || -z "$outside_guard_line" || -z "$allowed_roots_line" || -z "$delete_line" ]]; then
     fail "Unity package export project guard is missing expected structure" \
-        "root_guard_line='${root_guard_line}', outside_guard_line='${outside_guard_line}', delete_line='${delete_line}'"
-elif (( root_guard_line < delete_line && outside_guard_line < delete_line )); then
-    pass "Unity package export refuses artifacts root before deleting the project directory"
+        "root_guard_line='${root_guard_line}', outside_guard_line='${outside_guard_line}', allowed_roots_line='${allowed_roots_line}', delete_line='${delete_line}'"
+elif (( root_guard_line < delete_line && outside_guard_line < delete_line && allowed_roots_line < delete_line )); then
+    pass "Unity package export refuses an allowed root itself before deleting the project directory"
 else
     fail "Unity package export validates project path too late" \
-        "Root guard line ${root_guard_line}, outside guard line ${outside_guard_line}, delete line ${delete_line}"
+        "Root guard line ${root_guard_line}, outside guard line ${outside_guard_line}, allowed roots line ${allowed_roots_line}, delete line ${delete_line}"
+fi
+
+# The structural check above cannot tell a guard that runs from one that is merely present, and
+# this guard stands in front of an `rm -rf` of a caller-supplied path. Drive it: both refusals
+# are cheap, because the guard is ahead of the npm pack (#556).
+run_test
+guard_refusals=()
+for refused_dir in "$REPO_ROOT/.artifacts" "$REPO_ROOT" "/"; do
+    guard_output="$(bash "$unity_export_package" --stage-only --project-dir "$refused_dir" 2>&1 || true)"
+    if ! grep -Fq 'Refusing to create the export project' <<<"$guard_output"; then
+        guard_refusals+=("$refused_dir")
+    fi
+done
+# The accepting half is B5 below, which stages into a strict subdirectory of the temp root and
+# asserts what lands there. Running an accepting case here too would pay for a second `npm pack`
+# (4.4 s) to learn the same thing.
+if (( ${#guard_refusals[@]} == 0 )); then
+    pass "Unity package export refuses the artifacts root, the repository root and /"
+else
+    fail "Unity package export accepted a project directory it must refuse" \
+        "Accepted: ${guard_refusals[*]}"
 fi
 
 echo ""
@@ -374,9 +396,12 @@ echo ""
 echo "--- B5: Unity package export stages package content roots ---"
 
 run_test
-stage_project="$REPO_ROOT/.artifacts/unity/shell-portability-unitypackage-stage"
+# Staged under the system temp directory, not .artifacts. Copying the packed package is ~1,900
+# files and 82 MB, and on a bind-mounted workspace that copy IS this check: 15.0 s against ~1 s
+# for the same --stage-only run into a temp directory, plus 1.4 s for each rm -rf (#540).
+stage_root="$(mktemp -d)"
+stage_project="$stage_root/unitypackage-stage"
 stage_log="$(mktemp)"
-rm -rf "$stage_project"
 if bash "$unity_export_package" --stage-only --project-dir "$stage_project" >"$stage_log" 2>&1; then
     staged_root="$stage_project/Assets/WallstopStudios/UnityHelpers"
     required_stage_entries=(
@@ -425,7 +450,7 @@ else
     stage_tail="$(tail -n 40 "$stage_log" 2>/dev/null || true)"
     fail "Unity package export stage-only command failed" "$stage_tail"
 fi
-rm -rf "$stage_project"
+rm -rf "$stage_root"
 rm -f "$stage_log"
 
 echo ""

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -697,17 +697,18 @@ $benchmarkRunsThoroughRandomInSharedInvocation = (
     -not $benchmarkJob.Contains('Run Random suite at full sample count') -and
     -not $benchmarkJob.Contains('benchmarks-random') -and
     $benchmarkJob.Contains('UH_BENCHMARK_ASSEMBLIES: ${{ matrix.assemblies }}') -and
-    $benchmarkJob.Contains("'Performance;Stress;Fast'") -and
-    $benchmarkJob.Contains("UH_RANDOM_SAMPLE_COUNT: `${{ matrix.test-mode == 'editmode' && '12750000' || '' }}") -and
-    $benchmarkJob.Contains("UH_RANDOM_NOISE_MAP_ITERATIONS: `${{ matrix.test-mode == 'editmode' && '1000' || '' }}") -and
-    $benchmarkJob.Contains("UH_EDITOR_TEST_TIMEOUT_SECONDS: `${{ matrix.test-mode == 'editmode' && '6600' || '' }}") -and
+    $benchmarkJob.Contains('UH_UNITY_TEST_CATEGORY: "Performance;Stress;Fast"') -and
+    $benchmarkJob.Contains('UH_RANDOM_SAMPLE_COUNT: "12750000"') -and
+    $benchmarkJob.Contains('UH_RANDOM_NOISE_MAP_ITERATIONS: "1000"') -and
+    $benchmarkJob.Contains('UH_EDITOR_TEST_TIMEOUT_SECONDS: "6600"') -and
+    -not $benchmarkJob.Contains("matrix.test-mode == 'editmode'") -and
     $benchmarkJob.Contains('-AssemblyNames $env:UH_BENCHMARK_ASSEMBLIES')
 )
 if (-not $benchmarkRunsThoroughRandomInSharedInvocation) {
-    Write-Host '::error file=.github/workflows/unity-benchmarks.yml::The EditMode benchmark leg must run Performance/Stress and the full-sample Random assembly in one Unity invocation with explicit assembly scoping.'
+    Write-Host '::error file=.github/workflows/unity-benchmarks.yml::The benchmark leg must run Performance/Stress/Fast and the full-sample Random assembly in one Unity invocation with explicit assembly scoping, and must not branch its configuration on a test-mode that no longer exists.'
     $failed = $true
 } elseif ($VerboseOutput) {
-    Write-Info 'Checked weekly EditMode performance and thorough Random coverage share one Unity invocation.'
+    Write-Info 'Checked weekly performance and thorough Random coverage share one Unity invocation.'
 }
 
 $benchmarkAssemblyDiscoveryIsCentralized = (
@@ -716,7 +717,13 @@ $benchmarkAssemblyDiscoveryIsCentralized = (
     $benchmarksJobTexts['matrix-config'].Contains('require("./scripts/unity/lib/asmdef-discovery.js")') -and
     $benchmarksJobTexts['matrix-config'].Contains('const performanceAssembly = "WallstopStudios.UnityHelpers.Tests.Runtime.Performance"') -and
     $benchmarksJobTexts['matrix-config'].Contains('const randomAssembly = "WallstopStudios.UnityHelpers.Tests.Runtime.Random"') -and
-    $benchmarksJobTexts['matrix-config'].Contains('if (target === "editmode" && !discovered.includes(randomAssembly))') -and
+    $benchmarksJobTexts['matrix-config'].Contains('for (const required of [performanceAssembly, randomAssembly])') -and
+    # PlayMode only, and asserted rather than assumed. Both benchmark assemblies are
+    # platform-neutral, and Unity's EditMode runner takes only assemblies flagged
+    # EditorAssembly -- so an editmode benchmark leg is handed two assembly names, runs zero
+    # tests, and fails "Verify tests actually ran" on every scheduled run (#570).
+    $benchmarksJobTexts['matrix-config'].Contains('for (const mode of ["playmode"])') -and
+    -not $benchmarksJobTexts['matrix-config'].Contains('editmode: benchmarkProfile("editmode")') -and
     $benchmarksWorkflowContent.Contains('matrix-include: ${{ steps.resolve.outputs.matrix-include }}') -and
     $benchmarksWorkflowContent.Contains('expected-result-files: ${{ steps.resolve.outputs.expected-result-files }}') -and
     $benchmarksWorkflowContent.Contains('allow-baseline-refresh: ${{ steps.resolve.outputs.allow-baseline-refresh }}') -and

--- a/scripts/unity/bootstrap-windows-runner.ps1
+++ b/scripts/unity/bootstrap-windows-runner.ps1
@@ -283,6 +283,8 @@ function Invoke-RunnerInstaller {
         Assert-RunnerMicrosoftAuthenticodeSignature -Path $installerPath
 
         Write-RunnerBootstrapInfo "Running $FileName $($Arguments -join ' ')"
+        # lint-pwsh-invocations: allow-start-process-argument-list every caller passes fixed
+        # switches and -Wait is load-bearing for installer descendants.
         # -ArgumentList joins an array without quoting, so a value containing a space would
         # truncate. Safe here and deliberately left alone: every caller passes fixed switches
         # (/q, /install, /quiet, /norestart) and -Wait waits for installer descendants in a way

--- a/scripts/unity/export-unitypackage.sh
+++ b/scripts/unity/export-unitypackage.sh
@@ -51,16 +51,26 @@ fi
 # --stage-only run (#540).
 ARTIFACTS_ROOT="$(realpath -m "${REPO_ROOT}/.artifacts")"
 TEMP_ROOT="$(realpath -m "${TMPDIR:-/tmp}")"
+RESOLVED_REPO_ROOT="$(realpath -m "${REPO_ROOT}")"
 PROJECT_DIR="$(realpath -m "${PROJECT_DIR}")"
+
+# .artifacts is unconditionally fine -- it IS the repository's scratch directory. The temp root is
+# fine only outside the checkout, because a checkout can live under it: a CI runner working
+# directory, or a container whose workspace is a temp mount. Without the second test, --project-dir
+# pointing at the repository root would be accepted there and then deleted (Bugbot, PR #574).
 PROJECT_DIR_ALLOWED=0
-for allowed_root in "${ARTIFACTS_ROOT}" "${TEMP_ROOT}"; do
-    if [[ "${PROJECT_DIR}" != "${allowed_root}" && "${PROJECT_DIR}" == "${allowed_root}/"* ]]; then
+if [[ "${PROJECT_DIR}" != "${ARTIFACTS_ROOT}" && "${PROJECT_DIR}" == "${ARTIFACTS_ROOT}/"* ]]; then
+    PROJECT_DIR_ALLOWED=1
+elif [[ "${PROJECT_DIR}" != "${TEMP_ROOT}" && "${PROJECT_DIR}" == "${TEMP_ROOT}/"* ]]; then
+    # Neither the checkout, nor anything inside it, nor anything containing it.
+    if [[ "${PROJECT_DIR}" != "${RESOLVED_REPO_ROOT}" &&
+          "${PROJECT_DIR}" != "${RESOLVED_REPO_ROOT}/"* &&
+          "${RESOLVED_REPO_ROOT}" != "${PROJECT_DIR}/"* ]]; then
         PROJECT_DIR_ALLOWED=1
-        break
     fi
-done
+fi
 if (( PROJECT_DIR_ALLOWED == 0 )); then
-    echo "ERROR: Refusing to create the export project unless it is a subdirectory under ${ARTIFACTS_ROOT} or ${TEMP_ROOT}: ${PROJECT_DIR}" >&2
+    echo "ERROR: Refusing to create the export project unless it is a subdirectory under ${ARTIFACTS_ROOT}, or under ${TEMP_ROOT} and outside ${RESOLVED_REPO_ROOT}: ${PROJECT_DIR}" >&2
     exit 1
 fi
 

--- a/scripts/unity/export-unitypackage.sh
+++ b/scripts/unity/export-unitypackage.sh
@@ -41,10 +41,26 @@ if [[ -z "${OUTPUT_PATH}" ]]; then
     OUTPUT_PATH="${REPO_ROOT}/.artifacts/release/${PACKAGE_NAME}-${PACKAGE_VERSION}.unitypackage"
 fi
 
+# The project directory is deleted with `rm -rf` below, so it has to be somewhere a mistake is
+# survivable. A strict subdirectory of .artifacts or of the system temp directory qualifies; the
+# roots themselves do not, and neither does anything else.
+#
+# The temp root is not a convenience. Staging copies ~1,900 files and 82 MB, and on a bind-mounted
+# workspace that is the whole cost of the export smoke gate: measured 4.25 s to copy Runtime and
+# Editor into .artifacts against 0.022 s into /tmp, and 15.0 s against ~1 s for the whole
+# --stage-only run (#540).
 ARTIFACTS_ROOT="$(realpath -m "${REPO_ROOT}/.artifacts")"
+TEMP_ROOT="$(realpath -m "${TMPDIR:-/tmp}")"
 PROJECT_DIR="$(realpath -m "${PROJECT_DIR}")"
-if [[ "${PROJECT_DIR}" == "${ARTIFACTS_ROOT}" || "${PROJECT_DIR}" != "${ARTIFACTS_ROOT}/"* ]]; then
-    echo "ERROR: Refusing to create the export project unless it is a subdirectory under ${ARTIFACTS_ROOT}: ${PROJECT_DIR}" >&2
+PROJECT_DIR_ALLOWED=0
+for allowed_root in "${ARTIFACTS_ROOT}" "${TEMP_ROOT}"; do
+    if [[ "${PROJECT_DIR}" != "${allowed_root}" && "${PROJECT_DIR}" == "${allowed_root}/"* ]]; then
+        PROJECT_DIR_ALLOWED=1
+        break
+    fi
+done
+if (( PROJECT_DIR_ALLOWED == 0 )); then
+    echo "ERROR: Refusing to create the export project unless it is a subdirectory under ${ARTIFACTS_ROOT} or ${TEMP_ROOT}: ${PROJECT_DIR}" >&2
     exit 1
 fi
 

--- a/scripts/unity/lib/asmdef-discovery.js
+++ b/scripts/unity/lib/asmdef-discovery.js
@@ -228,7 +228,19 @@ function isAsmdefCompatibleWithTarget(includePlatforms, excludePlatforms, target
     if (excludes.has("Editor")) {
       return false;
     }
-    return includes.size === 0 || includes.has("Editor");
+    // Editor-ONLY, not merely editor-compatible. Unity's EditMode runner takes only assemblies
+    // flagged `EditorAssembly`, and an asmdef with no `includePlatforms` compiles for every
+    // platform and is not flagged -- so naming one in `-assemblyNames` is accepted and then
+    // silently dropped, and the list reads as coverage that does not exist (#570).
+    //
+    // Measured twice on the same commit. In the editor,
+    // `CompilationPipeline.GetAssemblies(AssembliesType.Editor)` on 6000.4.6f1 flags 26 of this
+    // repository's 33 test assemblies, and the seven it does not are exactly the seven whose
+    // `includePlatforms` is not `["Editor"]`. In CI, the 2021.3.45f1 editmode leg's log mentions
+    // `Tests.Runtime.Random` three times -- the assembly list being echoed -- against 2,375
+    // times in the playmode leg, and `PoolLifecycleHooksTests` runs 94 times in playmode and
+    // zero times in editmode.
+    return includes.size === 1 && includes.has("Editor");
   }
 
   if (target === "playmode") {


### PR DESCRIPTION
**Why:** Unity's EditMode runner takes only assemblies flagged `EditorAssembly`, and discovery was handing the editmode legs seven it would silently drop — which had already cost a whole workflow.

**What:**

- Editmode discovery returns editor-only assemblies; the seven platform-neutral ones are named in a contract test that fails if an eighth appears.
- `unity-benchmarks.yml` is playmode-only: its four EditMode legs ran zero tests and failed `Verify tests actually ran` on every scheduled run.
- Every compiler warning is an error under `Generator~`, which found three assertions that could not fail and one symbol comparison that could be wrong.
- An attribute with only additive modifications recalculates 2.85x faster (0.4563 us -> 0.1600 us), and the effect stacking loop no longer reads a pooled list it has already returned.
- `PWS006` reports `Start-Process -ArgumentList <array>`, which joins without quoting.
- The export smoke gate stages off the bind mount (47 s -> 36 s) and its `rm -rf` guard is driven rather than grepped.
- Docs workflows install through `uv` (5.20 s -> 0.06 s).

Fixes #572
Fixes #570
Fixes #540
Fixes #556
Fixes #425
Fixes #378
Fixes #338
Fixes #515
Fixes #468
Fixes #415

Also advanced with code or measurement: #529, #543, #505, #435, #431. Filed: #575.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect gameplay-adjacent runtime (`Attribute`, `EffectHandler`) and CI matrix shape, though behavior is heavily tested; export path guards reduce accidental destructive deletes.
> 
> **Overview**
> **EditMode test discovery and weekly benchmarks** no longer list platform-neutral assemblies Unity silently skips in EditMode. `asmdef-discovery.js` treats EditMode as **editor-only** asmdefs; a new contract test pins the seven playmode-only test assemblies, and **`unity-benchmarks.yml` is playmode-only** with the full Random sweep and timeouts applied on every leg.
> 
> **Runtime behavior:** `Attribute.CalculateCurrentValue` does one addition pass that records whether multiplication/override are needed, skipping empty passes (~2.85× faster for additive-only cases). **`EffectHandler` stack trimming** re-fetches stack handles after each `RemoveEffect` so pooled lists and `OnEffectRemoved` callbacks cannot corrupt the loop.
> 
> **Tooling and CI:** Docs workflows install requirements via **`uv`** after `pip install uv`. **`Generator~/Directory.Build.props`** turns warnings into errors (test analyzer projects opt out). **`PWS006`** lints unsafe `Start-Process -ArgumentList` array usage; **`export-unitypackage.sh`** tightens which `--project-dir` values are allowed before `rm -rf`, with driven refusal tests and staging under temp in portability tests. **`WProtoGenerator`** uses `ReferenceEquals` for backing-field symbol checks (RS1024).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166eb4532fa13d216214b555623a8c39c339efbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->