### PR TITLE
ci: centralize Windows Unity lifecycle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,7 +324,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
@@ -370,7 +370,7 @@ jobs:
         id: release_unity_lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
@@ -384,7 +384,7 @@ jobs:
 
       - name: Require confirmed Unity cleanup
         if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           acquired: ${{ steps.unity_lock.outputs.acquired }}
           classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}

--- a/.github/workflows/runner-bootstrap.yml
+++ b/.github/workflows/runner-bootstrap.yml
@@ -105,7 +105,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require the selected Unity runner online
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -209,6 +209,7 @@ jobs:
         shell: powershell
         env:
           UH_BOOTSTRAP_DETECT_ONLY: ${{ inputs.detect-only }}
+          UNITY_EDITOR_INSTALL_ROOT: ${{ runner.tool_cache }}\u6-v3
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -259,6 +259,7 @@ jobs:
           # launch while the explicit assembly list prevents unrelated Fast
           # tests from entering the benchmark lane.
           UH_BENCHMARK_ASSEMBLIES: WallstopStudios.UnityHelpers.Tests.Runtime.Performance;WallstopStudios.UnityHelpers.Tests.Runtime.Random
+          UH_CENTRAL_LICENSE_RETURN: "true"
           UH_UNITY_TEST_CATEGORY: "Performance;Stress;Fast"
           UH_RANDOM_SAMPLE_COUNT: "12750000"
           UH_RANDOM_NOISE_MAP_ITERATIONS: "1000"

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -33,6 +33,7 @@ jobs:
       unity-versions: ${{ steps.resolve.outputs.unity-versions }}
       latest-version: ${{ steps.resolve.outputs.latest-version }}
       matrix-include: ${{ steps.resolve.outputs.matrix-include }}
+      matrix-exclude: ${{ steps.resolve.outputs.matrix-exclude }}
       expected-result-count: ${{ steps.resolve.outputs.expected-result-count }}
       expected-result-files: ${{ steps.resolve.outputs.expected-result-files }}
       allow-baseline-refresh: ${{ steps.resolve.outputs.allow-baseline-refresh }}
@@ -57,6 +58,7 @@ jobs:
         # override pins a single version.
         run: |
           set -euo pipefail
+          all_versions="$(jq -c '.all' .github/unity-versions.json)"
           if [ -n "${INPUT_UNITY_VERSION:-}" ]; then
             versions="[\"${INPUT_UNITY_VERSION}\"]"
             latest="${INPUT_UNITY_VERSION}"
@@ -107,10 +109,17 @@ jobs:
           process.stdout.write(JSON.stringify(include));
           NODE
           )"
+          matrix_exclude="$(jq -cn \
+            --argjson allVersions "${all_versions}" \
+            --argjson selectedVersions "${versions}" \
+            '[ $allVersions[] as $version |
+               select(($selectedVersions | index($version)) == null) |
+               { "unity-version": $version, "test-mode": "playmode" } ]')"
           {
             echo "unity-versions=${versions}"
             echo "latest-version=${latest}"
             echo "matrix-include=${matrix_include}"
+            echo "matrix-exclude=${matrix_exclude}"
             echo "expected-result-count=$(jq 'length' <<< "${matrix_include}")"
             echo "expected-result-files=$(jq -c 'map(."result-file") | sort' <<< "${matrix_include}")"
             if [ -z "${INPUT_UNITY_VERSION:-}" ]; then
@@ -149,7 +158,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -175,8 +184,27 @@ jobs:
       # count makes every completion a fresh self-hosted dispatch transition, and
       # that transition is what leaves both runners idle with legs queued.
       matrix:
-        include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include) }}
+        unity-version:
+          - 2021.3.45f1
+          - 2022.3.45f1
+          - 6000.3.16f1
+          - 6000.5.2f1
+        test-mode:
+          - playmode
+        exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}
     steps:
+      - name: Require manually installed Unity editor
+        id: ensure_unity_editor
+        timeout-minutes: 10
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: EditorOnly
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
+
       - name: Enable Git long paths
         shell: powershell
         env:
@@ -189,47 +217,6 @@ jobs:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/uh-gitconfig
         with:
           persist-credentials: false
-
-      - name: Maintain Unity editor on selected runner
-        timeout-minutes: 360
-        shell: powershell
-        run: |
-          $artifactsPath = '.artifacts/unity/benchmarks/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $maintenanceDiagnosticsRoot = Join-Path $artifactsPath 'provisioning/runner-maintenance'
-          New-Item -ItemType Directory -Force -Path $maintenanceDiagnosticsRoot | Out-Null
-          $provisioningProfile = 'EditorOnly'
-          $maintenanceScript = Join-Path $env:GITHUB_WORKSPACE 'scripts\unity\maintain-windows-runner.ps1'
-          if (-not (Test-Path -LiteralPath $maintenanceScript -PathType Leaf)) {
-            throw "Runner maintenance script not found: $maintenanceScript"
-          }
-          . $maintenanceScript
-          $maintenanceExitCode = Invoke-WindowsRunnerMaintenance `
-            -UnityVersions '${{ matrix.unity-version }}' `
-            -ProvisioningProfile $provisioningProfile `
-            -DiagnosticsRoot $maintenanceDiagnosticsRoot
-          if ($maintenanceExitCode -ne 0) {
-            throw "Runner maintenance failed with exit code $maintenanceExitCode."
-          }
-          $pwshCandidates = @(
-            (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'),
-            $(if (${env:ProgramFiles(x86)}) { Join-Path ${env:ProgramFiles(x86)} 'PowerShell\7\pwsh.exe' })
-          )
-          $pathPwsh = Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
-          if ($pathPwsh -and $pathPwsh -notlike '*\Microsoft\WindowsApps\pwsh.exe') {
-            $pwshCandidates += $pathPwsh
-          }
-          $pwshCandidates = @(
-            $pwshCandidates |
-              Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-              Select-Object -Unique
-          )
-          $pwshPath = @($pwshCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf })[0]
-          if (-not $pwshPath) {
-            throw 'PowerShell 7 maintenance completed, but pwsh.exe was not found for later GitHub Actions steps.'
-          }
-          $pwshDirectory = Split-Path -Parent $pwshPath
-          $pwshDirectory | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-          Write-Host "Added PowerShell 7 to GITHUB_PATH: $pwshDirectory"
 
       - name: Print runner diagnostics
         # Never use plain `shell: bash` on self-hosted Windows runners (the WSL
@@ -245,34 +232,9 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
-      - name: Provision Unity Editor
-        timeout-minutes: 180
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/benchmarks/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $diagnosticsPath = Join-Path $artifactsPath 'provisioning'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $editor = ./scripts/unity/ensure-editor.ps1 `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -CiManagedOnly `
-            -RequireHealthyExisting `
-            -ProvisioningProfile EditorOnly `
-            -DiagnosticsPath $diagnosticsFile
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Upload Unity provisioning diagnostics
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: unity-benchmark-provisioning-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: .artifacts/unity/benchmarks/${{ matrix.unity-version }}-${{ matrix.test-mode }}/provisioning
-          if-no-files-found: warn
-          retention-days: 90
-
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -287,6 +249,7 @@ jobs:
         timeout-minutes: 120
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -295,7 +258,7 @@ jobs:
           # assembly and Fast category folds that sweep into this one Unity
           # launch while the explicit assembly list prevents unrelated Fast
           # tests from entering the benchmark lane.
-          UH_BENCHMARK_ASSEMBLIES: ${{ matrix.assemblies }}
+          UH_BENCHMARK_ASSEMBLIES: WallstopStudios.UnityHelpers.Tests.Runtime.Performance;WallstopStudios.UnityHelpers.Tests.Runtime.Random
           UH_UNITY_TEST_CATEGORY: "Performance;Stress;Fast"
           UH_RANDOM_SAMPLE_COUNT: "12750000"
           UH_RANDOM_NOISE_MAP_ITERATIONS: "1000"
@@ -328,64 +291,42 @@ jobs:
 
       - name: Return Unity license
         id: return_unity_license
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        continue-on-error: true
-        uses: ./.github/actions/return-unity-license
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
-          prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log
-          prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
-        env:
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          unity-version: ${{ matrix.unity-version }}
+          tool-cache: ${{ runner.tool_cache }}
+          unity-email: ${{ secrets.UNITY_EMAIL }}
+          unity-password: ${{ secrets.UNITY_PASSWORD }}
+          evidence-suffix: benchmark
+
+      - name: Classify Unity cleanup evidence
+        id: cleanup_classification
+        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
+          return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
+          return-exit-code: ${{ steps.return_unity_license.outputs.return-exit-code }}
+          evidence-capture-complete: ${{ steps.return_unity_license.outputs.evidence-capture-complete }}
+          return-log-digest: ${{ steps.return_unity_license.outputs.return-log-digest }}
 
       - name: Release organization Unity lock
         id: release_unity_lock
-        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
+        if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
           runner-id: ${{ runner.name }}
-          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
-          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
-          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
+          resource-cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.cleanup_classification.outputs.resource-health }}
+          resource-reason: ${{ steps.cleanup_classification.outputs.resource-reason }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
-
-      - name: Require confirmed Unity cleanup
-        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
-        with:
-          acquired: ${{ steps.unity_lock.outputs.acquired }}
-          classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}
-          cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
-          cleanup-health: ${{ steps.return_unity_license.outputs.resource-health }}
-          cleanup-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
-          release-outcome: ${{ steps.release_unity_lock.outcome }}
-          cleanup-result: ${{ steps.release_unity_lock.outputs.cleanup-result }}
-          released: ${{ steps.release_unity_lock.outputs.released }}
-          release-health: ${{ steps.release_unity_lock.outputs.resource-health }}
-          release-reason: ${{ steps.release_unity_lock.outputs.resource-reason }}
-          reservation-state: ${{ steps.release_unity_lock.outputs.reservation-state }}
-          reservation-id: ${{ steps.release_unity_lock.outputs.reservation-id }}
-          incident-id: ${{ steps.release_unity_lock.outputs.incident-id }}
-
-      - name: Delete private Unity cleanup evidence
-        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        shell: pwsh
-        env:
-          RETURN_LOG_PATH: ${{ steps.return_unity_license.outputs.return-log-path }}
-          SUPPLEMENTAL_EVIDENCE_PATHS: ${{ steps.return_unity_license.outputs.supplemental-evidence-paths }}
-        run: |
-          $evidencePaths = @($env:RETURN_LOG_PATH) + @($env:SUPPLEMENTAL_EVIDENCE_PATHS -split "`r?`n")
-          foreach ($evidencePath in @($evidencePaths | Sort-Object -Unique)) {
-            if (-not [string]::IsNullOrWhiteSpace($evidencePath) -and (Test-Path -LiteralPath $evidencePath -PathType Leaf)) {
-              Remove-Item -LiteralPath $evidencePath -Force
-            }
-          }
 
       - name: Dump Unity log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}
@@ -422,7 +363,7 @@ jobs:
           $stageDir = 'perf-staging'
           New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
           if (Test-Path -LiteralPath $src -PathType Leaf) {
-            Copy-Item -LiteralPath $src -Destination (Join-Path $stageDir '${{ matrix.result-file }}') -Force
+            Copy-Item -LiteralPath $src -Destination (Join-Path $stageDir 'results-${{ matrix.unity-version }}-${{ matrix.test-mode }}.xml') -Force
             Write-Host "::notice::Staged perf results for ${{ matrix.unity-version }} ${{ matrix.test-mode }}."
           } else {
             Write-Host "::warning::No results.xml to stage for ${{ matrix.unity-version }} ${{ matrix.test-mode }}."
@@ -445,6 +386,24 @@ jobs:
           path: .artifacts/unity/benchmarks/${{ matrix.unity-version }}-${{ matrix.test-mode }}
           if-no-files-found: warn
           retention-days: 90
+
+      - name: Require confirmed Unity cleanup
+        if: always()
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          acquired: ${{ steps.unity_lock.outputs.acquired }}
+          classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
+          cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
+          cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}
+          cleanup-reason: ${{ steps.cleanup_classification.outputs.resource-reason }}
+          release-outcome: ${{ steps.release_unity_lock.outcome }}
+          cleanup-result: ${{ steps.release_unity_lock.outputs.cleanup-result }}
+          released: ${{ steps.release_unity_lock.outputs.released }}
+          release-health: ${{ steps.release_unity_lock.outputs.resource-health }}
+          release-reason: ${{ steps.release_unity_lock.outputs.resource-reason }}
+          reservation-state: ${{ steps.release_unity_lock.outputs.reservation-state }}
+          reservation-id: ${{ steps.release_unity_lock.outputs.reservation-id }}
+          incident-id: ${{ steps.release_unity_lock.outputs.incident-id }}
 
   commit-perf-results:
     name: Commit refreshed perf results

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -70,6 +70,13 @@ jobs:
       matrix-include: ${{ steps.resolve.outputs.matrix-include }}
       matrix-include-standalone: ${{ steps.resolve.outputs.matrix-include-standalone }}
       matrix-include-single-threaded: ${{ steps.resolve.outputs.matrix-include-single-threaded }}
+      matrix-exclude: ${{ steps.resolve.outputs.matrix-exclude }}
+      matrix-exclude-standalone: ${{ steps.resolve.outputs.matrix-exclude-standalone }}
+      editmode-integration-assemblies: ${{ steps.assemblies.outputs.editmode_integrations }}
+      playmode-integration-assemblies: ${{ steps.assemblies.outputs.playmode_integrations }}
+      standalone-integration-assemblies: ${{ steps.assemblies.outputs.standalone_integrations }}
+      editmode-core-assemblies: ${{ steps.assemblies.outputs.editmode_core }}
+      playmode-core-assemblies: ${{ steps.assemblies.outputs.playmode_core }}
       has-required-secrets: ${{ steps.check-secrets.outputs.has-secrets }}
       superseded: ${{ steps.superseded.outputs.superseded }}
     steps:
@@ -256,6 +263,24 @@ jobs:
           fi
           include_fast="$(build_include "${fast_modes}")"
           include_std="$(build_include "${std_modes}")"
+          all_versions="$(jq -c '.all' .github/unity-versions.json)"
+          exclude_fast="$(jq -cn \
+            --argjson allVersions "${all_versions}" \
+            --argjson selectedVersions "${versions}" \
+            --argjson selectedModes "${fast_modes}" \
+            '[ $allVersions[] as $version |
+               ["editmode", "playmode", "standalone"][] as $mode |
+               select(($selectedVersions | index($version)) == null or
+                      ($selectedModes | index($mode)) == null) |
+               { "unity-version": $version, "test-mode": $mode } ]')"
+          exclude_std="$(jq -cn \
+            --argjson allVersions "${all_versions}" \
+            --argjson selectedVersions "${versions}" \
+            --argjson selectedModes "${std_modes}" \
+            '[ $allVersions[] as $version |
+               select(($selectedVersions | index($version)) == null or
+                      ($selectedModes | index("standalone")) == null) |
+               { "unity-version": $version, "test-mode": "standalone" } ]')"
           include_single_threaded="$(jq -cn \
             --arg editmode "${EDITMODE_CORE_ASSEMBLIES}" \
             --arg playmode "${PLAYMODE_CORE_ASSEMBLIES}" \
@@ -271,6 +296,8 @@ jobs:
             echo "matrix-include=${include_fast}"
             echo "matrix-include-standalone=${include_std}"
             echo "matrix-include-single-threaded=${include_single_threaded}"
+            echo "matrix-exclude=${exclude_fast}"
+            echo "matrix-exclude-standalone=${exclude_std}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Check for required licensed workflow secrets
@@ -340,7 +367,7 @@ jobs:
 
       - name: Require an online Unity runner
         if: ${{ steps.credentials.outputs.present == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -361,6 +388,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected) &&
         needs.matrix-config.outputs.has-required-secrets == 'true' &&
+        needs.matrix-config.outputs.matrix-include != '[]' &&
         needs.matrix-config.outputs.superseded != 'true'
       }}
     runs-on: [self-hosted, Windows, RAM-64GB]
@@ -386,17 +414,36 @@ jobs:
       # trade-off accepted here is politeness -- a sibling repo's Unity job can now
       # queue behind more of ours at once.
       matrix:
-        # Ordered fast-tier include from matrix-config: editmode then playmode,
-        # version-minor. matrix.unity-version / matrix.test-mode come from each
-        # include object. (Standalone runs in the gated unity-tests-standalone job.)
-        include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include) }}
+        unity-version:
+          - 2021.3.45f1
+          - 2022.3.45f1
+          - 6000.3.16f1
+          - 6000.5.2f1
+        test-mode:
+          - editmode
+          - playmode
+          - standalone
+        exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
+        timeout-minutes: 2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@300501e91c9bec81bb9b5a977c22aa5bb2d9b649
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
           expected-head-sha: ${{ github.event.pull_request.head.sha }}
+
+      - name: Require manually installed Unity editor
+        id: ensure_unity_editor
+        timeout-minutes: 10
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }}
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
 
       - name: Enable Git long paths
         shell: powershell
@@ -411,54 +458,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Maintain Unity editor on selected runner
-        if: ${{ matrix.is-empty != true }}
-        timeout-minutes: 360
-        shell: powershell
-        run: |
-          $artifactsPath = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $maintenanceDiagnosticsRoot = Join-Path $artifactsPath 'provisioning/runner-maintenance'
-          New-Item -ItemType Directory -Force -Path $maintenanceDiagnosticsRoot | Out-Null
-          $provisioningProfile = if ('${{ matrix.test-mode }}' -eq 'standalone') {
-            'StandaloneWindowsIl2Cpp'
-          } else {
-            'EditorOnly'
-          }
-          $maintenanceScript = Join-Path $env:GITHUB_WORKSPACE 'scripts\unity\maintain-windows-runner.ps1'
-          if (-not (Test-Path -LiteralPath $maintenanceScript -PathType Leaf)) {
-            throw "Runner maintenance script not found: $maintenanceScript"
-          }
-          . $maintenanceScript
-          $maintenanceExitCode = Invoke-WindowsRunnerMaintenance `
-            -UnityVersions '${{ matrix.unity-version }}' `
-            -ProvisioningProfile $provisioningProfile `
-            -DiagnosticsRoot $maintenanceDiagnosticsRoot
-          if ($maintenanceExitCode -ne 0) {
-            throw "Runner maintenance failed with exit code $maintenanceExitCode."
-          }
-          $pwshCandidates = @(
-            (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'),
-            $(if (${env:ProgramFiles(x86)}) { Join-Path ${env:ProgramFiles(x86)} 'PowerShell\7\pwsh.exe' })
-          )
-          $pathPwsh = Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
-          if ($pathPwsh -and $pathPwsh -notlike '*\Microsoft\WindowsApps\pwsh.exe') {
-            $pwshCandidates += $pathPwsh
-          }
-          $pwshCandidates = @(
-            $pwshCandidates |
-              Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-              Select-Object -Unique
-          )
-          $pwshPath = @($pwshCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf })[0]
-          if (-not $pwshPath) {
-            throw 'PowerShell 7 maintenance completed, but pwsh.exe was not found for later GitHub Actions steps.'
-          }
-          $pwshDirectory = Split-Path -Parent $pwshPath
-          $pwshDirectory | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-          Write-Host "Added PowerShell 7 to GITHUB_PATH: $pwshDirectory"
-
       - name: Print runner diagnostics
-        if: ${{ matrix.is-empty != true }}
         # Composite action runs PowerShell internally; `shell: bash` on a
         # self-hosted Windows runner can resolve to the WSL stub at
         # C:\Windows\System32\bash.exe and fail with "Windows Subsystem
@@ -469,51 +469,15 @@ jobs:
           matrix-note: "default (organization lock wraps the Unity section)"
 
       - name: Validate Unity license secrets
-        if: ${{ matrix.is-empty != true }}
         uses: ./.github/actions/validate-unity-license
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
-      # Skip provisioning, the org lock, and the run when the hosted matrix job
-      # found no unity-helpers test assembly for this target. The verify step is
-      # told that the skip was expected. This never triggers for the current
-      # asmdef set; it is the robustness path for a future empty target.
-      - name: Provision Unity Editor
-        if: ${{ matrix.is-empty != true }}
-        timeout-minutes: 180
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $diagnosticsPath = Join-Path $artifactsPath 'provisioning'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $provisioningProfile = if ('${{ matrix.test-mode }}' -eq 'standalone') {
-            'StandaloneWindowsIl2Cpp'
-          } else {
-            'EditorOnly'
-          }
-          $editor = ./scripts/unity/ensure-editor.ps1 `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -CiManagedOnly `
-            -RequireHealthyExisting `
-            -ProvisioningProfile $provisioningProfile `
-            -DiagnosticsPath $diagnosticsFile
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Upload Unity provisioning diagnostics
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: unity-provisioning-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/provisioning
-          if-no-files-found: warn
-          retention-days: 14
-
       - name: Require current PR head before lock acquisition
-        if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
+        timeout-minutes: 2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@300501e91c9bec81bb9b5a977c22aa5bb2d9b649
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -521,8 +485,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -537,7 +500,7 @@ jobs:
 
       - name: Run Unity Test Runner
         id: run_tests
-        if: ${{ matrix.is-empty != true }}
+        if: ${{ steps.unity_lock.outputs.acquired == 'true' }}
         # Per-mode timeout, sized from measurement rather than fear. Across the 60
         # most recent Unity Tests runs (~430 leg instances) the slowest this step
         # has EVER been is 9.1 min (editmode), with standalone topping out at
@@ -551,11 +514,12 @@ jobs:
         timeout-minutes: ${{ (matrix.test-mode == 'standalone' && 60) || 40 }}
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          UH_TEST_ASSEMBLIES: ${{ matrix.assemblies }}
+          UH_TEST_ASSEMBLIES: ${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-integration-assemblies || matrix.test-mode == 'playmode' && needs.matrix-config.outputs.playmode-integration-assemblies || needs.matrix-config.outputs.standalone-integration-assemblies }}
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
           # CiTestResultStreamLogger). When a PlayMode run aborts/reloads mid-run and
@@ -585,8 +549,47 @@ jobs:
       # Surface the slowest fixtures/cases every run (the measurement backbone for
       # keeping the suite fast). Warn at 120s/fixture; add -FailOverBudget once the
       # budget is tight enough to enforce as a hard wall-clock gate.
+      - name: Return Unity license
+        id: return_unity_license
+        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
+        timeout-minutes: 5
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          tool-cache: ${{ runner.tool_cache }}
+          unity-email: ${{ secrets.UNITY_EMAIL }}
+          unity-password: ${{ secrets.UNITY_PASSWORD }}
+          evidence-suffix: tests
+
+      - name: Classify Unity cleanup evidence
+        id: cleanup_classification
+        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
+          return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
+          return-exit-code: ${{ steps.return_unity_license.outputs.return-exit-code }}
+          evidence-capture-complete: ${{ steps.return_unity_license.outputs.evidence-capture-complete }}
+          return-log-digest: ${{ steps.return_unity_license.outputs.return-log-digest }}
+
+      - name: Release organization Unity lock
+        id: release_unity_lock
+        if: always()
+        timeout-minutes: 5
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          lock-name: wallstop-organization-builds
+          holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
+          resource-cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.cleanup_classification.outputs.resource-health }}
+          resource-reason: ${{ steps.cleanup_classification.outputs.resource-reason }}
+        env:
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
+
       - name: Report slowest tests
-        if: ${{ always() && matrix.is-empty != true }}
+        if: always()
         shell: pwsh
         run: |
           $results = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/results.xml'
@@ -596,75 +599,6 @@ jobs:
             Write-Host "::notice::No results.xml at $results to report slow tests."
           }
 
-      - name: Return Unity license
-        id: return_unity_license
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        timeout-minutes: 5
-        continue-on-error: true
-        uses: ./.github/actions/return-unity-license
-        with:
-          prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log
-          prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
-        env:
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-
-      - name: Release organization Unity lock
-        id: release_unity_lock
-        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
-        with:
-          lock-name: wallstop-organization-builds
-          holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          runner-id: ${{ runner.name }}
-          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
-          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
-          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
-        env:
-          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
-          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
-
-      - name: Require confirmed Unity cleanup
-        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
-        with:
-          acquired: ${{ steps.unity_lock.outputs.acquired }}
-          classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}
-          cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
-          cleanup-health: ${{ steps.return_unity_license.outputs.resource-health }}
-          cleanup-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
-          release-outcome: ${{ steps.release_unity_lock.outcome }}
-          cleanup-result: ${{ steps.release_unity_lock.outputs.cleanup-result }}
-          released: ${{ steps.release_unity_lock.outputs.released }}
-          release-health: ${{ steps.release_unity_lock.outputs.resource-health }}
-          release-reason: ${{ steps.release_unity_lock.outputs.resource-reason }}
-          reservation-state: ${{ steps.release_unity_lock.outputs.reservation-state }}
-          reservation-id: ${{ steps.release_unity_lock.outputs.reservation-id }}
-          incident-id: ${{ steps.release_unity_lock.outputs.incident-id }}
-
-      - name: Delete private Unity cleanup evidence
-        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        shell: pwsh
-        env:
-          RETURN_LOG_PATH: ${{ steps.return_unity_license.outputs.return-log-path }}
-          SUPPLEMENTAL_EVIDENCE_PATHS: ${{ steps.return_unity_license.outputs.supplemental-evidence-paths }}
-        run: |
-          $evidencePaths = @($env:RETURN_LOG_PATH) + @($env:SUPPLEMENTAL_EVIDENCE_PATHS -split "`r?`n")
-          foreach ($evidencePath in @($evidencePaths | Sort-Object -Unique)) {
-            if (-not [string]::IsNullOrWhiteSpace($evidencePath) -and (Test-Path -LiteralPath $evidencePath -PathType Leaf)) {
-              Remove-Item -LiteralPath $evidencePath -Force
-            }
-          }
-
-      # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity hangs in csc the runner
-      # step times out (or the operator cancels), and the verify step below
-      # skips -- so its catastrophic-pattern scan never fires either. This step
-      # covers both failure() AND cancelled() so the operator has SOMETHING to
-      # look at in the GitHub summary (the tail of unity.log + any catastrophic
-      # patterns the partial log happened to surface). Best-effort: never fails
-      # the job, no-ops when unity.log doesn't exist (cancellation before Unity
-      # launched).
       - name: Dump Unity log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}
         uses: ./.github/actions/dump-unity-log-tail
@@ -686,13 +620,13 @@ jobs:
         if: >-
           ${{
             !cancelled() &&
-            (matrix.is-empty == true || steps.run_tests.outcome != 'skipped')
+            steps.run_tests.outcome != 'skipped'
           }}
         uses: ./.github/actions/verify-unity-results
         with:
           results-dir: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}
           label: Unity ${{ matrix.unity-version }} ${{ matrix.test-mode }}
-          expected-empty: ${{ matrix.is-empty }}
+          expected-empty: false
 
       - name: Upload Unity test artifacts
         if: always()
@@ -702,6 +636,33 @@ jobs:
           path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Require confirmed Unity cleanup
+        if: always()
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          acquired: ${{ steps.unity_lock.outputs.acquired }}
+          classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
+          cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
+          cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}
+          cleanup-reason: ${{ steps.cleanup_classification.outputs.resource-reason }}
+          release-outcome: ${{ steps.release_unity_lock.outcome }}
+          cleanup-result: ${{ steps.release_unity_lock.outputs.cleanup-result }}
+          released: ${{ steps.release_unity_lock.outputs.released }}
+          release-health: ${{ steps.release_unity_lock.outputs.resource-health }}
+          release-reason: ${{ steps.release_unity_lock.outputs.resource-reason }}
+          reservation-state: ${{ steps.release_unity_lock.outputs.reservation-state }}
+          reservation-id: ${{ steps.release_unity_lock.outputs.reservation-id }}
+          incident-id: ${{ steps.release_unity_lock.outputs.incident-id }}
+
+      # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity hangs in csc the runner
+      # step times out (or the operator cancels), and the verify step below
+      # skips -- so its catastrophic-pattern scan never fires either. This step
+      # covers both failure() AND cancelled() so the operator has SOMETHING to
+      # look at in the GitHub summary (the tail of unity.log + any catastrophic
+      # patterns the partial log happened to surface). Best-effort: never fails
+      # the job, no-ops when unity.log doesn't exist (cancellation before Unity
+      # launched).
 
   # GATED STANDALONE tier: the expensive IL2CPP player legs. `needs: unity-tests`
   # means any failure in the fast tier (a compile error in an editmode leg, a mass
@@ -752,16 +713,34 @@ jobs:
       # were created at +32.0 min and the first started at +42.1, both runners idle
       # throughout.
       matrix:
-        # Standalone-tier include from matrix-config (empty -> this job is skipped
-        # by the if-guard above -- single-mode dispatch pins run in the fast tier).
-        include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include-standalone) }}
+        unity-version:
+          - 2021.3.45f1
+          - 2022.3.45f1
+          - 6000.3.16f1
+          - 6000.5.2f1
+        test-mode:
+          - standalone
+        exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude-standalone) }}
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
+        timeout-minutes: 2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@300501e91c9bec81bb9b5a977c22aa5bb2d9b649
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
           expected-head-sha: ${{ github.event.pull_request.head.sha }}
+
+      - name: Require manually installed Unity editor
+        id: ensure_unity_editor
+        timeout-minutes: 10
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }}
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
 
       - name: Enable Git long paths
         shell: powershell
@@ -776,54 +755,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Maintain Unity editor on selected runner
-        if: ${{ matrix.is-empty != true }}
-        timeout-minutes: 360
-        shell: powershell
-        run: |
-          $artifactsPath = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $maintenanceDiagnosticsRoot = Join-Path $artifactsPath 'provisioning/runner-maintenance'
-          New-Item -ItemType Directory -Force -Path $maintenanceDiagnosticsRoot | Out-Null
-          $provisioningProfile = if ('${{ matrix.test-mode }}' -eq 'standalone') {
-            'StandaloneWindowsIl2Cpp'
-          } else {
-            'EditorOnly'
-          }
-          $maintenanceScript = Join-Path $env:GITHUB_WORKSPACE 'scripts\unity\maintain-windows-runner.ps1'
-          if (-not (Test-Path -LiteralPath $maintenanceScript -PathType Leaf)) {
-            throw "Runner maintenance script not found: $maintenanceScript"
-          }
-          . $maintenanceScript
-          $maintenanceExitCode = Invoke-WindowsRunnerMaintenance `
-            -UnityVersions '${{ matrix.unity-version }}' `
-            -ProvisioningProfile $provisioningProfile `
-            -DiagnosticsRoot $maintenanceDiagnosticsRoot
-          if ($maintenanceExitCode -ne 0) {
-            throw "Runner maintenance failed with exit code $maintenanceExitCode."
-          }
-          $pwshCandidates = @(
-            (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'),
-            $(if (${env:ProgramFiles(x86)}) { Join-Path ${env:ProgramFiles(x86)} 'PowerShell\7\pwsh.exe' })
-          )
-          $pathPwsh = Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
-          if ($pathPwsh -and $pathPwsh -notlike '*\Microsoft\WindowsApps\pwsh.exe') {
-            $pwshCandidates += $pathPwsh
-          }
-          $pwshCandidates = @(
-            $pwshCandidates |
-              Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-              Select-Object -Unique
-          )
-          $pwshPath = @($pwshCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf })[0]
-          if (-not $pwshPath) {
-            throw 'PowerShell 7 maintenance completed, but pwsh.exe was not found for later GitHub Actions steps.'
-          }
-          $pwshDirectory = Split-Path -Parent $pwshPath
-          $pwshDirectory | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-          Write-Host "Added PowerShell 7 to GITHUB_PATH: $pwshDirectory"
-
       - name: Print runner diagnostics
-        if: ${{ matrix.is-empty != true }}
         # Composite action runs PowerShell internally; `shell: bash` on a
         # self-hosted Windows runner can resolve to the WSL stub at
         # C:\Windows\System32\bash.exe and fail with "Windows Subsystem
@@ -834,51 +766,15 @@ jobs:
           matrix-note: "gated standalone (organization lock wraps the Unity section)"
 
       - name: Validate Unity license secrets
-        if: ${{ matrix.is-empty != true }}
         uses: ./.github/actions/validate-unity-license
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
-      # Skip provisioning, the org lock, and the run when the hosted matrix job
-      # found no unity-helpers test assembly for this target. The verify step is
-      # told that the skip was expected. This never triggers for the current
-      # asmdef set; it is the robustness path for a future empty target.
-      - name: Provision Unity Editor
-        if: ${{ matrix.is-empty != true }}
-        timeout-minutes: 180
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $diagnosticsPath = Join-Path $artifactsPath 'provisioning'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $provisioningProfile = if ('${{ matrix.test-mode }}' -eq 'standalone') {
-            'StandaloneWindowsIl2Cpp'
-          } else {
-            'EditorOnly'
-          }
-          $editor = ./scripts/unity/ensure-editor.ps1 `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -CiManagedOnly `
-            -RequireHealthyExisting `
-            -ProvisioningProfile $provisioningProfile `
-            -DiagnosticsPath $diagnosticsFile
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Upload Unity provisioning diagnostics
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: unity-provisioning-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/provisioning
-          if-no-files-found: warn
-          retention-days: 14
-
       - name: Require current PR head before lock acquisition
-        if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
+        timeout-minutes: 2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@300501e91c9bec81bb9b5a977c22aa5bb2d9b649
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -886,8 +782,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -902,7 +797,7 @@ jobs:
 
       - name: Run Unity Test Runner
         id: run_tests
-        if: ${{ matrix.is-empty != true }}
+        if: ${{ steps.unity_lock.outputs.acquired == 'true' }}
         # Per-mode timeout, sized from measurement rather than fear. Across the 60
         # most recent Unity Tests runs (~430 leg instances) the slowest this step
         # has EVER been is 9.1 min (editmode), with standalone topping out at
@@ -916,11 +811,12 @@ jobs:
         timeout-minutes: ${{ (matrix.test-mode == 'standalone' && 60) || 40 }}
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          UH_TEST_ASSEMBLIES: ${{ matrix.assemblies }}
+          UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.standalone-integration-assemblies }}
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
           # CiTestResultStreamLogger). When a PlayMode run aborts/reloads mid-run and
@@ -942,8 +838,47 @@ jobs:
       # Surface the slowest fixtures/cases every run (the measurement backbone for
       # keeping the suite fast). Warn at 120s/fixture; add -FailOverBudget once the
       # budget is tight enough to enforce as a hard wall-clock gate.
+      - name: Return Unity license
+        id: return_unity_license
+        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
+        timeout-minutes: 5
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          tool-cache: ${{ runner.tool_cache }}
+          unity-email: ${{ secrets.UNITY_EMAIL }}
+          unity-password: ${{ secrets.UNITY_PASSWORD }}
+          evidence-suffix: standalone
+
+      - name: Classify Unity cleanup evidence
+        id: cleanup_classification
+        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
+          return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
+          return-exit-code: ${{ steps.return_unity_license.outputs.return-exit-code }}
+          evidence-capture-complete: ${{ steps.return_unity_license.outputs.evidence-capture-complete }}
+          return-log-digest: ${{ steps.return_unity_license.outputs.return-log-digest }}
+
+      - name: Release organization Unity lock
+        id: release_unity_lock
+        if: always()
+        timeout-minutes: 5
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          lock-name: wallstop-organization-builds
+          holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
+          resource-cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.cleanup_classification.outputs.resource-health }}
+          resource-reason: ${{ steps.cleanup_classification.outputs.resource-reason }}
+        env:
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
+
       - name: Report slowest tests
-        if: ${{ always() && matrix.is-empty != true }}
+        if: always()
         shell: pwsh
         run: |
           $results = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/results.xml'
@@ -953,75 +888,6 @@ jobs:
             Write-Host "::notice::No results.xml at $results to report slow tests."
           }
 
-      - name: Return Unity license
-        id: return_unity_license
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        timeout-minutes: 5
-        continue-on-error: true
-        uses: ./.github/actions/return-unity-license
-        with:
-          prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log
-          prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
-        env:
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-
-      - name: Release organization Unity lock
-        id: release_unity_lock
-        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
-        with:
-          lock-name: wallstop-organization-builds
-          holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          runner-id: ${{ runner.name }}
-          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
-          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
-          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
-        env:
-          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
-          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
-
-      - name: Require confirmed Unity cleanup
-        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
-        with:
-          acquired: ${{ steps.unity_lock.outputs.acquired }}
-          classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}
-          cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
-          cleanup-health: ${{ steps.return_unity_license.outputs.resource-health }}
-          cleanup-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
-          release-outcome: ${{ steps.release_unity_lock.outcome }}
-          cleanup-result: ${{ steps.release_unity_lock.outputs.cleanup-result }}
-          released: ${{ steps.release_unity_lock.outputs.released }}
-          release-health: ${{ steps.release_unity_lock.outputs.resource-health }}
-          release-reason: ${{ steps.release_unity_lock.outputs.resource-reason }}
-          reservation-state: ${{ steps.release_unity_lock.outputs.reservation-state }}
-          reservation-id: ${{ steps.release_unity_lock.outputs.reservation-id }}
-          incident-id: ${{ steps.release_unity_lock.outputs.incident-id }}
-
-      - name: Delete private Unity cleanup evidence
-        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        shell: pwsh
-        env:
-          RETURN_LOG_PATH: ${{ steps.return_unity_license.outputs.return-log-path }}
-          SUPPLEMENTAL_EVIDENCE_PATHS: ${{ steps.return_unity_license.outputs.supplemental-evidence-paths }}
-        run: |
-          $evidencePaths = @($env:RETURN_LOG_PATH) + @($env:SUPPLEMENTAL_EVIDENCE_PATHS -split "`r?`n")
-          foreach ($evidencePath in @($evidencePaths | Sort-Object -Unique)) {
-            if (-not [string]::IsNullOrWhiteSpace($evidencePath) -and (Test-Path -LiteralPath $evidencePath -PathType Leaf)) {
-              Remove-Item -LiteralPath $evidencePath -Force
-            }
-          }
-
-      # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity hangs in csc the runner
-      # step times out (or the operator cancels), and the verify step below
-      # skips -- so its catastrophic-pattern scan never fires either. This step
-      # covers both failure() AND cancelled() so the operator has SOMETHING to
-      # look at in the GitHub summary (the tail of unity.log + any catastrophic
-      # patterns the partial log happened to surface). Best-effort: never fails
-      # the job, no-ops when unity.log doesn't exist (cancellation before Unity
-      # launched).
       - name: Dump Unity log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}
         uses: ./.github/actions/dump-unity-log-tail
@@ -1043,13 +909,13 @@ jobs:
         if: >-
           ${{
             !cancelled() &&
-            (matrix.is-empty == true || steps.run_tests.outcome != 'skipped')
+            steps.run_tests.outcome != 'skipped'
           }}
         uses: ./.github/actions/verify-unity-results
         with:
           results-dir: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}
           label: Unity ${{ matrix.unity-version }} ${{ matrix.test-mode }}
-          expected-empty: ${{ matrix.is-empty }}
+          expected-empty: false
 
       - name: Upload Unity test artifacts
         if: always()
@@ -1060,6 +926,32 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Require confirmed Unity cleanup
+        if: always()
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          acquired: ${{ steps.unity_lock.outputs.acquired }}
+          classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
+          cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
+          cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}
+          cleanup-reason: ${{ steps.cleanup_classification.outputs.resource-reason }}
+          release-outcome: ${{ steps.release_unity_lock.outcome }}
+          cleanup-result: ${{ steps.release_unity_lock.outputs.cleanup-result }}
+          released: ${{ steps.release_unity_lock.outputs.released }}
+          release-health: ${{ steps.release_unity_lock.outputs.resource-health }}
+          release-reason: ${{ steps.release_unity_lock.outputs.resource-reason }}
+          reservation-state: ${{ steps.release_unity_lock.outputs.reservation-state }}
+          reservation-id: ${{ steps.release_unity_lock.outputs.reservation-id }}
+          incident-id: ${{ steps.release_unity_lock.outputs.incident-id }}
+
+      # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity hangs in csc the runner
+      # step times out (or the operator cancels), and the verify step below
+      # skips -- so its catastrophic-pattern scan never fires either. This step
+      # covers both failure() AND cancelled() so the operator has SOMETHING to
+      # look at in the GitHub summary (the tail of unity.log + any catastrophic
+      # patterns the partial log happened to surface). Best-effort: never fails
+      # the job, no-ops when unity.log doesn't exist (cancellation before Unity
+      # launched).
   # SINGLE_THREADED leg. The default matrix never exercises the SINGLE_THREADED
   # code paths (Runtime/Core/DataStructure/Cache.cs et al. gate thread-safe vs
   # single-threaded behavior on `#if SINGLE_THREADED`, OFF by default). This job
@@ -1112,19 +1004,31 @@ jobs:
       fail-fast: false
       # No max-parallel, for the reason recorded on the fast tier above.
       matrix:
-        # Unity 6 ONLY (6000.3.16f1), editmode + playmode. PlayMode owns the
-        # platform-neutral runtime/core assemblies; EditMode keeps the editor-only
-        # assemblies that caught editor scheduling races. The hosted matrix job
-        # attaches both disjoint lists, so these self-hosted legs neither repeat
-        # runtime tests nor need Node/asmdef discovery.
-        include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include-single-threaded) }}
+        unity-version:
+          - 6000.3.16f1
+        test-mode:
+          - editmode
+          - playmode
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
+        timeout-minutes: 2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@300501e91c9bec81bb9b5a977c22aa5bb2d9b649
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
           expected-head-sha: ${{ github.event.pull_request.head.sha }}
+
+      - name: Require manually installed Unity editor
+        id: ensure_unity_editor
+        timeout-minutes: 10
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: EditorOnly
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
 
       - name: Enable Git long paths
         shell: powershell
@@ -1139,50 +1043,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Maintain Unity editor on selected runner
-        if: ${{ matrix.is-empty != true }}
-        timeout-minutes: 360
-        shell: powershell
-        run: |
-          $artifactsPath = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded'
-          $maintenanceDiagnosticsRoot = Join-Path $artifactsPath 'provisioning/runner-maintenance'
-          New-Item -ItemType Directory -Force -Path $maintenanceDiagnosticsRoot | Out-Null
-          $provisioningProfile = 'EditorOnly'
-          $maintenanceScript = Join-Path $env:GITHUB_WORKSPACE 'scripts\unity\maintain-windows-runner.ps1'
-          if (-not (Test-Path -LiteralPath $maintenanceScript -PathType Leaf)) {
-            throw "Runner maintenance script not found: $maintenanceScript"
-          }
-          . $maintenanceScript
-          $maintenanceExitCode = Invoke-WindowsRunnerMaintenance `
-            -UnityVersions '${{ matrix.unity-version }}' `
-            -ProvisioningProfile $provisioningProfile `
-            -DiagnosticsRoot $maintenanceDiagnosticsRoot
-          if ($maintenanceExitCode -ne 0) {
-            throw "Runner maintenance failed with exit code $maintenanceExitCode."
-          }
-          $pwshCandidates = @(
-            (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'),
-            $(if (${env:ProgramFiles(x86)}) { Join-Path ${env:ProgramFiles(x86)} 'PowerShell\7\pwsh.exe' })
-          )
-          $pathPwsh = Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
-          if ($pathPwsh -and $pathPwsh -notlike '*\Microsoft\WindowsApps\pwsh.exe') {
-            $pwshCandidates += $pathPwsh
-          }
-          $pwshCandidates = @(
-            $pwshCandidates |
-              Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-              Select-Object -Unique
-          )
-          $pwshPath = @($pwshCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf })[0]
-          if (-not $pwshPath) {
-            throw 'PowerShell 7 maintenance completed, but pwsh.exe was not found for later GitHub Actions steps.'
-          }
-          $pwshDirectory = Split-Path -Parent $pwshPath
-          $pwshDirectory | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-          Write-Host "Added PowerShell 7 to GITHUB_PATH: $pwshDirectory"
-
       - name: Print runner diagnostics
-        if: ${{ matrix.is-empty != true }}
         # Composite action runs PowerShell internally; `shell: bash` on a
         # self-hosted Windows runner can resolve to the WSL stub and fail. Never
         # use plain `shell: bash` on self-hosted Windows runners.
@@ -1191,42 +1052,15 @@ jobs:
           matrix-note: "single-threaded (organization lock wraps the Unity section)"
 
       - name: Validate Unity license secrets
-        if: ${{ matrix.is-empty != true }}
         uses: ./.github/actions/validate-unity-license
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
-      - name: Provision Unity Editor
-        if: ${{ matrix.is-empty != true }}
-        timeout-minutes: 180
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded'
-          $diagnosticsPath = Join-Path $artifactsPath 'provisioning'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $editor = ./scripts/unity/ensure-editor.ps1 `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -CiManagedOnly `
-            -RequireHealthyExisting `
-            -ProvisioningProfile 'EditorOnly' `
-            -DiagnosticsPath $diagnosticsFile
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Upload Unity provisioning diagnostics
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: unity-provisioning-${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
-          path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded/provisioning
-          if-no-files-found: warn
-          retention-days: 14
-
       - name: Require current PR head before lock acquisition
-        if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
+        timeout-minutes: 2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@300501e91c9bec81bb9b5a977c22aa5bb2d9b649
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1234,8 +1068,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        if: ${{ matrix.is-empty != true }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1250,7 +1083,7 @@ jobs:
 
       - name: Run Unity Test Runner
         id: run_tests
-        if: ${{ matrix.is-empty != true }}
+        if: ${{ steps.unity_lock.outputs.acquired == 'true' }}
         # editmode + playmode ONLY (no standalone IL2CPP build). Measured worst case
         # for this leg across the 60 most recent runs is 7.8 min, so 40 keeps >5x
         # headroom while failing a hang 50 min sooner than the old 90 -- a stuck
@@ -1260,11 +1093,12 @@ jobs:
         timeout-minutes: 40
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          UH_TEST_ASSEMBLIES: ${{ matrix.assemblies }}
+          UH_TEST_ASSEMBLIES: ${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-core-assemblies || needs.matrix-config.outputs.playmode-core-assemblies }}
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
           # CiTestResultStreamLogger). When a PlayMode run aborts/reloads mid-run and
@@ -1285,8 +1119,47 @@ jobs:
 
       # Surface the slowest fixtures/cases for the SINGLE_THREADED leg (the 40-min
       # leg the optimization targets). Warn-only; see the main job's note.
+      - name: Return Unity license
+        id: return_unity_license
+        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
+        timeout-minutes: 5
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          tool-cache: ${{ runner.tool_cache }}
+          unity-email: ${{ secrets.UNITY_EMAIL }}
+          unity-password: ${{ secrets.UNITY_PASSWORD }}
+          evidence-suffix: single-threaded
+
+      - name: Classify Unity cleanup evidence
+        id: cleanup_classification
+        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
+          return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
+          return-exit-code: ${{ steps.return_unity_license.outputs.return-exit-code }}
+          evidence-capture-complete: ${{ steps.return_unity_license.outputs.evidence-capture-complete }}
+          return-log-digest: ${{ steps.return_unity_license.outputs.return-log-digest }}
+
+      - name: Release organization Unity lock
+        id: release_unity_lock
+        if: always()
+        timeout-minutes: 5
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          lock-name: wallstop-organization-builds
+          holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
+          runner-id: ${{ runner.name }}
+          resource-cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.cleanup_classification.outputs.resource-health }}
+          resource-reason: ${{ steps.cleanup_classification.outputs.resource-reason }}
+        env:
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
+
       - name: Report slowest tests
-        if: ${{ always() && matrix.is-empty != true }}
+        if: always()
         shell: pwsh
         run: |
           $results = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded/results.xml'
@@ -1294,67 +1167,6 @@ jobs:
             ./scripts/unity/report-slow-tests.ps1 -ResultsPath $results -Top 30 -FixtureBudgetSeconds 120 -StepSummary
           } else {
             Write-Host "::notice::No results.xml at $results to report slow tests."
-          }
-
-      - name: Return Unity license
-        id: return_unity_license
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        timeout-minutes: 5
-        continue-on-error: true
-        uses: ./.github/actions/return-unity-license
-        with:
-          prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log
-          prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
-        env:
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-
-      - name: Release organization Unity lock
-        id: release_unity_lock
-        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
-        with:
-          lock-name: wallstop-organization-builds
-          holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
-          runner-id: ${{ runner.name }}
-          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
-          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
-          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
-        env:
-          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
-          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
-
-      - name: Require confirmed Unity cleanup
-        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
-        with:
-          acquired: ${{ steps.unity_lock.outputs.acquired }}
-          classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}
-          cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
-          cleanup-health: ${{ steps.return_unity_license.outputs.resource-health }}
-          cleanup-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
-          release-outcome: ${{ steps.release_unity_lock.outcome }}
-          cleanup-result: ${{ steps.release_unity_lock.outputs.cleanup-result }}
-          released: ${{ steps.release_unity_lock.outputs.released }}
-          release-health: ${{ steps.release_unity_lock.outputs.resource-health }}
-          release-reason: ${{ steps.release_unity_lock.outputs.resource-reason }}
-          reservation-state: ${{ steps.release_unity_lock.outputs.reservation-state }}
-          reservation-id: ${{ steps.release_unity_lock.outputs.reservation-id }}
-          incident-id: ${{ steps.release_unity_lock.outputs.incident-id }}
-
-      - name: Delete private Unity cleanup evidence
-        if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        shell: pwsh
-        env:
-          RETURN_LOG_PATH: ${{ steps.return_unity_license.outputs.return-log-path }}
-          SUPPLEMENTAL_EVIDENCE_PATHS: ${{ steps.return_unity_license.outputs.supplemental-evidence-paths }}
-        run: |
-          $evidencePaths = @($env:RETURN_LOG_PATH) + @($env:SUPPLEMENTAL_EVIDENCE_PATHS -split "`r?`n")
-          foreach ($evidencePath in @($evidencePaths | Sort-Object -Unique)) {
-            if (-not [string]::IsNullOrWhiteSpace($evidencePath) -and (Test-Path -LiteralPath $evidencePath -PathType Leaf)) {
-              Remove-Item -LiteralPath $evidencePath -Force
-            }
           }
 
       - name: Dump Unity log tail on failure or cancellation
@@ -1368,13 +1180,13 @@ jobs:
         if: >-
           ${{
             !cancelled() &&
-            (matrix.is-empty == true || steps.run_tests.outcome != 'skipped')
+            steps.run_tests.outcome != 'skipped'
           }}
         uses: ./.github/actions/verify-unity-results
         with:
           results-dir: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
           label: Unity ${{ matrix.unity-version }} ${{ matrix.test-mode }} (SINGLE_THREADED)
-          expected-empty: ${{ matrix.is-empty }}
+          expected-empty: false
 
       - name: Upload Unity test artifacts
         if: always()
@@ -1384,6 +1196,24 @@ jobs:
           path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Require confirmed Unity cleanup
+        if: always()
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
+        with:
+          acquired: ${{ steps.unity_lock.outputs.acquired }}
+          classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
+          cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
+          cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}
+          cleanup-reason: ${{ steps.cleanup_classification.outputs.resource-reason }}
+          release-outcome: ${{ steps.release_unity_lock.outcome }}
+          cleanup-result: ${{ steps.release_unity_lock.outputs.cleanup-result }}
+          released: ${{ steps.release_unity_lock.outputs.released }}
+          release-health: ${{ steps.release_unity_lock.outputs.resource-health }}
+          release-reason: ${{ steps.release_unity_lock.outputs.resource-reason }}
+          reservation-state: ${{ steps.release_unity_lock.outputs.reservation-state }}
+          reservation-id: ${{ steps.release_unity_lock.outputs.reservation-id }}
+          incident-id: ${{ steps.release_unity_lock.outputs.incident-id }}
 
   unitypackage-smoke:
     name: Unity package export smoke
@@ -1412,7 +1242,8 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
+        timeout-minutes: 2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@300501e91c9bec81bb9b5a977c22aa5bb2d9b649
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1437,7 +1268,8 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Require current PR head before lock acquisition
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10
+        timeout-minutes: 2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@300501e91c9bec81bb9b5a977c22aa5bb2d9b649
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1445,7 +1277,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
@@ -1493,7 +1325,7 @@ jobs:
         id: release_unity_lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@168b8dea5351f1cc448ed499e354cb31ad64ef10 # v1.12.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
@@ -1507,7 +1339,7 @@ jobs:
 
       - name: Require confirmed Unity cleanup
         if: ${{ always() && steps.unity_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@300501e91c9bec81bb9b5a977c22aa5bb2d9b649 # v1.13.0
         with:
           acquired: ${{ steps.unity_lock.outputs.acquired }}
           classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -519,7 +519,12 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          UH_TEST_ASSEMBLIES: ${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-integration-assemblies || matrix.test-mode == 'playmode' && needs.matrix-config.outputs.playmode-integration-assemblies || needs.matrix-config.outputs.standalone-integration-assemblies }}
+          UH_TEST_ASSEMBLIES: >-
+            ${{ matrix.test-mode == 'editmode' &&
+            needs.matrix-config.outputs.editmode-integration-assemblies ||
+            matrix.test-mode == 'playmode' &&
+            needs.matrix-config.outputs.playmode-integration-assemblies ||
+            needs.matrix-config.outputs.standalone-integration-assemblies }}
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
           # CiTestResultStreamLogger). When a PlayMode run aborts/reloads mid-run and

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -77,6 +77,8 @@ jobs:
       standalone-integration-assemblies: ${{ steps.assemblies.outputs.standalone_integrations }}
       editmode-core-assemblies: ${{ steps.assemblies.outputs.editmode_core }}
       playmode-core-assemblies: ${{ steps.assemblies.outputs.playmode_core }}
+      integration-assembly-profiles: ${{ steps.assemblies.outputs.integration_profiles }}
+      core-assembly-profiles: ${{ steps.assemblies.outputs.core_profiles }}
       has-required-secrets: ${{ steps.check-secrets.outputs.has-secrets }}
       superseded: ${{ steps.superseded.outputs.superseded }}
     steps:
@@ -112,10 +114,22 @@ jobs:
             editmode_core: { target: "editmode", editorOnly: true },
             playmode_core: { target: "playmode" }
           };
-          const lines = Object.entries(profiles).map(([name, options]) => {
+          const resolved = Object.fromEntries(Object.entries(profiles).map(([name, options]) => {
             const assemblies = discovery.defaultIncludeAssemblies(process.cwd(), options).join(";");
-            return `${name}=${assemblies}`;
-          });
+            return [name, assemblies];
+          }));
+          const lines = Object.entries(resolved).map(([name, assemblies]) =>
+            `${name}=${assemblies}`
+          );
+          lines.push(`integration_profiles=${JSON.stringify({
+            editmode: resolved.editmode_integrations,
+            playmode: resolved.playmode_integrations,
+            standalone: resolved.standalone_integrations
+          })}`);
+          lines.push(`core_profiles=${JSON.stringify({
+            editmode: resolved.editmode_core,
+            playmode: resolved.playmode_core
+          })}`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join("\n")}\n`, "utf8");
           NODE
 
@@ -519,12 +533,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          UH_TEST_ASSEMBLIES: >-
-            ${{ matrix.test-mode == 'editmode' &&
-            needs.matrix-config.outputs.editmode-integration-assemblies ||
-            matrix.test-mode == 'playmode' &&
-            needs.matrix-config.outputs.playmode-integration-assemblies ||
-            needs.matrix-config.outputs.standalone-integration-assemblies }}
+          UH_TEST_ASSEMBLIES: ${{ fromJSON(needs.matrix-config.outputs.integration-assembly-profiles)[matrix.test-mode] }}
           UH_CENTRAL_LICENSE_RETURN: "true"
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
@@ -822,7 +831,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.standalone-integration-assemblies }}
+          UH_TEST_ASSEMBLIES: ${{ fromJSON(needs.matrix-config.outputs.integration-assembly-profiles)[matrix.test-mode] }}
           UH_CENTRAL_LICENSE_RETURN: "true"
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
@@ -1105,7 +1114,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          UH_TEST_ASSEMBLIES: ${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-core-assemblies || needs.matrix-config.outputs.playmode-core-assemblies }}
+          UH_TEST_ASSEMBLIES: ${{ fromJSON(needs.matrix-config.outputs.core-assembly-profiles)[matrix.test-mode] }}
           UH_CENTRAL_LICENSE_RETURN: "true"
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -525,6 +525,7 @@ jobs:
             matrix.test-mode == 'playmode' &&
             needs.matrix-config.outputs.playmode-integration-assemblies ||
             needs.matrix-config.outputs.standalone-integration-assemblies }}
+          UH_CENTRAL_LICENSE_RETURN: "true"
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
           # CiTestResultStreamLogger). When a PlayMode run aborts/reloads mid-run and
@@ -822,6 +823,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
           UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.standalone-integration-assemblies }}
+          UH_CENTRAL_LICENSE_RETURN: "true"
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
           # CiTestResultStreamLogger). When a PlayMode run aborts/reloads mid-run and
@@ -1104,6 +1106,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
           UH_TEST_ASSEMBLIES: ${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-core-assemblies || needs.matrix-config.outputs.playmode-core-assemblies }}
+          UH_CENTRAL_LICENSE_RETURN: "true"
           UH_UNITY_TEST_CATEGORY: "!Performance;!Stress"
           # Stream per-test results to unity.log as each test finishes (editor-side
           # CiTestResultStreamLogger). When a PlayMode run aborts/reloads mid-run and

--- a/scripts/tests/test-portable-cleanup-classifier.js
+++ b/scripts/tests/test-portable-cleanup-classifier.js
@@ -267,7 +267,27 @@ for (const [name, overrides, expected] of gateCases) {
 const returnActionPath = path.join(root, ".github/actions/return-unity-license/action.yml");
 const returnAction = fs.readFileSync(returnActionPath, "utf8");
 const centralClassifierUse = `Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@${policyCommit}`;
-assert.match(returnAction, new RegExp(`uses: ${centralClassifierUse}`, "u"));
+const legacyClassifierMatches = [
+  ...returnAction.matchAll(
+    /uses:\s*Ambiguous-Interactive\/ambiguous-organization-build-lock\/\.github\/actions\/classify-unity-cleanup-evidence@([0-9a-f]{40})/gu
+  )
+];
+const legacyClassifierCommits = [...new Set(legacyClassifierMatches.map((match) => match[1]))];
+assert.equal(
+  legacyClassifierMatches.length,
+  2,
+  "the container wrapper must classify both return paths"
+);
+assert.equal(
+  legacyClassifierCommits.length,
+  1,
+  "the container wrapper must use one immutable historical classifier"
+);
+assert.notEqual(
+  legacyClassifierCommits[0],
+  policyCommit,
+  "the container wrapper must not adopt the digest-requiring classifier before a trusted container executor exists"
+);
 assert.match(
   returnAction,
   /value:\s*\$\{\{ steps\.classify_return\.outputs\.resource-safe \|\| steps\.classify_prior\.outputs\.resource-safe \}\}/u
@@ -324,29 +344,73 @@ const workflow = licenseReturningWorkflows.map((entry) => entry.body).join("\n")
 const occurrences = (haystack, needle) => haystack.split(needle).length - 1;
 const licenseReturns = occurrences(workflow, "id: return_unity_license");
 const centralGateUse = `Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@${policyCommit}`;
-
-for (const [description, needle] of [
-  ["the pinned central cleanup gate", `uses: ${centralGateUse}`],
-  ["a lock release", "id: release_unity_lock"],
-  [
-    "a forwarded resource-cleanup-status",
+const centralReturnUse = `Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@${policyCommit}`;
+const centralReturns = occurrences(workflow, `uses: ${centralReturnUse}`);
+const legacyReturns = occurrences(workflow, "uses: ./.github/actions/return-unity-license");
+assert.ok(centralReturns > 0, "no Windows caller uses the central return executor");
+assert.ok(legacyReturns > 0, "no container caller preserves the legacy return wrapper");
+assert.equal(
+  centralReturns + legacyReturns,
+  licenseReturns,
+  "every return must use one reviewed executor"
+);
+assert.equal(
+  occurrences(workflow, `uses: ${centralGateUse}`),
+  licenseReturns,
+  "every licensed lifecycle must finish at the pinned central cleanup gate"
+);
+assert.equal(
+  occurrences(workflow, "id: release_unity_lock"),
+  licenseReturns,
+  "every licensed lifecycle must release its lock"
+);
+assert.equal(
+  occurrences(workflow, `uses: ${centralClassifierUse}`),
+  centralReturns,
+  "every central return must feed one digest-bound central classifier"
+);
+assert.equal(
+  occurrences(
+    workflow,
+    "resource-cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}"
+  ),
+  centralReturns,
+  "every central classifier must forward its typed cleanup status to release"
+);
+assert.equal(
+  occurrences(
+    workflow,
     "resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}"
-  ],
-  [
-    "a forwarded classification-complete",
+  ),
+  legacyReturns,
+  "every container wrapper must forward its typed cleanup status to release"
+);
+assert.equal(
+  occurrences(
+    workflow,
+    "classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}"
+  ),
+  centralReturns,
+  "every central classifier must feed the final gate"
+);
+assert.equal(
+  occurrences(
+    workflow,
     "classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}"
-  ],
-  ["a forwarded release outcome", "release-outcome: ${{ steps.release_unity_lock.outcome }}"],
-  ["an evidence deletion step", "- name: Delete private Unity cleanup evidence"]
-]) {
-  assert.equal(
-    occurrences(workflow, needle),
-    licenseReturns,
-    `${licenseReturns} license return(s) across ` +
-      `${licenseReturningWorkflows.map((entry) => entry.name).join(", ")} but ` +
-      `${occurrences(workflow, needle)} instance(s) of ${description}`
-  );
-}
+  ),
+  legacyReturns,
+  "every container wrapper must feed the final gate"
+);
+assert.equal(
+  occurrences(workflow, "release-outcome: ${{ steps.release_unity_lock.outcome }}"),
+  licenseReturns,
+  "every final gate must consume the release outcome"
+);
+assert.equal(
+  occurrences(workflow, "- name: Delete private Unity cleanup evidence"),
+  legacyReturns,
+  "only legacy container wrappers delete private evidence locally"
+);
 
 process.stdout.write(
   `Central Unity cleanup policy parity passed (${classificationCases.length} classifier cases, ${gateCases.length} gate cases).\n`

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -1742,7 +1742,6 @@ $unityTestsMatrixJob = if ($jobTexts.ContainsKey('unity-tests')) { $jobTexts['un
 $unityTestsStandaloneJob = if ($jobTexts.ContainsKey('unity-tests-standalone')) { $jobTexts['unity-tests-standalone'] } else { '' }
 $unityTestsSingleThreadedJob = if ($jobTexts.ContainsKey('unity-tests-single-threaded')) { $jobTexts['unity-tests-single-threaded'] } else { '' }
 $benchmarksMatrixJob = if ($benchmarksJobTexts.ContainsKey('benchmarks')) { $benchmarksJobTexts['benchmarks'] } else { '' }
-$unityTestsMatrixJobWithoutWhitespace = $unityTestsMatrixJob -replace '\s', ''
 $matrixConfigAssemblyDiscoveryIsCentralized = (
     $jobTexts.ContainsKey('matrix-config') -and
     $jobTexts['matrix-config'].Contains('- name: Setup Node.js for assembly discovery') -and
@@ -1758,14 +1757,16 @@ $matrixConfigAssemblyDiscoveryIsCentralized = (
     $workflowContent.Contains('standalone-integration-assemblies: ${{ steps.assemblies.outputs.standalone_integrations }}') -and
     $workflowContent.Contains('editmode-core-assemblies: ${{ steps.assemblies.outputs.editmode_core }}') -and
     $workflowContent.Contains('playmode-core-assemblies: ${{ steps.assemblies.outputs.playmode_core }}') -and
+    $workflowContent.Contains('integration-assembly-profiles: ${{ steps.assemblies.outputs.integration_profiles }}') -and
+    $workflowContent.Contains('core-assembly-profiles: ${{ steps.assemblies.outputs.core_profiles }}') -and
     $workflowContent.Contains('matrix-exclude: ${{ steps.resolve.outputs.matrix-exclude }}') -and
     $workflowContent.Contains('matrix-exclude-standalone: ${{ steps.resolve.outputs.matrix-exclude-standalone }}') -and
     $unityTestsMatrixJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}') -and
     $unityTestsStandaloneJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude-standalone) }}') -and
     $unityTestsMatrixJob.Contains('- standalone') -and
-    $unityTestsMatrixJobWithoutWhitespace.Contains("UH_TEST_ASSEMBLIES:>-`${{matrix.test-mode=='editmode'&&needs.matrix-config.outputs.editmode-integration-assemblies||matrix.test-mode=='playmode'&&needs.matrix-config.outputs.playmode-integration-assemblies||needs.matrix-config.outputs.standalone-integration-assemblies}}") -and
-    $unityTestsStandaloneJob.Contains('UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.standalone-integration-assemblies }}') -and
-    $unityTestsSingleThreadedJob.Contains("UH_TEST_ASSEMBLIES: `${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-core-assemblies || needs.matrix-config.outputs.playmode-core-assemblies }}") -and
+    $unityTestsMatrixJob.Contains('UH_TEST_ASSEMBLIES: ${{ fromJSON(needs.matrix-config.outputs.integration-assembly-profiles)[matrix.test-mode] }}') -and
+    $unityTestsStandaloneJob.Contains('UH_TEST_ASSEMBLIES: ${{ fromJSON(needs.matrix-config.outputs.integration-assembly-profiles)[matrix.test-mode] }}') -and
+    $unityTestsSingleThreadedJob.Contains('UH_TEST_ASSEMBLIES: ${{ fromJSON(needs.matrix-config.outputs.core-assembly-profiles)[matrix.test-mode] }}') -and
     -not $unityTestsMatrixJob.Contains('actions/setup-node@') -and
     -not $unityTestsStandaloneJob.Contains('actions/setup-node@') -and
     -not $unityTestsSingleThreadedJob.Contains('actions/setup-node@') -and
@@ -3593,10 +3594,11 @@ if (
 
 $centralReturnOwnershipContract = (
     $runCiTestsContent.Contains('$centralReturnOwnsLicense = [string]::Equals(') -and
-    [regex]::Matches($runCiTestsContent, 'if \(\$hasLicenseCreds -and -not \$centralReturnOwnsLicense\)').Count -eq 2
+    [regex]::Matches($runCiTestsContent, 'if \(\$hasLicenseCreds -and -not \$centralReturnOwnsLicense\)').Count -eq 1 -and
+    [regex]::Matches($runCiTestsContent, 'if \(\$hasLicenseCreds\)').Count -eq 1
 )
 if (-not $centralReturnOwnershipContract) {
-    Write-Host "::error file=scripts/unity/run-ci-tests.ps1::The central lifecycle must suppress both repository-local return-at-start and finally-return so the immutable central executor owns the single authoritative return and does not quarantine a redundant 400006."
+    Write-Host "::error file=scripts/unity/run-ci-tests.ps1::The central lifecycle must preserve pre-activation reclaim but suppress repository-local finally-return so the immutable central executor owns the single post-activation return and does not quarantine a redundant 400006."
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info 'Checked central lifecycle callers leave the single authoritative return to the central executor.'

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -172,6 +172,7 @@ function Get-BuildLockActionPins {
     }
 
     $pins = @{}
+    $splitCleanupActions = @('classify-unity-cleanup-evidence')
     foreach ($name in ($observed.Keys | Sort-Object)) {
         $usages = @($observed[$name])
 
@@ -187,6 +188,32 @@ function Get-BuildLockActionPins {
             [string[]]@($usages | Select-Object -ExpandProperty Reference) |
                 Sort-Object -CaseSensitive -Unique
         )
+        if ($name -in $splitCleanupActions -and $distinctReferences.Count -eq 2) {
+            $versionedUsages = @($usages | Where-Object { $_.Comment -match '^v\d+\.\d+\.\d+$' })
+            $legacyUsages = @($usages | Where-Object { [string]::IsNullOrWhiteSpace($_.Comment) })
+            $versionedReferences = @(
+                [string[]]@($versionedUsages | Select-Object -ExpandProperty Reference) |
+                    Sort-Object -CaseSensitive -Unique
+            )
+            $legacyReferences = @(
+                [string[]]@($legacyUsages | Select-Object -ExpandProperty Reference) |
+                    Sort-Object -CaseSensitive -Unique
+            )
+            if (
+                $versionedUsages.Count -gt 0 -and
+                $legacyUsages.Count -gt 0 -and
+                ($versionedUsages.Count + $legacyUsages.Count) -eq $usages.Count -and
+                $versionedReferences.Count -eq 1 -and
+                $legacyReferences.Count -eq 1
+            ) {
+                $pins[$name] = [pscustomobject]@{
+                    Sha     = $versionedReferences[0]
+                    Comment = $versionedUsages[0].Comment
+                    Count   = $versionedUsages.Count
+                }
+                continue
+            }
+        }
         if ($distinctReferences.Count -ne 1) {
             $detail = ($usages | ForEach-Object { "$($_.File) -> @$($_.Reference)" }) -join ', '
             Write-Host "::error file=scripts/tests/test-unity-workflow-matrix-contract.ps1::Build-lock action '$name' is pinned to $($distinctReferences.Count) different commits. A partial bump leaves two versions live against one Unity seat. Usages: $detail."
@@ -233,6 +260,8 @@ $buildLockPins = Get-BuildLockActionPins -GitHubRoot (Join-Path $repoRoot '.gith
     'release-build-lock',
     'check-unity-runner-availability',
     'require-current-pr-head',
+    'ensure-unity-editor',
+    'return-unity-license',
     'require-confirmed-unity-cleanup',
     'classify-unity-cleanup-evidence'
 )
@@ -243,6 +272,8 @@ $buildLockActionVersion = $buildLockPins['release-build-lock'].Comment
 $runnerAvailabilityActionCommit = $buildLockPins['check-unity-runner-availability'].Sha
 $runnerAvailabilityActionVersion = $buildLockPins['check-unity-runner-availability'].Comment
 $currentPrHeadGuardCommit = $buildLockPins['require-current-pr-head'].Sha
+$centralEditorActionCommit = $buildLockPins['ensure-unity-editor'].Sha
+$centralReturnActionCommit = $buildLockPins['return-unity-license'].Sha
 $centralCleanupGateCommit = $buildLockPins['require-confirmed-unity-cleanup'].Sha
 $centralCleanupClassifierCommit = $buildLockPins['classify-unity-cleanup-evidence'].Sha
 Write-Info "Derived build-lock pins: $((($buildLockPins.Keys | Sort-Object) | ForEach-Object { "$_@$($buildLockPins[$_].Sha.Substring(0, 8))" }) -join ' ')"
@@ -481,15 +512,17 @@ function Test-UnityLockCleanupIsGated {
 
     $acquireUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@$acquireBuildLockActionCommit"
     $releaseUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@$buildLockActionCommit"
-    $returnUses = './.github/actions/return-unity-license'
-    $requiredCleanupGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
-    $requiredReleaseGate = 'if: ${{ always() && (steps.unity_lock.outcome == ''success'' || steps.unity_lock.outcome == ''failure'' || steps.unity_lock.outcome == ''cancelled'') }}'
+    $legacyReturnUses = './.github/actions/return-unity-license'
+    $centralReturnUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@$centralReturnActionCommit"
+    $centralClassifierUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@$centralCleanupClassifierCommit"
+    $legacyCleanupGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
+    $centralCleanupGate = 'if: ${{ always() && steps.unity_lock.outputs.acquired == ''true'' }}'
+    $legacyReleaseGate = 'if: ${{ always() && (steps.unity_lock.outcome == ''success'' || steps.unity_lock.outcome == ''failure'' || steps.unity_lock.outcome == ''cancelled'') }}'
+    $centralReleaseGate = 'if: always()'
     $acquireUsesLineSuffix = '[ \t]+# ' + [regex]::Escape($acquireBuildLockActionComment) + '[ \t]*\r?$'
     $buildLockUsesLineSuffix = '[ \t]+# ' + [regex]::Escape($buildLockActionVersion) + '[ \t]*\r?$'
 
     $acquirePattern = '(?m)- name: Acquire organization Unity lock\s*\r?\n\s+id:\s+unity_lock\s*\r?\n(?:[^\r\n]*\r?\n)*?\s+uses:\s+' + [regex]::Escape($acquireUses) + $acquireUsesLineSuffix
-    $returnPattern = '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_unity_license\s*\r?\n\s+' + [regex]::Escape($requiredCleanupGate) + '\s*\r?\n\s+timeout-minutes:\s+5\s*\r?\n\s+continue-on-error:\s+true\s*\r?\n\s+uses:\s+' + [regex]::Escape($returnUses)
-    $releasePattern = '(?m)- name: Release organization Unity lock\s*\r?\n\s+id:\s+release_unity_lock\s*\r?\n\s+' + [regex]::Escape($requiredReleaseGate) + '\s*\r?\n\s+timeout-minutes:\s+5\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses) + $buildLockUsesLineSuffix
     $failures = @()
 
     foreach ($job in $Jobs.GetEnumerator()) {
@@ -497,7 +530,8 @@ function Test-UnityLockCleanupIsGated {
         $usesUnityLock = (
             $jobText.Contains($acquireUses) -or
             $jobText.Contains($releaseUses) -or
-            $jobText.Contains($returnUses)
+            $jobText.Contains($legacyReturnUses) -or
+            $jobText.Contains($centralReturnUses)
         )
         if (-not $usesUnityLock) {
             continue
@@ -514,6 +548,15 @@ function Test-UnityLockCleanupIsGated {
         $acquireStep = [regex]::Match($jobText, '(?ms)^\s+- name: Acquire organization Unity lock\s*$.*?(?=^\s+- name:|\z)')
         $releaseStep = [regex]::Match($jobText, '(?ms)^\s+- name: Release organization Unity lock\s*$.*?(?=^\s+- name:|\z)')
         $returnStep = [regex]::Match($jobText, '(?ms)^\s+- name: Return Unity license\s*$.*?(?=^\s+- name:|\z)')
+        $usesCentralCleanup = $returnStep.Value.Contains($centralReturnUses)
+        $requiredCleanupGate = if ($usesCentralCleanup) { $centralCleanupGate } else { $legacyCleanupGate }
+        $requiredReleaseGate = if ($usesCentralCleanup) { $centralReleaseGate } else { $legacyReleaseGate }
+        $returnPattern = if ($usesCentralCleanup) {
+            '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_unity_license\s*\r?\n\s+' + [regex]::Escape($requiredCleanupGate) + '\s*\r?\n\s+timeout-minutes:\s+5\s*\r?\n\s+uses:\s+' + [regex]::Escape($centralReturnUses) + $buildLockUsesLineSuffix
+        } else {
+            '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_unity_license\s*\r?\n\s+' + [regex]::Escape($requiredCleanupGate) + '\s*\r?\n\s+timeout-minutes:\s+5\s*\r?\n\s+continue-on-error:\s+true\s*\r?\n\s+uses:\s+' + [regex]::Escape($legacyReturnUses)
+        }
+        $releasePattern = '(?m)- name: Release organization Unity lock\s*\r?\n\s+id:\s+release_unity_lock\s*\r?\n\s+' + [regex]::Escape($requiredReleaseGate) + '\s*\r?\n\s+timeout-minutes:\s+5\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses) + $buildLockUsesLineSuffix
         $acquireHolder = [regex]::Match($acquireStep.Value, '(?m)^\s+holder-id-suffix:\s*(?<value>[^\r\n]+)')
         $releaseHolder = [regex]::Match($releaseStep.Value, '(?m)^\s+holder-id-suffix:\s*(?<value>[^\r\n]+)')
         $acquireRunner = [regex]::Match($acquireStep.Value, '(?m)^\s+runner-id:\s*(?<value>[^\r\n]+)')
@@ -525,11 +568,18 @@ function Test-UnityLockCleanupIsGated {
         if ($jobText -notmatch $returnPattern) {
             $failures += "$($job.Key): return-unity-license must be identified, success-gated, bounded to five minutes, and non-masking"
         }
-        if ($returnStep.Success -and (
+        if (-not $usesCentralCleanup -and $returnStep.Success -and (
                 $returnStep.Value -notmatch '(?m)^\s+prior-return-log-path:\s+\S.*$' -or
                 $returnStep.Value -notmatch '(?ms)^\s+prior-command-succeeded:\s+(?:>-\s*\r?\n\s*)?\$\{\{\s+.+?\s+\}\}\s*(?=^\s+env:)'
             )) {
             $failures += "$($job.Key): return-unity-license must classify the licensed command's log and successful outcome"
+        }
+        if ($usesCentralCleanup -and (
+                $returnStep.Value -notmatch '(?m)^\s+unity-version:\s+\$\{\{ matrix\.unity-version \}\}\s*$' -or
+                $returnStep.Value -notmatch '(?m)^\s+tool-cache:\s+\$\{\{ runner\.tool_cache \}\}\s*$' -or
+                $jobText -notmatch ('(?ms)- name: Classify Unity cleanup evidence\s*\r?\n\s+id:\s+cleanup_classification\s*\r?\n\s+' + [regex]::Escape($centralCleanupGate) + '.*?uses:\s+' + [regex]::Escape($centralClassifierUses) + $buildLockUsesLineSuffix + '.*?return-log-digest:\s+\$\{\{ steps\.return_unity_license\.outputs\.return-log-digest \}\}')
+            )) {
+            $failures += "$($job.Key): central Windows cleanup must bind the canonical editor version/tool cache and digest-bound classifier"
         }
         if ($jobText -notmatch $releasePattern) {
             $failures += "$($job.Key): release-build-lock must be five-minute bounded and run after every non-skipped acquire outcome"
@@ -569,10 +619,11 @@ function Test-UnityLockCleanupIsGated {
         if (-not $acquireRunner.Success -or -not $releaseRunner.Success -or $acquireRunner.Groups['value'].Value.Trim() -ne $releaseRunner.Groups['value'].Value.Trim()) {
             $failures += "$($job.Key): acquire and release must use the same runner-id"
         }
+        $cleanupOutputStep = if ($usesCentralCleanup) { 'cleanup_classification' } else { 'return_unity_license' }
         if (
-            $releaseStep.Value -notmatch '(?m)^\s+resource-cleanup-status:\s+\$\{\{ steps\.return_unity_license\.outputs\.resource-cleanup-status \}\}\s*$' -or
-            $releaseStep.Value -notmatch '(?m)^\s+resource-health:\s+\$\{\{ steps\.return_unity_license\.outputs\.resource-health \}\}\s*$' -or
-            $releaseStep.Value -notmatch '(?m)^\s+resource-reason:\s+\$\{\{ steps\.return_unity_license\.outputs\.resource-reason \}\}\s*$'
+            $releaseStep.Value -notmatch "(?m)^\s+resource-cleanup-status:\s+\`$\{\{ steps\.$cleanupOutputStep\.outputs\.resource-cleanup-status \}\}\s*`$" -or
+            $releaseStep.Value -notmatch "(?m)^\s+resource-health:\s+\`$\{\{ steps\.$cleanupOutputStep\.outputs\.resource-health \}\}\s*`$" -or
+            $releaseStep.Value -notmatch "(?m)^\s+resource-reason:\s+\`$\{\{ steps\.$cleanupOutputStep\.outputs\.resource-reason \}\}\s*`$"
         ) {
             $failures += "$($job.Key): release must pass the identified cleanup status, health, and reason outputs"
         }
@@ -696,7 +747,7 @@ $benchmarkRunsThoroughRandomInSharedInvocation = (
     $benchmarkInvocationCount -eq 1 -and
     -not $benchmarkJob.Contains('Run Random suite at full sample count') -and
     -not $benchmarkJob.Contains('benchmarks-random') -and
-    $benchmarkJob.Contains('UH_BENCHMARK_ASSEMBLIES: ${{ matrix.assemblies }}') -and
+    $benchmarkJob.Contains('UH_BENCHMARK_ASSEMBLIES: WallstopStudios.UnityHelpers.Tests.Runtime.Performance;WallstopStudios.UnityHelpers.Tests.Runtime.Random') -and
     $benchmarkJob.Contains('UH_UNITY_TEST_CATEGORY: "Performance;Stress;Fast"') -and
     $benchmarkJob.Contains('UH_RANDOM_SAMPLE_COUNT: "12750000"') -and
     $benchmarkJob.Contains('UH_RANDOM_NOISE_MAP_ITERATIONS: "1000"') -and
@@ -727,14 +778,22 @@ $benchmarkAssemblyDiscoveryIsCentralized = (
     $benchmarksWorkflowContent.Contains('matrix-include: ${{ steps.resolve.outputs.matrix-include }}') -and
     $benchmarksWorkflowContent.Contains('expected-result-files: ${{ steps.resolve.outputs.expected-result-files }}') -and
     $benchmarksWorkflowContent.Contains('allow-baseline-refresh: ${{ steps.resolve.outputs.allow-baseline-refresh }}') -and
-    $benchmarkJob.Contains('include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include) }}') -and
+    $benchmarkJob.Contains('unity-version:') -and
+    $benchmarkJob.Contains('- 2021.3.45f1') -and
+    $benchmarkJob.Contains('- 2022.3.45f1') -and
+    $benchmarkJob.Contains('- 6000.3.16f1') -and
+    $benchmarkJob.Contains('- 6000.5.2f1') -and
+    $benchmarkJob.Contains('- playmode') -and
+    $benchmarksWorkflowContent.Contains('matrix-exclude: ${{ steps.resolve.outputs.matrix-exclude }}') -and
+    $benchmarkJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}') -and
+    -not $benchmarkJob.Contains('include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include) }}') -and
     $benchmarkJob.Contains('expected-empty: false') -and
     -not $benchmarkJob.Contains('actions/setup-node@') -and
     -not $benchmarkJob.Contains('./.github/actions/compute-unity-assemblies') -and
     -not $benchmarkJob.Contains('steps.compute')
 )
 if (-not $benchmarkAssemblyDiscoveryIsCentralized) {
-    Write-Host '::error file=.github/workflows/unity-benchmarks.yml::Resolve the exact non-empty Performance and Random benchmark assembly profiles once in hosted matrix-config, pass assemblies/result identity through every matrix entry, and do not install Node or rediscover asmdefs on self-hosted legs.'
+    Write-Host '::error file=.github/workflows/unity-benchmarks.yml::Resolve and validate the exact non-empty Performance and Random benchmark profile in hosted matrix-config, use the reviewed static Unity-version/playmode matrix required by the central editor authority, and do not install Node or rediscover asmdefs on self-hosted legs.'
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info 'Checked benchmark assembly discovery is authoritative and centralized.'
@@ -1622,117 +1681,60 @@ if (-not $computeUnityAssembliesActionUsesBootstrapSafeShell) {
     Write-Info "Checked compute-unity-assemblies can run before runner maintenance bootstraps PowerShell 7."
 }
 
-function Test-UnityJobMaintainsSelectedRunner {
-    param([Parameter(Mandatory = $true)][string]$JobText)
+function Test-UnityJobUsesCentralEditorGate {
+    param(
+        [Parameter(Mandatory = $true)][string]$JobText,
+        [Parameter(Mandatory = $true)][string]$ProvisioningProfile
+    )
 
-    $maintenanceIndex = $JobText.IndexOf('- name: Maintain Unity editor on selected runner')
-    $provisionIndex = $JobText.IndexOf('- name: Provision Unity Editor')
-    $firstPwshShellIndex = $JobText.IndexOf('shell: pwsh')
-    $runnerDiagnosticsIndex = $JobText.IndexOf('- name: Print runner diagnostics')
-    $setupNodeIndex = $JobText.IndexOf('- name: Setup Node.js')
-    $computeIndex = $JobText.IndexOf('- name: Compute')
-    $licenseValidationIndex = $JobText.IndexOf('- name: Validate Unity license secrets')
-    $maintenanceUsesWindowsPowerShell = $JobText -match '(?s)- name: Maintain Unity editor on selected runner.*?shell:\s*powershell'
-    $programFilesPwshIndex = $JobText.IndexOf('PowerShell\7\pwsh.exe')
-    $getCommandPwshIndex = $JobText.IndexOf('Get-Command pwsh')
-    $maintenancePublishesPowerShell7Path = (
-        $JobText -match '(?s)- name: Maintain Unity editor on selected runner.*?\$env:GITHUB_PATH' -and
-        $JobText.Contains('PowerShell\7\pwsh.exe') -and
-        $JobText.Contains('pwsh.exe was not found for later GitHub Actions steps')
-    )
-    $maintenancePrefersRealPowerShell7Install = (
-        $programFilesPwshIndex -ge 0 -and
-        $getCommandPwshIndex -ge 0 -and
-        $programFilesPwshIndex -lt $getCommandPwshIndex -and
-        $JobText.Contains('$pathPwsh -and $pathPwsh -notlike ''*\Microsoft\WindowsApps\pwsh.exe''') -and
-        $JobText.Contains('Select-Object -Unique') -and
-        -not $JobText.Contains('Join-Path $env:LocalAppData ''Microsoft\WindowsApps\pwsh.exe''')
-    )
-    $setupNodeAndAssemblyComputeRunBeforeMaintenance = (
-        $setupNodeIndex -ge 0 -and
-        $computeIndex -ge 0 -and
-        $setupNodeIndex -lt $computeIndex -and
-        $computeIndex -lt $maintenanceIndex
-    )
-    $assemblySelectionComesFromHostedMatrix = (
-        $setupNodeIndex -lt 0 -and
-        $computeIndex -lt 0 -and
-        $JobText.Contains('include: ${{ fromJSON(needs.matrix-config.outputs.matrix-include') -and
+    $editorUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@$centralEditorActionCommit"
+    $editorIndex = $JobText.IndexOf('- name: Require manually installed Unity editor', [StringComparison]::Ordinal)
+    $checkoutIndex = $JobText.IndexOf('- name: Checkout', [StringComparison]::Ordinal)
+    $acquireIndex = $JobText.IndexOf('- name: Acquire organization Unity lock', [StringComparison]::Ordinal)
+    $licenseValidationIndex = $JobText.IndexOf('- name: Validate Unity license secrets', [StringComparison]::Ordinal)
+    $firstStep = [regex]::Match($JobText, '(?m)^      - name: (?<name>[^\r\n]+)')
+    $secondStep = if ($firstStep.Success) {
+        [regex]::Match($JobText.Substring($firstStep.Index + $firstStep.Length), '(?m)^      - name: (?<name>[^\r\n]+)')
+    } else {
+        [System.Text.RegularExpressions.Match]::Empty
+    }
+    $trustedPrefixIsClosed = (
+        $firstStep.Success -and
         (
-            $JobText.Contains('UH_TEST_ASSEMBLIES: ${{ matrix.assemblies }}') -or
-            $JobText.Contains('UH_BENCHMARK_ASSEMBLIES: ${{ matrix.assemblies }}')
-        ) -and
-        (
-            $JobText.Contains('matrix.is-empty') -or
+            $firstStep.Groups['name'].Value -eq 'Require manually installed Unity editor' -or
             (
-                $JobText.Contains('UH_BENCHMARK_ASSEMBLIES: ${{ matrix.assemblies }}') -and
-                $JobText.Contains('expected-empty: false')
+                $firstStep.Groups['name'].Value -eq 'Require current PR head before setup' -and
+                $secondStep.Success -and
+                $secondStep.Groups['name'].Value -eq 'Require manually installed Unity editor'
             )
         )
     )
-    $assemblySelectionReadyBeforeMaintenance = (
-        $setupNodeAndAssemblyComputeRunBeforeMaintenance -or
-        $assemblySelectionComesFromHostedMatrix
-    )
-    $benchmarkProfilesAreFailClosed = (
-        $JobText.Contains('UH_BENCHMARK_ASSEMBLIES: ${{ matrix.assemblies }}') -and
-        $JobText.Contains('expected-empty: false')
-    )
-    $unityExpensiveStepsSkipEmptyAssemblyLegs = $benchmarkProfilesAreFailClosed -or (
-        (Test-UnityWorkflowStepHasEmptyAssemblyGate -JobText $JobText -StepName 'Maintain Unity editor on selected runner') -and
-        (Test-UnityWorkflowStepHasEmptyAssemblyGate -JobText $JobText -StepName 'Print runner diagnostics') -and
-        (Test-UnityWorkflowStepHasEmptyAssemblyGate -JobText $JobText -StepName 'Validate Unity license secrets') -and
-        (Test-UnityWorkflowStepHasEmptyAssemblyGate -JobText $JobText -StepName 'Provision Unity Editor') -and
-        (Test-UnityWorkflowStepHasEmptyAssemblyGate -JobText $JobText -StepName 'Acquire organization Unity lock') -and
-        (Test-UnityWorkflowStepHasEmptyAssemblyGate -JobText $JobText -StepName 'Run Unity Test Runner')
-    )
-    $jobTimeoutCoversMaintenanceBudget = $JobText -match '(?m)^\s+timeout-minutes:\s*1200\s*$'
-    $maintenanceStepEndCandidates = @(
-        $runnerDiagnosticsIndex,
-        $licenseValidationIndex,
-        $provisionIndex
-    ) | Where-Object { $_ -gt $maintenanceIndex } | Sort-Object
-    $maintenanceStepText = ''
-    if ($maintenanceIndex -ge 0 -and $maintenanceStepEndCandidates.Count -gt 0) {
-        $maintenanceStepEndIndex = $maintenanceStepEndCandidates[0]
-        $maintenanceStepText = $JobText.Substring(
-            $maintenanceIndex,
-            $maintenanceStepEndIndex - $maintenanceIndex
-        )
-    }
-    $maintenanceStepAllowsRepair = (
-        $maintenanceStepText.Contains('scripts\unity\maintain-windows-runner.ps1') -and
-        -not $maintenanceStepText.Contains('-RequireHealthyExisting') -and
-        -not $maintenanceStepText.Contains('-RequireHealthyExistingEditors')
-    )
-    $maintenanceInvokesFunctionAfterDotSource = (
-        $maintenanceStepText.Contains('$maintenanceScript = Join-Path $env:GITHUB_WORKSPACE ''scripts\unity\maintain-windows-runner.ps1''') -and
-        $maintenanceStepText.Contains('. $maintenanceScript') -and
-        $maintenanceStepText.Contains('$maintenanceExitCode = Invoke-WindowsRunnerMaintenance') -and
-        $maintenanceStepText.Contains('if ($maintenanceExitCode -ne 0)') -and
-        -not ($maintenanceStepText -match '(?m)^\s+\.\\scripts\\unity\\maintain-windows-runner\.ps1\s*`')
+    $editorStep = [regex]::Match(
+        $JobText,
+        '(?ms)^\s+- name: Require manually installed Unity editor\s*$.*?(?=^\s+- name:|\z)'
     )
 
     return (
-        $maintenanceIndex -ge 0 -and
-        $provisionIndex -ge 0 -and
-        $maintenanceIndex -lt $provisionIndex -and
-        $assemblySelectionReadyBeforeMaintenance -and
-        $unityExpensiveStepsSkipEmptyAssemblyLegs -and
-        ($firstPwshShellIndex -lt 0 -or $maintenanceIndex -lt $firstPwshShellIndex) -and
-        ($runnerDiagnosticsIndex -lt 0 -or $maintenanceIndex -lt $runnerDiagnosticsIndex) -and
-        ($licenseValidationIndex -lt 0 -or $maintenanceIndex -lt $licenseValidationIndex) -and
-        $maintenanceUsesWindowsPowerShell -and
-        $maintenancePublishesPowerShell7Path -and
-        $maintenancePrefersRealPowerShell7Install -and
-        $jobTimeoutCoversMaintenanceBudget -and
-        $maintenanceInvokesFunctionAfterDotSource -and
-        $JobText.Contains('-UnityVersions ''${{ matrix.unity-version }}''') -and
-        $JobText.Contains('-ProvisioningProfile $provisioningProfile') -and
-        $maintenanceStepAllowsRepair -and
-        $JobText.Contains('provisioning/runner-maintenance') -and
-        -not $JobText.Contains('- runner-maintenance') -and
-        -not $JobText.Contains('needs.runner-maintenance.result')
+        $editorIndex -ge 0 -and
+        $trustedPrefixIsClosed -and
+        ($checkoutIndex -lt 0 -or $editorIndex -lt $checkoutIndex) -and
+        ($licenseValidationIndex -lt 0 -or $editorIndex -lt $licenseValidationIndex) -and
+        ($acquireIndex -lt 0 -or $editorIndex -lt $acquireIndex) -and
+        $editorStep.Value -match '(?m)^\s+id:\s+ensure_unity_editor\s*$' -and
+        $editorStep.Value -match '(?m)^\s+timeout-minutes:\s+10\s*$' -and
+        $editorStep.Value.Contains("uses: $editorUses") -and
+        $editorStep.Value -match '(?m)^\s+unity-version:\s+\$\{\{ matrix\.unity-version \}\}\s*$' -and
+        $editorStep.Value -match '(?m)^\s+install-root:\s+\$\{\{ runner\.tool_cache \}\}\\u6-v3\s*$' -and
+        $editorStep.Value -match ('(?m)^\s+provisioning-profile:\s+' + [regex]::Escape($ProvisioningProfile) + '\s*$') -and
+        $editorStep.Value -match '(?m)^\s+diagnostics-path:\s+unity-editor-check\.json\s*$' -and
+        $editorStep.Value -match '(?m)^\s+ci-managed-only:\s+true\s*$' -and
+        $editorStep.Value -match '(?m)^\s+require-healthy-existing:\s+true\s*$' -and
+        $editorStep.Value -notmatch '(?m)^\s+if:' -and
+        $JobText.Contains('UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}') -and
+        -not $JobText.Contains('- name: Maintain Unity editor on selected runner') -and
+        -not $JobText.Contains('- name: Provision Unity Editor') -and
+        -not $JobText.Contains('UNITY_EDITOR_PATH=$editor') -and
+        $JobText -match '(?m)^\s+timeout-minutes:\s*1200\s*$'
     )
 }
 
@@ -1750,7 +1752,19 @@ $matrixConfigAssemblyDiscoveryIsCentralized = (
     $jobTexts['matrix-config'].Contains('standalone_integrations') -and
     $jobTexts['matrix-config'].Contains('editmode_core: { target: "editmode", editorOnly: true }') -and
     $jobTexts['matrix-config'].Contains('playmode_core') -and
-    $workflowContent.Contains('matrix-include-single-threaded: ${{ steps.resolve.outputs.matrix-include-single-threaded }}') -and
+    $workflowContent.Contains('editmode-integration-assemblies: ${{ steps.assemblies.outputs.editmode_integrations }}') -and
+    $workflowContent.Contains('playmode-integration-assemblies: ${{ steps.assemblies.outputs.playmode_integrations }}') -and
+    $workflowContent.Contains('standalone-integration-assemblies: ${{ steps.assemblies.outputs.standalone_integrations }}') -and
+    $workflowContent.Contains('editmode-core-assemblies: ${{ steps.assemblies.outputs.editmode_core }}') -and
+    $workflowContent.Contains('playmode-core-assemblies: ${{ steps.assemblies.outputs.playmode_core }}') -and
+    $workflowContent.Contains('matrix-exclude: ${{ steps.resolve.outputs.matrix-exclude }}') -and
+    $workflowContent.Contains('matrix-exclude-standalone: ${{ steps.resolve.outputs.matrix-exclude-standalone }}') -and
+    $unityTestsMatrixJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}') -and
+    $unityTestsStandaloneJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude-standalone) }}') -and
+    $unityTestsMatrixJob.Contains('- standalone') -and
+    $unityTestsMatrixJob.Contains("UH_TEST_ASSEMBLIES: `${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-integration-assemblies || matrix.test-mode == 'playmode' && needs.matrix-config.outputs.playmode-integration-assemblies || needs.matrix-config.outputs.standalone-integration-assemblies }}") -and
+    $unityTestsStandaloneJob.Contains('UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.standalone-integration-assemblies }}') -and
+    $unityTestsSingleThreadedJob.Contains("UH_TEST_ASSEMBLIES: `${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-core-assemblies || needs.matrix-config.outputs.playmode-core-assemblies }}") -and
     -not $unityTestsMatrixJob.Contains('actions/setup-node@') -and
     -not $unityTestsStandaloneJob.Contains('actions/setup-node@') -and
     -not $unityTestsSingleThreadedJob.Contains('actions/setup-node@') -and
@@ -1759,25 +1773,27 @@ $matrixConfigAssemblyDiscoveryIsCentralized = (
     -not $unityTestsSingleThreadedJob.Contains('./.github/actions/compute-unity-assemblies')
 )
 if (-not $matrixConfigAssemblyDiscoveryIsCentralized) {
-    Write-Host "::error file=.github/workflows/unity-tests.yml::Compute the integration and core assembly profiles once in the hosted matrix-config job, pass assemblies/is-empty through every Unity matrix include, and do not install Node or run asmdef discovery again on self-hosted Unity test legs."
+    Write-Host "::error file=.github/workflows/unity-tests.yml::Compute integration and core assembly profiles once in hosted matrix-config, bind those outputs into the reviewed static Unity-version/test-mode matrices, and do not install Node or run asmdef discovery again on self-hosted Unity test legs."
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info "Checked Unity test assembly discovery is centralized on the hosted matrix job."
 }
 
-$unityWorkflowsMaintainSelectedRunnerBeforeProvisioning = (
+$trustedEditorMatrixProfile = '${{ fromJSON(''{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}'')[matrix.test-mode] }}'
+$unityWorkflowsUseCentralEditorAuthority = (
     -not $jobTexts.ContainsKey('runner-maintenance') -and
     -not $benchmarksJobTexts.ContainsKey('runner-maintenance') -and
-    (Test-UnityJobMaintainsSelectedRunner -JobText $unityTestsMatrixJob) -and
-    (Test-UnityJobMaintainsSelectedRunner -JobText $unityTestsStandaloneJob) -and
-    (Test-UnityJobMaintainsSelectedRunner -JobText $unityTestsSingleThreadedJob) -and
-    (Test-UnityJobMaintainsSelectedRunner -JobText $benchmarksMatrixJob)
+    $runnerBootstrapContent -match '(?m)^\s+UNITY_EDITOR_INSTALL_ROOT:\s+\$\{\{ runner\.tool_cache \}\}\\u6-v3\s*$' -and
+    (Test-UnityJobUsesCentralEditorGate -JobText $unityTestsMatrixJob -ProvisioningProfile $trustedEditorMatrixProfile) -and
+    (Test-UnityJobUsesCentralEditorGate -JobText $unityTestsStandaloneJob -ProvisioningProfile $trustedEditorMatrixProfile) -and
+    (Test-UnityJobUsesCentralEditorGate -JobText $unityTestsSingleThreadedJob -ProvisioningProfile 'EditorOnly') -and
+    (Test-UnityJobUsesCentralEditorGate -JobText $benchmarksMatrixJob -ProvisioningProfile 'EditorOnly')
 )
-if (-not $unityWorkflowsMaintainSelectedRunnerBeforeProvisioning) {
-    Write-Host "::error file=.github/workflows/unity-tests.yml::Unity workflows must resolve the test assembly list before runner maintenance (from the hosted matrix or the benchmark's local compute step); skip maintenance, diagnostics, license validation, provisioning, lock acquisition, and Unity test execution when the selected leg is empty; and still run scripts/unity/maintain-windows-runner.ps1 inside each non-empty self-hosted Unity job before Provision Unity Editor. Maintenance must use Windows PowerShell, publish the discovered PowerShell 7 directory through GITHUB_PATH, and remain the repair path. Job timeouts must also cover the in-job maintenance/provisioning/lock/test budget. Keep .github/workflows/unity-benchmarks.yml in sync."
+if (-not $unityWorkflowsUseCentralEditorAuthority) {
+    Write-Host "::error file=.github/workflows/unity-tests.yml::Every Windows licensed job must run the exact central ensure-unity-editor action first, or immediately after the immutable current-head guard, with a ten-minute fail-closed health check under the runner tool cache. CI must not maintain or provision editors, the Unity command must consume the action's bound editor-path output, and the operator bootstrap must provision the same runner.tool_cache\\u6-v3 root. Keep .github/workflows/unity-benchmarks.yml in sync."
     $failed = $true
 } elseif ($VerboseOutput) {
-    Write-Info "Checked Unity workflows skip empty legs before runner maintenance and maintain editors before provisioning."
+    Write-Info "Checked Windows Unity workflows use the central editor authority before repository-controlled code."
 }
 
 $timeoutEventsPreserveReason = (
@@ -3423,19 +3439,30 @@ if (-not $unityLockCleanupIsGated) {
     Write-Info "Checked Unity lock cleanup runs only after acquisition and before release."
 }
 
-$runnerTempReturnLogInput = [regex]::Escape('prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log')
-$testRunnerTempReturnLogs = [regex]::Matches($workflowContent, $runnerTempReturnLogInput).Count
-$benchmarkRunnerTempReturnLogs = [regex]::Matches(($benchmarksWorkflowLines -join "`n"), $runnerTempReturnLogInput).Count
-if ($testRunnerTempReturnLogs -ne 3 -or $benchmarkRunnerTempReturnLogs -ne 1) {
-    Write-Host "::error file=scripts/tests/test-unity-workflow-matrix-contract.ps1::run-ci-tests.ps1 cleanup proof must come from its non-uploaded runner-temp return log (tests=$testRunnerTempReturnLogs, benchmarks=$benchmarkRunnerTempReturnLogs)."
+$centralReturnUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@$centralReturnActionCommit"
+$testCentralReturnCalls = [regex]::Matches($workflowContent, [regex]::Escape("uses: $centralReturnUses")).Count
+$benchmarkCentralReturnCalls = [regex]::Matches(($benchmarksWorkflowLines -join "`n"), [regex]::Escape("uses: $centralReturnUses")).Count
+if ($testCentralReturnCalls -ne 3 -or $benchmarkCentralReturnCalls -ne 1) {
+    Write-Host "::error file=scripts/tests/test-unity-workflow-matrix-contract.ps1::All four Windows licensed callers must use the immutable central return executor (tests=$testCentralReturnCalls, benchmarks=$benchmarkCentralReturnCalls)."
     $failed = $true
 } elseif ($VerboseOutput) {
-    Write-Info 'Checked run-ci-tests workflows classify the runner-temp Unity return log.'
+    Write-Info 'Checked all Windows licensed callers use the central return executor.'
 }
 
-$centralClassifierUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@$centralCleanupClassifierCommit"
+$legacyClassifierReferences = @(
+    [regex]::Matches(
+        $returnUnityLicenseActionContent,
+        '(?m)^\s+uses:\s+Ambiguous-Interactive/ambiguous-organization-build-lock/\.github/actions/classify-unity-cleanup-evidence@(?<ref>[0-9a-f]{40})\s*$'
+    ) | ForEach-Object { $_.Groups['ref'].Value } | Sort-Object -CaseSensitive -Unique
+)
+$legacyClassifierUses = if ($legacyClassifierReferences.Count -eq 1) {
+    "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@$($legacyClassifierReferences[0])"
+} else {
+    ''
+}
 $returnActionResourceProofContract = (
-    [regex]::Matches($returnUnityLicenseActionContent, [regex]::Escape("uses: $centralClassifierUses")).Count -eq 2 -and
+    $legacyClassifierReferences.Count -eq 1 -and
+    [regex]::Matches($returnUnityLicenseActionContent, [regex]::Escape("uses: $legacyClassifierUses")).Count -eq 2 -and
     $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-safe:\s*$.*?^\s+value:\s+\$\{\{ steps\.classify_return\.outputs\.resource-safe \|\| steps\.classify_prior\.outputs\.resource-safe \}\}\s*$' -and
     $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-cleanup-status:\s*$.*?^\s+value:\s+\$\{\{ steps\.classify_return\.outputs\.resource-cleanup-status \|\| steps\.classify_prior\.outputs\.resource-cleanup-status \}\}\s*$' -and
     $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-health:\s*$.*?^\s+value:\s+\$\{\{ steps\.classify_return\.outputs\.resource-health \|\| steps\.classify_prior\.outputs\.resource-health \}\}\s*$' -and
@@ -3483,8 +3510,12 @@ if (
 }
 
 $centralGateUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@$centralCleanupGateCommit"
+$centralClassifierUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@$centralCleanupClassifierCommit"
+$legacyGateUses = $centralGateUses
 $centralLifecycleFailures = @()
 $licensedLifecycleCount = 0
+$centralLifecycleCount = 0
+$legacyLifecycleCount = 0
 foreach ($workflowJobSet in $licensedWorkflowJobSets) {
     foreach ($job in $workflowJobSet.Jobs.GetEnumerator()) {
         [string]$jobText = $job.Value
@@ -3493,37 +3524,68 @@ foreach ($workflowJobSet in $licensedWorkflowJobSets) {
         }
         $licensedLifecycleCount += 1
         $returnIndex = $jobText.IndexOf('- name: Return Unity license', [StringComparison]::Ordinal)
+        $classifierIndex = $jobText.IndexOf('- name: Classify Unity cleanup evidence', [StringComparison]::Ordinal)
         $releaseIndex = $jobText.IndexOf('- name: Release organization Unity lock', [StringComparison]::Ordinal)
         $gateIndex = $jobText.IndexOf('- name: Require confirmed Unity cleanup', [StringComparison]::Ordinal)
         $deleteIndex = $jobText.IndexOf('- name: Delete private Unity cleanup evidence', [StringComparison]::Ordinal)
-        $lifecycleIsOrdered = (
-            $returnIndex -ge 0 -and
-            $releaseIndex -gt $returnIndex -and
-            $gateIndex -gt $releaseIndex -and
-            $deleteIndex -gt $gateIndex
-        )
-        $releaseAndGateAreExact = (
-            $jobText -match '(?ms)- name: Release organization Unity lock\s*\r?\n\s+id: release_unity_lock\s*\r?\n.*?resource-cleanup-status: \$\{\{ steps\.return_unity_license\.outputs\.resource-cleanup-status \}\}.*?resource-health: \$\{\{ steps\.return_unity_license\.outputs\.resource-health \}\}.*?resource-reason: \$\{\{ steps\.return_unity_license\.outputs\.resource-reason \}\}' -and
-            $jobText.Contains("uses: $centralGateUses") -and
-            $jobText.Contains("classification-complete: `${{ steps.return_unity_license.outputs.classification-complete }}") -and
-            $jobText.Contains("release-outcome: `${{ steps.release_unity_lock.outcome }}") -and
-            $jobText.Contains("cleanup-result: `${{ steps.release_unity_lock.outputs.cleanup-result }}") -and
-            $jobText.Contains("reservation-state: `${{ steps.release_unity_lock.outputs.reservation-state }}") -and
-            $jobText.Contains("incident-id: `${{ steps.release_unity_lock.outputs.incident-id }}")
-        )
-        $privateEvidenceIsDeleted = (
-            $jobText -match '(?ms)- name: Delete private Unity cleanup evidence\s*\r?\n\s+if: \$\{\{ always\(\) && steps\.unity_lock\.outputs\.acquired == ''true'' \}\}.*?Remove-Item -LiteralPath \$evidencePath -Force'
-        )
-        if (-not $lifecycleIsOrdered -or -not $releaseAndGateAreExact -or -not $privateEvidenceIsDeleted) {
+        $usesCentralCleanup = $jobText.Contains("uses: $centralReturnUses")
+        if ($usesCentralCleanup) {
+            $centralLifecycleCount += 1
+            $lifecycleIsOrdered = (
+                $returnIndex -ge 0 -and
+                $classifierIndex -gt $returnIndex -and
+                $releaseIndex -gt $classifierIndex -and
+                $gateIndex -gt $releaseIndex -and
+                $deleteIndex -lt 0
+            )
+            $releaseAndGateAreExact = (
+                $jobText -match ('(?ms)- name: Classify Unity cleanup evidence\s*\r?\n\s+id: cleanup_classification\s*\r?\n\s+if: \$\{\{ always\(\) && steps\.unity_lock\.outputs\.acquired == ''true'' \}\}.*?uses: ' + [regex]::Escape($centralClassifierUses) + '.*?return-log-digest: \$\{\{ steps\.return_unity_license\.outputs\.return-log-digest \}\}') -and
+                $jobText -match '(?ms)- name: Release organization Unity lock\s*\r?\n\s+id: release_unity_lock\s*\r?\n\s+if: always\(\).*?resource-cleanup-status: \$\{\{ steps\.cleanup_classification\.outputs\.resource-cleanup-status \}\}.*?resource-health: \$\{\{ steps\.cleanup_classification\.outputs\.resource-health \}\}.*?resource-reason: \$\{\{ steps\.cleanup_classification\.outputs\.resource-reason \}\}' -and
+                $jobText.Contains("uses: $centralGateUses") -and
+                $jobText.Contains("classification-complete: `${{ steps.cleanup_classification.outputs.classification-complete }}") -and
+                $jobText.Contains("cleanup-status: `${{ steps.cleanup_classification.outputs.resource-cleanup-status }}") -and
+                $jobText.Contains("release-outcome: `${{ steps.release_unity_lock.outcome }}") -and
+                $jobText.Contains("cleanup-result: `${{ steps.release_unity_lock.outputs.cleanup-result }}") -and
+                $jobText.Contains("reservation-state: `${{ steps.release_unity_lock.outputs.reservation-state }}") -and
+                $jobText.Contains("incident-id: `${{ steps.release_unity_lock.outputs.incident-id }}")
+            )
+            $privateEvidenceContractIsExact = -not $jobText.Contains('- name: Delete private Unity cleanup evidence')
+        } else {
+            $legacyLifecycleCount += 1
+            $lifecycleIsOrdered = (
+                $returnIndex -ge 0 -and
+                $classifierIndex -lt 0 -and
+                $releaseIndex -gt $returnIndex -and
+                $gateIndex -gt $releaseIndex -and
+                $deleteIndex -gt $gateIndex
+            )
+            $releaseAndGateAreExact = (
+                $jobText -match '(?ms)- name: Release organization Unity lock\s*\r?\n\s+id: release_unity_lock\s*\r?\n.*?resource-cleanup-status: \$\{\{ steps\.return_unity_license\.outputs\.resource-cleanup-status \}\}.*?resource-health: \$\{\{ steps\.return_unity_license\.outputs\.resource-health \}\}.*?resource-reason: \$\{\{ steps\.return_unity_license\.outputs\.resource-reason \}\}' -and
+                -not [string]::IsNullOrWhiteSpace($legacyGateUses) -and
+                $jobText.Contains("uses: $legacyGateUses") -and
+                $jobText.Contains("classification-complete: `${{ steps.return_unity_license.outputs.classification-complete }}") -and
+                $jobText.Contains("release-outcome: `${{ steps.release_unity_lock.outcome }}") -and
+                $jobText.Contains("cleanup-result: `${{ steps.release_unity_lock.outputs.cleanup-result }}")
+            )
+            $privateEvidenceContractIsExact = (
+                $jobText -match '(?ms)- name: Delete private Unity cleanup evidence\s*\r?\n\s+if: \$\{\{ always\(\) && steps\.unity_lock\.outputs\.acquired == ''true'' \}\}.*?Remove-(?:Item|Directory) '
+            )
+        }
+        if (-not $lifecycleIsOrdered -or -not $releaseAndGateAreExact -or -not $privateEvidenceContractIsExact) {
             $centralLifecycleFailures += "$($workflowJobSet.File):$($job.Key)"
         }
     }
 }
-if ($licensedLifecycleCount -ne 6 -or $centralLifecycleFailures.Count -gt 0) {
-    Write-Host "::error file=scripts/tests/test-unity-workflow-matrix-contract.ps1::Every licensed job must preserve return -> central classify -> release -> central gate -> private evidence deletion. Count=$licensedLifecycleCount Failures=$($centralLifecycleFailures -join ', ')."
+if (
+    $licensedLifecycleCount -ne 6 -or
+    $centralLifecycleCount -ne 4 -or
+    $legacyLifecycleCount -ne 2 -or
+    $centralLifecycleFailures.Count -gt 0
+) {
+    Write-Host "::error file=scripts/tests/test-unity-workflow-matrix-contract.ps1::Four Windows jobs must preserve central return -> digest classifier -> release -> gate with classifier-owned evidence deletion, while two Ubuntu/Docker jobs retain the legacy fail-closed return -> release -> gate -> deletion contract. Total=$licensedLifecycleCount Central=$centralLifecycleCount Legacy=$legacyLifecycleCount Failures=$($centralLifecycleFailures -join ', ')."
     $failed = $true
 } elseif ($VerboseOutput) {
-    Write-Info 'Checked six licensed jobs use the central cleanup policy and fail-closed final gate.'
+    Write-Info 'Checked four central Windows lifecycles and two retained fail-closed container lifecycles.'
 }
 
 $sharedDiagnosticEvidenceFailures = @()

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -3592,10 +3592,22 @@ if (
     Write-Info 'Checked four central Windows lifecycles and two retained fail-closed container lifecycles.'
 }
 
+$preActivationReturnGuardIndex = $runCiTestsContent.IndexOf('if ($hasLicenseCreds) {', [StringComparison]::Ordinal)
+$preActivationReturnIndex = $runCiTestsContent.IndexOf('Invoke-UnityLicenseReturn -EditorPath', $preActivationReturnGuardIndex + 1, [StringComparison]::Ordinal)
+$activationGuardIndex = $runCiTestsContent.IndexOf('if ($hasLicenseCreds) {', $preActivationReturnGuardIndex + 1, [StringComparison]::Ordinal)
+$activationIndex = $runCiTestsContent.IndexOf('Invoke-UnityLicenseActivate -EditorPath', $activationGuardIndex + 1, [StringComparison]::Ordinal)
+$finalReturnGuardIndex = $runCiTestsContent.IndexOf('if ($hasLicenseCreds -and -not $centralReturnOwnsLicense) {', $activationIndex + 1, [StringComparison]::Ordinal)
+$finalReturnIndex = $runCiTestsContent.IndexOf('Invoke-UnityLicenseReturn -EditorPath', $finalReturnGuardIndex + 1, [StringComparison]::Ordinal)
 $centralReturnOwnershipContract = (
     $runCiTestsContent.Contains('$centralReturnOwnsLicense = [string]::Equals(') -and
-    [regex]::Matches($runCiTestsContent, 'if \(\$hasLicenseCreds -and -not \$centralReturnOwnsLicense\)').Count -eq 1 -and
-    [regex]::Matches($runCiTestsContent, 'if \(\$hasLicenseCreds\)').Count -eq 1
+    $preActivationReturnGuardIndex -ge 0 -and
+    $preActivationReturnIndex -gt $preActivationReturnGuardIndex -and
+    $activationGuardIndex -gt $preActivationReturnIndex -and
+    $activationIndex -gt $activationGuardIndex -and
+    $finalReturnGuardIndex -gt $activationIndex -and
+    $finalReturnIndex -gt $finalReturnGuardIndex -and
+    [regex]::Matches($runCiTestsContent, 'Invoke-UnityLicenseReturn -EditorPath').Count -eq 2 -and
+    [regex]::Matches($runCiTestsContent, 'Invoke-UnityLicenseActivate -EditorPath').Count -eq 1
 )
 if (-not $centralReturnOwnershipContract) {
     Write-Host "::error file=scripts/unity/run-ci-tests.ps1::The central lifecycle must preserve pre-activation reclaim but suppress repository-local finally-return so the immutable central executor owns the single post-activation return and does not quarantine a redundant 400006."

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -1742,6 +1742,7 @@ $unityTestsMatrixJob = if ($jobTexts.ContainsKey('unity-tests')) { $jobTexts['un
 $unityTestsStandaloneJob = if ($jobTexts.ContainsKey('unity-tests-standalone')) { $jobTexts['unity-tests-standalone'] } else { '' }
 $unityTestsSingleThreadedJob = if ($jobTexts.ContainsKey('unity-tests-single-threaded')) { $jobTexts['unity-tests-single-threaded'] } else { '' }
 $benchmarksMatrixJob = if ($benchmarksJobTexts.ContainsKey('benchmarks')) { $benchmarksJobTexts['benchmarks'] } else { '' }
+$unityTestsMatrixJobWithoutWhitespace = $unityTestsMatrixJob -replace '\s', ''
 $matrixConfigAssemblyDiscoveryIsCentralized = (
     $jobTexts.ContainsKey('matrix-config') -and
     $jobTexts['matrix-config'].Contains('- name: Setup Node.js for assembly discovery') -and
@@ -1762,7 +1763,7 @@ $matrixConfigAssemblyDiscoveryIsCentralized = (
     $unityTestsMatrixJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}') -and
     $unityTestsStandaloneJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude-standalone) }}') -and
     $unityTestsMatrixJob.Contains('- standalone') -and
-    $unityTestsMatrixJob.Contains("UH_TEST_ASSEMBLIES: `${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-integration-assemblies || matrix.test-mode == 'playmode' && needs.matrix-config.outputs.playmode-integration-assemblies || needs.matrix-config.outputs.standalone-integration-assemblies }}") -and
+    $unityTestsMatrixJobWithoutWhitespace.Contains("UH_TEST_ASSEMBLIES:>-`${{matrix.test-mode=='editmode'&&needs.matrix-config.outputs.editmode-integration-assemblies||matrix.test-mode=='playmode'&&needs.matrix-config.outputs.playmode-integration-assemblies||needs.matrix-config.outputs.standalone-integration-assemblies}}") -and
     $unityTestsStandaloneJob.Contains('UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.standalone-integration-assemblies }}') -and
     $unityTestsSingleThreadedJob.Contains("UH_TEST_ASSEMBLIES: `${{ matrix.test-mode == 'editmode' && needs.matrix-config.outputs.editmode-core-assemblies || needs.matrix-config.outputs.playmode-core-assemblies }}") -and
     -not $unityTestsMatrixJob.Contains('actions/setup-node@') -and

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -3551,6 +3551,7 @@ foreach ($workflowJobSet in $licensedWorkflowJobSets) {
                 $jobText.Contains("incident-id: `${{ steps.release_unity_lock.outputs.incident-id }}")
             )
             $privateEvidenceContractIsExact = -not $jobText.Contains('- name: Delete private Unity cleanup evidence')
+            $returnOwnershipIsExact = $jobText.Contains('UH_CENTRAL_LICENSE_RETURN: "true"')
         } else {
             $legacyLifecycleCount += 1
             $lifecycleIsOrdered = (
@@ -3571,8 +3572,9 @@ foreach ($workflowJobSet in $licensedWorkflowJobSets) {
             $privateEvidenceContractIsExact = (
                 $jobText -match '(?ms)- name: Delete private Unity cleanup evidence\s*\r?\n\s+if: \$\{\{ always\(\) && steps\.unity_lock\.outputs\.acquired == ''true'' \}\}.*?Remove-(?:Item|Directory) '
             )
+            $returnOwnershipIsExact = -not $jobText.Contains('UH_CENTRAL_LICENSE_RETURN:')
         }
-        if (-not $lifecycleIsOrdered -or -not $releaseAndGateAreExact -or -not $privateEvidenceContractIsExact) {
+        if (-not $lifecycleIsOrdered -or -not $releaseAndGateAreExact -or -not $privateEvidenceContractIsExact -or -not $returnOwnershipIsExact) {
             $centralLifecycleFailures += "$($workflowJobSet.File):$($job.Key)"
         }
     }
@@ -3587,6 +3589,17 @@ if (
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info 'Checked four central Windows lifecycles and two retained fail-closed container lifecycles.'
+}
+
+$centralReturnOwnershipContract = (
+    $runCiTestsContent.Contains('$centralReturnOwnsLicense = [string]::Equals(') -and
+    [regex]::Matches($runCiTestsContent, 'if \(\$hasLicenseCreds -and -not \$centralReturnOwnsLicense\)').Count -eq 2
+)
+if (-not $centralReturnOwnershipContract) {
+    Write-Host "::error file=scripts/unity/run-ci-tests.ps1::The central lifecycle must suppress both repository-local return-at-start and finally-return so the immutable central executor owns the single authoritative return and does not quarantine a redundant 400006."
+    $failed = $true
+} elseif ($VerboseOutput) {
+    Write-Info 'Checked central lifecycle callers leave the single authoritative return to the central executor.'
 }
 
 $sharedDiagnosticEvidenceFailures = @()

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -3759,13 +3759,19 @@ if ($env:GITHUB_ENV) {
 }
 
 # Classic SERIAL activation: the paid seat is activated from UNITY_SERIAL +
-# UNITY_EMAIL + UNITY_PASSWORD and explicitly returned on EVERY exit path so the
-# seat is never leaked. All three credentials are required together; we test each
-# with IsNullOrWhiteSpace so a blank-but-set secret counts as missing.
+# UNITY_EMAIL + UNITY_PASSWORD. Legacy callers return inside this process;
+# central-lifecycle callers leave return ownership to their immutable adjacent
+# workflow action. All three credentials are required together; we test each with
+# IsNullOrWhiteSpace so a blank-but-set secret counts as missing.
 $hasLicenseCreds = (
     -not [string]::IsNullOrWhiteSpace($env:UNITY_SERIAL) -and
     -not [string]::IsNullOrWhiteSpace($env:UNITY_EMAIL) -and
     -not [string]::IsNullOrWhiteSpace($env:UNITY_PASSWORD)
+)
+$centralReturnOwnsLicense = [string]::Equals(
+    $env:UH_CENTRAL_LICENSE_RETURN,
+    'true',
+    [System.StringComparison]::OrdinalIgnoreCase
 )
 # In CI all three credentials are MANDATORY: a missing one means the editor would
 # launch unlicensed and fail opaquely. The error names the missing VARS (never
@@ -3848,12 +3854,11 @@ $licenseLogDir = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Pa
 $activateLogPath = Join-Path $licenseLogDir "unity-activate-$UnityVersion-$TestMode.log"
 $returnLogPath = Join-Path $licenseLogDir "unity-return-$UnityVersion-$TestMode.log"
 
-# Return-at-start (defense-in-depth): reclaim a seat that a PRIOR force-killed run
-# on this persistent self-hosted runner may have leaked before its own finally /
-# the workflow if:always() step could run. Best-effort and never throws; if no
-# seat is held this is a harmless no-op. Done BEFORE the activate so we start each
-# run from a clean licensing state.
-if ($hasLicenseCreds) {
+# Legacy return-at-start defense: reclaim a seat that a PRIOR force-killed run on
+# this persistent self-hosted runner may have leaked before its own finally or
+# workflow backstop could run. Central lifecycle admission owns that recovery and
+# must not perform an unclassified repository-local return.
+if ($hasLicenseCreds -and -not $centralReturnOwnsLicense) {
     Invoke-UnityLicenseReturn -EditorPath $UnityEditorPath -Email $env:UNITY_EMAIL -Password $env:UNITY_PASSWORD -LogPath $returnLogPath
 }
 
@@ -4104,12 +4109,11 @@ try {
     # and the next attempt invalidates compilation outputs again.
     Write-UnityCompilationSourceInventoryMarker -Project $ProjectPath -RepoRoot $RepoRoot
 } finally {
-    # Deterministic RETURN of the seat on EVERY exit path (clean exit, throw, or a
-    # kill that still unwinds this finally). The workflow if:always() step is the
-    # additional backstop for a hard-killed process that never reaches this finally,
-    # and the NEXT run's return-at-start reclaims anything still leaked. Best-effort
-    # and never throws, so it cannot mask a real test failure.
-    if ($hasLicenseCreds) {
+    # Legacy callers return here as defense in depth. Central-lifecycle callers
+    # deliberately leave the one authoritative return to the adjacent immutable
+    # workflow action: a second local return consumes the seat first, making the
+    # central executor observe 400006 and quarantine a successfully tested leg.
+    if ($hasLicenseCreds -and -not $centralReturnOwnsLicense) {
         Invoke-UnityLicenseReturn -EditorPath $UnityEditorPath -Email $env:UNITY_EMAIL -Password $env:UNITY_PASSWORD -LogPath $returnLogPath
     }
 }

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -3854,11 +3854,12 @@ $licenseLogDir = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Pa
 $activateLogPath = Join-Path $licenseLogDir "unity-activate-$UnityVersion-$TestMode.log"
 $returnLogPath = Join-Path $licenseLogDir "unity-return-$UnityVersion-$TestMode.log"
 
-# Legacy return-at-start defense: reclaim a seat that a PRIOR force-killed run on
-# this persistent self-hosted runner may have leaked before its own finally or
-# workflow backstop could run. Central lifecycle admission owns that recovery and
-# must not perform an unclassified repository-local return.
-if ($hasLicenseCreds -and -not $centralReturnOwnsLicense) {
+# Return-at-start defense: reclaim a seat that a PRIOR force-killed run on this
+# persistent self-hosted runner may have leaked before its own finally or
+# workflow backstop could run. This is safe for central-lifecycle callers too:
+# the fresh activation below establishes the seat that the central executor will
+# later return, so this pre-activation cleanup cannot consume that evidence.
+if ($hasLicenseCreds) {
     Invoke-UnityLicenseReturn -EditorPath $UnityEditorPath -Email $env:UNITY_EMAIL -Password $env:UNITY_PASSWORD -LogPath $returnLogPath
 }
 


### PR DESCRIPTION
## RCA

Dependabot PR #590 updated the repository-local cleanup classifier to v1.13.0 without supplying the new required `return-log-digest` input. That made the composite fail closed (63/64 contracts passed) and exposed that the Windows callers still coupled editor provisioning and license return to repository-owned code.

The central repository now authorizes the exact v1.13.0 action/return SHAs in Ambiguous-Interactive/ambiguous-organization-build-lock#218. Its enrollment analyzer recognizes the safe static-exclusion and post-release-diagnostics shapes after Ambiguous-Interactive/ambiguous-organization-build-lock#219.

## Change

- use the central trusted editor authority before repository-controlled code in all four Windows licensed jobs
- use the central return executor, direct digest-bound classifier, typed release, and final cleanup gate
- preserve manual dispatch version/mode pins with reviewed static axes plus exclusion-only filters
- return/classify/release immediately after Unity work, before diagnostics and artifact uploads; keep the fail-closed gate final
- move runner bootstrap provisioning to the canonical `${{ runner.tool_cache }}\u6-v3` root
- preserve the historical return/classifier executor for the two Ubuntu/Docker callers until the trusted container executor in Ambiguous-Interactive/ambiguous-organization-build-lock#153 exists
- retain the safe v1.13.0 acquisition, release, runner-preflight, current-head, and cleanup-gate pin updates from #590
- strengthen both workflow contracts around the exact central/container split

This supersedes #590 rather than weakening the new digest contract.

## Live canary RCA

The first central-path canary passed all 4,777 selected Unity tests, but the final cleanup gate quarantined `unity-return-400006`. Its sanitized job log proved the repository-local `run-ci-tests.ps1` finally had already returned the seat successfully immediately before the central action ran. The fix preserves the pre-activation reclaim, then suppresses only the repository-local post-test finally-return for central-path callers, leaving one authoritative digest-bound post-activation return to the central executor; the two retained container callers keep their historical local finally-return behavior.

## Validation

- YAML Prettier check
- pinned actionlint v1.7.7
- build-lock action-input validation: 43 calls / 5 files / 9 pinned action versions
- action-input parser: 17 assertions
- portable cleanup parity: 11 classifier cases / 9 gate cases
- dispatch exclusion fixtures: standalone/version pins leave exactly one requested cell
- organization enrollment analyzer: all four Windows lifecycle chains recognized; remaining container findings stay tracked by central #153
- `git diff --check`

PowerShell is not installed in the authoring container, so the repository's full PowerShell contract executes in Local Gates CI.

Closes #411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes organization-wide Unity lock, license return, and editor provisioning on self-hosted runners; mis-wiring could strand seats or quarantine successful legs.
> 
> **Overview**
> Moves **Windows** Unity CI onto **ambiguous-organization-build-lock v1.13.0** for editor checks, license return, digest-bound cleanup classification, lock release, and the final cleanup gate—replacing per-job `maintain-windows-runner.ps1` / `ensure-editor.ps1` and the repo-local return action on those legs.
> 
> **Matrix and assemblies:** Self-hosted jobs use a **static** `unity-version` / `test-mode` matrix with **exclude-only** filters from hosted `matrix-config` (dispatch pins still work). Test/benchmark assembly lists are bound from centralized discovery outputs (`integration-assembly-profiles`, `core_profiles`) instead of per-matrix `include` objects; benchmarks hard-code the Performance+Random assembly pair.
> 
> **License ownership:** Windows callers set `UH_CENTRAL_LICENSE_RETURN` so `run-ci-tests.ps1` keeps **pre-activation reclaim** but skips the **finally** return, avoiding a double-return that tripped the central gate with `400006`. **Ubuntu/Docker** release and unitypackage-smoke paths keep the legacy return wrapper and local evidence deletion until a trusted container executor exists.
> 
> **Other:** `runner-bootstrap` points maintenance at `${{ runner.tool_cache }}\u6-v3`. Contract tests (`test-unity-workflow-matrix-contract.ps1`, `test-portable-cleanup-classifier.js`) encode the four central vs two legacy lifecycles and new pin rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bae0af252a9751cc1fdb3cddfe0b05520cd8084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->