### PR TITLE
Keep valid spatial entries queryable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,7 +307,7 @@ jobs:
         id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          fetch-depth: 0
+          fetch-depth: 1 # Export inputs come from this source tree, without history or tags.
           ref: ${{ needs.release-ready.outputs.source-sha }}
           persist-credentials: false
 

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -1334,7 +1334,7 @@ jobs:
         id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          fetch-depth: 0
+          fetch-depth: 1 # Export inputs come from this source tree, without history or tags.
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.llm/skills/defensive-editor-programming.md
+++ b/.llm/skills/defensive-editor-programming.md
@@ -68,6 +68,15 @@ See [editor-singleton-patterns](./editor-singleton-patterns.md) for:
 - Lazy singleton caching after asset creation (`ClearInstance()`)
 - Singleton instance path validation in find-or-create patterns
 
+### Progress Cleanup
+
+Every operation that displays `EditorUi` progress must clear it in a `finally` covering the first
+display, the processing loop, and batch disposal. Clear progress before fallible save, refresh, or
+disposal calls inside an existing `finally`; a clear placed after them can still be skipped. Preserve
+each tool's cancellation and partial-result behavior. Test thrown processing and cancellation through
+the internal `EditorUi` callbacks, restoring both callbacks in `finally`
+([#648](https://github.com/Ambiguous-Interactive/unity-helpers/issues/648)).
+
 ### Code Samples
 
 Detailed code patterns are in dedicated sample files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix stuck progress bars after failed prefab checks, sprite and texture batches, atlas operations, reference replacement, and animation copy or delete cleanup ([#648](https://github.com/Ambiguous-Interactive/unity-helpers/issues/648)).
+- Fix infinite stored geometry hiding finite spatial-tree entries. Constructors exclude non-finite positions and bounds edges while preserving source identities; infinite query radii remain supported ([#718](https://github.com/Ambiguous-Interactive/unity-helpers/issues/718)).
 - Fix NaN guards in random sampling, sprite extraction, parabola math, spatial queries and cache timing. Nonfinite coroutine intervals use the existing one-frame delay. See [Numeric Guards](./docs/features/utilities/math-and-extensions.md) ([#716](https://github.com/Ambiguous-Interactive/unity-helpers/issues/716)).
 - Fix package stylesheet and asset paths for local checkouts outside the Unity project. Cached packages resolve through their package identity, and similarly named sibling projects no longer count as project content ([#655](https://github.com/Ambiguous-Interactive/unity-helpers/issues/655)).
 - Fix child-component binding to select nearer matches first for single fields and capped collections ([#709](https://github.com/Ambiguous-Interactive/unity-helpers/issues/709)).

--- a/Editor/FitTextureSizeWindow.cs
+++ b/Editor/FitTextureSizeWindow.cs
@@ -685,6 +685,7 @@ namespace WallstopStudios.UnityHelpers.Editor
             }
             finally
             {
+                EditorUi.ClearProgress();
                 if (labelSetRes.resource != null)
                 {
                     labelSetRes.Dispose();
@@ -693,8 +694,6 @@ namespace WallstopStudios.UnityHelpers.Editor
                 {
                     batchScope.Dispose();
                 }
-                EditorUi.ClearProgress();
-
                 if (applyChanges)
                 {
                     _hasLastRunSummary = true;

--- a/Editor/PrefabChecker.cs
+++ b/Editor/PrefabChecker.cs
@@ -472,234 +472,243 @@ namespace WallstopStudios.UnityHelpers.Editor
             int skippedByLabel = 0;
             _lastReport = new ScanReport(validPaths);
 
-            for (int idx = 0; idx < guids.Length; idx++)
+            try
             {
-                if (
-                    EditorUi.CancelableProgress(
-                        "Prefab Checker",
-                        $"Scanning prefabs... {idx + 1}/{guids.Length}",
-                        (float)(idx + 1) / Mathf.Max(1, guids.Length)
+                for (int idx = 0; idx < guids.Length; idx++)
+                {
+                    if (
+                        EditorUi.CancelableProgress(
+                            "Prefab Checker",
+                            $"Scanning prefabs... {idx + 1}/{guids.Length}",
+                            (float)(idx + 1) / Mathf.Max(1, guids.Length)
+                        )
                     )
-                )
-                {
-                    this.LogWarn($"Prefab scan canceled by user.");
-                    break;
-                }
-
-                string path = AssetDatabase.GUIDToAssetPath(guids[idx]);
-                GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
-                if (prefab == null)
-                {
-                    continue;
-                }
-
-                string[] labels = AssetDatabase.GetLabels(prefab);
-                if (0 < includeSet.Count)
-                {
-                    bool anyIncluded = false;
-                    foreach (string label in labels)
                     {
-                        if (includeSet.Contains(label))
+                        this.LogWarn($"Prefab scan canceled by user.");
+                        break;
+                    }
+
+                    string path = AssetDatabase.GUIDToAssetPath(guids[idx]);
+                    GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+                    if (prefab == null)
+                    {
+                        continue;
+                    }
+
+                    string[] labels = AssetDatabase.GetLabels(prefab);
+                    if (0 < includeSet.Count)
+                    {
+                        bool anyIncluded = false;
+                        foreach (string label in labels)
                         {
-                            anyIncluded = true;
-                            break;
-                        }
-                    }
-                    if (!anyIncluded)
-                    {
-                        skippedByLabel++;
-                        continue;
-                    }
-                }
-                if (0 < excludeSet.Count)
-                {
-                    bool anyExcluded = false;
-                    foreach (string label in labels)
-                    {
-                        if (excludeSet.Contains(label))
-                        {
-                            anyExcluded = true;
-                            break;
-                        }
-                    }
-                    if (anyExcluded)
-                    {
-                        skippedByLabel++;
-                        continue;
-                    }
-                }
-
-                totalPrefabsChecked++;
-                int issuesForThisPrefab = 0;
-                using PooledResource<List<string>> resultLease = Buffers<string>.List.Get(
-                    out List<string> messages
-                );
-
-                if (_checkDisabledRootGameObjects && !prefab.activeSelf)
-                {
-                    messages.Add("Prefab root GameObject is disabled.");
-                    issuesForThisPrefab++;
-                }
-
-                using PooledResource<List<MonoBehaviour>> componentBufferResource =
-                    Buffers<MonoBehaviour>.List.Get(out List<MonoBehaviour> componentBuffer);
-                prefab.GetComponentsInChildren(true, componentBuffer);
-
-                using PooledResource<Dictionary<GameObject, HashSet<Type>>> typeMapLease =
-                    DictionaryBuffer<GameObject, HashSet<Type>>.Dictionary.Get(
-                        out Dictionary<GameObject, HashSet<Type>> typeMap
-                    );
-                using PooledResource<List<Component>> compsLease = Buffers<Component>.List.Get(
-                    out List<Component> comps
-                );
-                using PooledResource<List<PooledResource<HashSet<Type>>>> createdSetsLeases =
-                    Buffers<PooledResource<HashSet<Type>>>.List.Get(
-                        out List<PooledResource<HashSet<Type>>> createdSets
-                    );
-
-                foreach (MonoBehaviour script in componentBuffer)
-                {
-                    if (_checkMissingScripts && !script)
-                    {
-                        GameObject owner = FindOwnerOfMissingScriptBounded(prefab, componentBuffer);
-                        string ownerName = owner ? owner.name : "[[Unknown GameObject]]";
-                        messages.Add($"Detected missing script on GameObject '{ownerName}'.");
-                        issuesForThisPrefab++;
-                        continue;
-                    }
-                    if (!script)
-                    {
-                        continue;
-                    }
-
-                    GameObject ownerGameObject = script.gameObject;
-                    bool denied = false;
-                    if (!string.IsNullOrWhiteSpace(_componentTypeDenyListCsv))
-                    {
-                        string typeName = script.GetType().Name;
-                        string fullName = script.GetType().FullName;
-                        string[] tokens = _componentTypeDenyListCsv.Split(',');
-                        foreach (string token in tokens)
-                        {
-                            string t = token.Trim();
-                            if (t.Length == 0)
+                            if (includeSet.Contains(label))
                             {
-                                continue;
-                            }
-                            if (
-                                string.Equals(t, typeName, StringComparison.Ordinal)
-                                || string.Equals(t, fullName, StringComparison.Ordinal)
-                            )
-                            {
-                                denied = true;
+                                anyIncluded = true;
                                 break;
                             }
                         }
-                    }
-                    if (denied)
-                    {
-                        continue;
-                    }
-                    if (_checkNullElementsInLists)
-                    {
-                        issuesForThisPrefab += ValidateNoNullsInLists(script, ownerGameObject);
-                    }
-
-                    if (_checkMissingRequiredComponents)
-                    {
-                        HashSet<Type> present = GetOrBuildTypeSet(ownerGameObject);
-                        issuesForThisPrefab += ValidateRequiredComponentsFast(
-                            script,
-                            ownerGameObject,
-                            present
-                        );
-                    }
-                    if (_checkEmptyStringFields)
-                    {
-                        issuesForThisPrefab += ValidateEmptyStrings(script, ownerGameObject);
-                    }
-
-                    if (_checkNullObjectReferences)
-                    {
-                        issuesForThisPrefab += ValidateNullObjectReferences(
-                            script,
-                            ownerGameObject
-                        );
-                    }
-
-                    if (_checkDisabledComponents && script is Behaviour { enabled: false })
-                    {
-                        messages.Add(
-                            $"Component '{script.GetType().Name}' on GameObject '{ownerGameObject.name}' is disabled."
-                        );
-                        issuesForThisPrefab++;
-                    }
-                }
-
-                if (0 < issuesForThisPrefab)
-                {
-                    int toLog = Mathf.Min(100, messages.Count);
-                    for (int m = 0; m < toLog; m++)
-                    {
-                        prefab.LogWarn($"{messages[m]}");
-                    }
-
-                    if (toLog < messages.Count)
-                    {
-                        prefab.LogWarn($"... and {messages.Count - toLog} more.");
-                    }
-
-                    this.LogWarn(
-                        $"Prefab '{prefab.name}' at path '{path}' has {issuesForThisPrefab} potential issues."
-                    );
-                    _lastReport.Add(path, messages);
-                    totalIssuesFound += issuesForThisPrefab;
-                }
-
-                foreach (PooledResource<HashSet<Type>> setLease in createdSets)
-                {
-                    setLease.Dispose();
-                }
-                createdSets.Clear();
-                continue;
-
-                HashSet<Type> GetOrBuildTypeSet(GameObject go)
-                {
-                    if (typeMap.TryGetValue(go, out HashSet<Type> cached))
-                    {
-                        return cached;
-                    }
-                    PooledResource<HashSet<Type>> setLease = Buffers<Type>.HashSet.Get(
-                        out HashSet<Type> set
-                    );
-                    createdSets.Add(setLease);
-                    go.GetComponents(comps);
-                    foreach (Component comp in comps)
-                    {
-                        if (comp != null)
+                        if (!anyIncluded)
                         {
-                            set.Add(comp.GetType());
+                            skippedByLabel++;
+                            continue;
                         }
                     }
-                    comps.Clear();
-                    typeMap[go] = set;
-                    return set;
+                    if (0 < excludeSet.Count)
+                    {
+                        bool anyExcluded = false;
+                        foreach (string label in labels)
+                        {
+                            if (excludeSet.Contains(label))
+                            {
+                                anyExcluded = true;
+                                break;
+                            }
+                        }
+                        if (anyExcluded)
+                        {
+                            skippedByLabel++;
+                            continue;
+                        }
+                    }
+
+                    totalPrefabsChecked++;
+                    int issuesForThisPrefab = 0;
+                    using PooledResource<List<string>> resultLease = Buffers<string>.List.Get(
+                        out List<string> messages
+                    );
+
+                    if (_checkDisabledRootGameObjects && !prefab.activeSelf)
+                    {
+                        messages.Add("Prefab root GameObject is disabled.");
+                        issuesForThisPrefab++;
+                    }
+
+                    using PooledResource<List<MonoBehaviour>> componentBufferResource =
+                        Buffers<MonoBehaviour>.List.Get(out List<MonoBehaviour> componentBuffer);
+                    prefab.GetComponentsInChildren(true, componentBuffer);
+
+                    using PooledResource<Dictionary<GameObject, HashSet<Type>>> typeMapLease =
+                        DictionaryBuffer<GameObject, HashSet<Type>>.Dictionary.Get(
+                            out Dictionary<GameObject, HashSet<Type>> typeMap
+                        );
+                    using PooledResource<List<Component>> compsLease = Buffers<Component>.List.Get(
+                        out List<Component> comps
+                    );
+                    using PooledResource<List<PooledResource<HashSet<Type>>>> createdSetsLeases =
+                        Buffers<PooledResource<HashSet<Type>>>.List.Get(
+                            out List<PooledResource<HashSet<Type>>> createdSets
+                        );
+
+                    foreach (MonoBehaviour script in componentBuffer)
+                    {
+                        if (_checkMissingScripts && !script)
+                        {
+                            GameObject owner = FindOwnerOfMissingScriptBounded(
+                                prefab,
+                                componentBuffer
+                            );
+                            string ownerName = owner ? owner.name : "[[Unknown GameObject]]";
+                            messages.Add($"Detected missing script on GameObject '{ownerName}'.");
+                            issuesForThisPrefab++;
+                            continue;
+                        }
+                        if (!script)
+                        {
+                            continue;
+                        }
+
+                        GameObject ownerGameObject = script.gameObject;
+                        bool denied = false;
+                        if (!string.IsNullOrWhiteSpace(_componentTypeDenyListCsv))
+                        {
+                            string typeName = script.GetType().Name;
+                            string fullName = script.GetType().FullName;
+                            string[] tokens = _componentTypeDenyListCsv.Split(',');
+                            foreach (string token in tokens)
+                            {
+                                string t = token.Trim();
+                                if (t.Length == 0)
+                                {
+                                    continue;
+                                }
+                                if (
+                                    string.Equals(t, typeName, StringComparison.Ordinal)
+                                    || string.Equals(t, fullName, StringComparison.Ordinal)
+                                )
+                                {
+                                    denied = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (denied)
+                        {
+                            continue;
+                        }
+                        if (_checkNullElementsInLists)
+                        {
+                            issuesForThisPrefab += ValidateNoNullsInLists(script, ownerGameObject);
+                        }
+
+                        if (_checkMissingRequiredComponents)
+                        {
+                            HashSet<Type> present = GetOrBuildTypeSet(ownerGameObject);
+                            issuesForThisPrefab += ValidateRequiredComponentsFast(
+                                script,
+                                ownerGameObject,
+                                present
+                            );
+                        }
+                        if (_checkEmptyStringFields)
+                        {
+                            issuesForThisPrefab += ValidateEmptyStrings(script, ownerGameObject);
+                        }
+
+                        if (_checkNullObjectReferences)
+                        {
+                            issuesForThisPrefab += ValidateNullObjectReferences(
+                                script,
+                                ownerGameObject
+                            );
+                        }
+
+                        if (_checkDisabledComponents && script is Behaviour { enabled: false })
+                        {
+                            messages.Add(
+                                $"Component '{script.GetType().Name}' on GameObject '{ownerGameObject.name}' is disabled."
+                            );
+                            issuesForThisPrefab++;
+                        }
+                    }
+
+                    if (0 < issuesForThisPrefab)
+                    {
+                        int toLog = Mathf.Min(100, messages.Count);
+                        for (int m = 0; m < toLog; m++)
+                        {
+                            prefab.LogWarn($"{messages[m]}");
+                        }
+
+                        if (toLog < messages.Count)
+                        {
+                            prefab.LogWarn($"... and {messages.Count - toLog} more.");
+                        }
+
+                        this.LogWarn(
+                            $"Prefab '{prefab.name}' at path '{path}' has {issuesForThisPrefab} potential issues."
+                        );
+                        _lastReport.Add(path, messages);
+                        totalIssuesFound += issuesForThisPrefab;
+                    }
+
+                    foreach (PooledResource<HashSet<Type>> setLease in createdSets)
+                    {
+                        setLease.Dispose();
+                    }
+                    createdSets.Clear();
+                    continue;
+
+                    HashSet<Type> GetOrBuildTypeSet(GameObject go)
+                    {
+                        if (typeMap.TryGetValue(go, out HashSet<Type> cached))
+                        {
+                            return cached;
+                        }
+                        PooledResource<HashSet<Type>> setLease = Buffers<Type>.HashSet.Get(
+                            out HashSet<Type> set
+                        );
+                        createdSets.Add(setLease);
+                        go.GetComponents(comps);
+                        foreach (Component comp in comps)
+                        {
+                            if (comp != null)
+                            {
+                                set.Add(comp.GetType());
+                            }
+                        }
+                        comps.Clear();
+                        typeMap[go] = set;
+                        return set;
+                    }
+                }
+
+                if (0 < totalIssuesFound)
+                {
+                    this.LogError(
+                        $"Prefab check complete. Found {totalIssuesFound} potential issues across {totalPrefabsChecked} prefabs."
+                    );
+                }
+                else
+                {
+                    this.Log(
+                        $"Prefab check complete. No issues found in {totalPrefabsChecked} prefabs."
+                    );
                 }
             }
-
-            if (0 < totalIssuesFound)
+            finally
             {
-                this.LogError(
-                    $"Prefab check complete. Found {totalIssuesFound} potential issues across {totalPrefabsChecked} prefabs."
-                );
+                EditorUi.ClearProgress();
             }
-            else
-            {
-                this.Log(
-                    $"Prefab check complete. No issues found in {totalPrefabsChecked} prefabs."
-                );
-            }
-            EditorUi.ClearProgress();
             stopwatch.Stop();
             this.Log(
                 $"Scanned {totalPrefabsChecked} prefabs in {stopwatch.ElapsedMilliseconds} ms. Skipped {skippedByLabel} by label."

--- a/Editor/Sprites/AnimationCopierWindow.cs
+++ b/Editor/Sprites/AnimationCopierWindow.cs
@@ -925,13 +925,13 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             }
             finally
             {
+                ClearProgress();
+                _isCopying = false;
                 if (!_dryRun)
                 {
                     AssetDatabase.SaveAssets();
                     AssetDatabaseBatchHelper.RefreshIfNotBatching();
                 }
-                ClearProgress();
-                _isCopying = false;
                 this.Log(
                     $"Copy operation finished{(_dryRun ? " (dry run)" : string.Empty)}. Mode: {mode}. Success: {successCount}, Errors: {errorCount}."
                 );
@@ -1045,12 +1045,12 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             }
             finally
             {
+                ClearProgress();
+                _isDeleting = false;
                 if (!_dryRun)
                 {
                     AssetDatabaseBatchHelper.RefreshIfNotBatching();
                 }
-                ClearProgress();
-                _isDeleting = false;
                 this.Log(
                     $"Delete operation finished{(_dryRun ? " (dry run)" : string.Empty)}. Successfully processed: {successCount}, Errors: {errorCount}."
                 );
@@ -1936,12 +1936,12 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             }
             finally
             {
+                ClearProgress();
+                _isDeleting = false;
                 if (!_dryRun)
                 {
                     AssetDatabaseBatchHelper.RefreshIfNotBatching();
                 }
-                ClearProgress();
-                _isDeleting = false;
                 this.Log(
                     $"Mirror delete finished{(_dryRun ? " (dry run)" : string.Empty)}. Success: {success}, Errors: {errors}."
                 );

--- a/Editor/Sprites/ScriptableSpriteAtlasEditor.cs
+++ b/Editor/Sprites/ScriptableSpriteAtlasEditor.cs
@@ -1326,26 +1326,32 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             int totalConfigs = _atlasConfigs.Count;
             int currentConfig = 0;
 
-            using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
+            try
             {
-                foreach (ScriptableSpriteAtlas config in _atlasConfigs)
+                using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
                 {
-                    if (config == null)
+                    foreach (ScriptableSpriteAtlas config in _atlasConfigs)
                     {
-                        continue;
-                    }
+                        if (config == null)
+                        {
+                            continue;
+                        }
 
-                    currentConfig++;
-                    float progress = (float)currentConfig / totalConfigs;
-                    Utils.EditorUi.ShowProgress(
-                        "Generating Sprite Atlases",
-                        $"Processing: {config.name}",
-                        progress
-                    );
-                    GenerateSingleAtlas(config, false);
+                        currentConfig++;
+                        float progress = (float)currentConfig / totalConfigs;
+                        Utils.EditorUi.ShowProgress(
+                            "Generating Sprite Atlases",
+                            $"Processing: {config.name}",
+                            progress
+                        );
+                        GenerateSingleAtlas(config, false);
+                    }
                 }
             }
-            Utils.EditorUi.ClearProgress();
+            finally
+            {
+                Utils.EditorUi.ClearProgress();
+            }
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
         }
@@ -1546,7 +1552,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             EditorUtility.RevealInFinder(outputPath);
         }
 
-        private void ForceUncompressedSourceSprites(ScriptableSpriteAtlas config)
+        internal void ForceUncompressedSourceSprites(ScriptableSpriteAtlas config)
         {
             if (config == null)
             {
@@ -1575,113 +1581,124 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             using PooledResource<List<TextureImporter>> importersLease =
                 Buffers<TextureImporter>.List.Get(out List<TextureImporter> importers);
             {
-                using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
+                try
                 {
-                    for (int i = 0; i < spritesToProcess.Count; ++i)
+                    using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
                     {
-                        Sprite sprite = spritesToProcess[i];
-                        Utils.EditorUi.ShowProgress(
-                            "Modifying Source Sprite Import Settings",
-                            $"Processing: {sprite.name} ({i + 1}/{spritesToProcess.Count})",
-                            (float)(i + 1) / spritesToProcess.Count
-                        );
-
-                        string assetPath = AssetDatabase.GetAssetPath(sprite.texture);
-                        if (string.IsNullOrWhiteSpace(assetPath))
+                        for (int i = 0; i < spritesToProcess.Count; ++i)
                         {
-                            this.LogWarn(
-                                $"Could not find asset path for sprite's texture: {sprite.name}. Skipping."
+                            Sprite sprite = spritesToProcess[i];
+                            Utils.EditorUi.ShowProgress(
+                                "Modifying Source Sprite Import Settings",
+                                $"Processing: {sprite.name} ({i + 1}/{spritesToProcess.Count})",
+                                (float)(i + 1) / spritesToProcess.Count
                             );
-                            errorCount++;
-                            continue;
-                        }
 
-                        if (!processedAssetPaths.Add(assetPath))
-                        {
-                            continue;
-                        }
-
-                        TextureImporter importer =
-                            AssetImporter.GetAtPath(assetPath) as TextureImporter;
-                        if (importer == null)
-                        {
-                            this.LogWarn(
-                                $"Could not get TextureImporter for asset: {assetPath} (from sprite: {sprite.name}). Skipping."
-                            );
-                            errorCount++;
-                            continue;
-                        }
-
-                        bool undoRecorded = false;
-                        bool settingsActuallyModified = false;
-
-                        void EnsureUndoRecorded()
-                        {
-                            if (undoRecorded)
+                            string assetPath = AssetDatabase.GetAssetPath(sprite.texture);
+                            if (string.IsNullOrWhiteSpace(assetPath))
                             {
-                                return;
+                                this.LogWarn(
+                                    $"Could not find asset path for sprite's texture: {sprite.name}. Skipping."
+                                );
+                                errorCount++;
+                                continue;
                             }
-                            Undo.RecordObject(importer, "Set Sprite Texture To Uncompressed");
-                            undoRecorded = true;
-                        }
 
-                        if (importer.crunchedCompression)
-                        {
-                            EnsureUndoRecorded();
-                            importer.crunchedCompression = false;
-                            settingsActuallyModified = true;
-                        }
+                            if (!processedAssetPaths.Add(assetPath))
+                            {
+                                continue;
+                            }
 
-                        if (importer.textureCompression != TextureImporterCompression.Uncompressed)
-                        {
-                            EnsureUndoRecorded();
-                            importer.textureCompression = TextureImporterCompression.Uncompressed;
-                            settingsActuallyModified = true;
-                        }
+                            TextureImporter importer =
+                                AssetImporter.GetAtPath(assetPath) as TextureImporter;
+                            if (importer == null)
+                            {
+                                this.LogWarn(
+                                    $"Could not get TextureImporter for asset: {assetPath} (from sprite: {sprite.name}). Skipping."
+                                );
+                                errorCount++;
+                                continue;
+                            }
 
-                        TextureImporterPlatformSettings platformSettings =
-                            importer.GetDefaultPlatformTextureSettings();
-                        bool platformSettingsChangedThisTime = false;
-                        TextureImporterFormat targetFormat = importer.DoesSourceTextureHaveAlpha()
-                            ? TextureImporterFormat.RGBA32
-                            : TextureImporterFormat.RGB24;
+                            bool undoRecorded = false;
+                            bool settingsActuallyModified = false;
 
-                        if (platformSettings.format != targetFormat)
-                        {
-                            platformSettings.format = targetFormat;
-                            platformSettingsChangedThisTime = true;
-                        }
-                        if (platformSettings.crunchedCompression)
-                        {
-                            platformSettings.crunchedCompression = false;
-                            platformSettingsChangedThisTime = true;
-                        }
-                        if (platformSettings.compressionQuality != 100)
-                        {
-                            platformSettings.compressionQuality = 100;
-                            platformSettingsChangedThisTime = true;
-                        }
+                            void EnsureUndoRecorded()
+                            {
+                                if (undoRecorded)
+                                {
+                                    return;
+                                }
+                                Undo.RecordObject(importer, "Set Sprite Texture To Uncompressed");
+                                undoRecorded = true;
+                            }
 
-                        if (platformSettingsChangedThisTime || !platformSettings.overridden)
-                        {
-                            EnsureUndoRecorded();
-                            platformSettings.overridden = true;
-                            importer.SetPlatformTextureSettings(platformSettings);
-                            settingsActuallyModified = true;
-                        }
+                            if (importer.crunchedCompression)
+                            {
+                                EnsureUndoRecorded();
+                                importer.crunchedCompression = false;
+                                settingsActuallyModified = true;
+                            }
 
-                        if (settingsActuallyModified)
-                        {
-                            importer.SaveAndReimport();
-                            importers.Add(importer);
-                            modifiedCount++;
-                            this.Log(
-                                $"Set import settings for texture: {assetPath} (from sprite: {sprite.name}) to uncompressed ({targetFormat})."
-                            );
+                            if (
+                                importer.textureCompression
+                                != TextureImporterCompression.Uncompressed
+                            )
+                            {
+                                EnsureUndoRecorded();
+                                importer.textureCompression =
+                                    TextureImporterCompression.Uncompressed;
+                                settingsActuallyModified = true;
+                            }
+
+                            TextureImporterPlatformSettings platformSettings =
+                                importer.GetDefaultPlatformTextureSettings();
+                            bool platformSettingsChangedThisTime = false;
+                            TextureImporterFormat targetFormat =
+                                importer.DoesSourceTextureHaveAlpha()
+                                    ? TextureImporterFormat.RGBA32
+                                    : TextureImporterFormat.RGB24;
+
+                            if (platformSettings.format != targetFormat)
+                            {
+                                platformSettings.format = targetFormat;
+                                platformSettingsChangedThisTime = true;
+                            }
+                            if (platformSettings.crunchedCompression)
+                            {
+                                platformSettings.crunchedCompression = false;
+                                platformSettingsChangedThisTime = true;
+                            }
+                            if (platformSettings.compressionQuality != 100)
+                            {
+                                platformSettings.compressionQuality = 100;
+                                platformSettingsChangedThisTime = true;
+                            }
+
+                            if (platformSettingsChangedThisTime || !platformSettings.overridden)
+                            {
+                                EnsureUndoRecorded();
+                                platformSettings.overridden = true;
+                                importer.SetPlatformTextureSettings(platformSettings);
+                                settingsActuallyModified = true;
+                            }
+
+                            if (settingsActuallyModified)
+                            {
+                                importer.SaveAndReimport();
+                                importers.Add(importer);
+                                modifiedCount++;
+                                this.Log(
+                                    $"Set import settings for texture: {assetPath} (from sprite: {sprite.name}) to uncompressed ({targetFormat})."
+                                );
+                            }
                         }
                     }
                 }
-                Utils.EditorUi.ClearProgress();
+                finally
+                {
+                    Utils.EditorUi.ClearProgress();
+                }
 
                 foreach (TextureImporter importer in importers)
                 {

--- a/Editor/Sprites/SpriteCropper.cs
+++ b/Editor/Sprites/SpriteCropper.cs
@@ -502,8 +502,8 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                     }
                     finally
                     {
-                        AssetDatabase.SaveAssets();
                         Utils.EditorUi.ClearProgress();
+                        AssetDatabase.SaveAssets();
                     }
                 }
 

--- a/Editor/Sprites/SpriteSettingsApplierWindow.cs
+++ b/Editor/Sprites/SpriteSettingsApplierWindow.cs
@@ -340,46 +340,51 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 SpriteSettingsApplierAPI.PrepareProfiles(currentSettings);
 
             double lastUpdateTime = EditorApplication.timeSinceStartup;
-            for (int i = 0; i < targetFiles.Count; i++)
+            try
             {
-                (string _, string relativePath) = targetFiles[i];
-
-                double now = EditorApplication.timeSinceStartup;
-                if (
-                    i == 0
-                    || i == targetFiles.Count - 1
-                    || i % 50 == 0
-                    || 0.2 < now - lastUpdateTime
-                )
+                for (int i = 0; i < targetFiles.Count; i++)
                 {
-                    Utils.EditorUi.ShowProgress(
-                        "Calculating Stats",
-                        $"Checking '{Path.GetFileName(relativePath)}' ({i + 1}/{_totalSpritesToProcess})",
-                        (float)(i + 1) / _totalSpritesToProcess
-                    );
-                    lastUpdateTime = now;
-                }
+                    (string _, string relativePath) = targetFiles[i];
 
-                if (
-                    SpriteSettingsApplierAPI.WillTextureSettingsChange(
-                        relativePath,
-                        prepared,
-                        _settingsBuffer
+                    double now = EditorApplication.timeSinceStartup;
+                    if (
+                        i == 0
+                        || i == targetFiles.Count - 1
+                        || i % 50 == 0
+                        || 0.2 < now - lastUpdateTime
                     )
-                )
-                {
-                    _spritesThatWillChange++;
-                    _assetsThatWillChange.Add(relativePath);
+                    {
+                        Utils.EditorUi.ShowProgress(
+                            "Calculating Stats",
+                            $"Checking '{Path.GetFileName(relativePath)}' ({i + 1}/{_totalSpritesToProcess})",
+                            (float)(i + 1) / _totalSpritesToProcess
+                        );
+                        lastUpdateTime = now;
+                    }
+
+                    if (
+                        SpriteSettingsApplierAPI.WillTextureSettingsChange(
+                            relativePath,
+                            prepared,
+                            _settingsBuffer
+                        )
+                    )
+                    {
+                        _spritesThatWillChange++;
+                        _assetsThatWillChange.Add(relativePath);
+                    }
                 }
             }
-
-            Utils.EditorUi.ClearProgress();
+            finally
+            {
+                Utils.EditorUi.ClearProgress();
+            }
             this.Log(
                 $"Calculation complete. Sprites to process: {_totalSpritesToProcess}, Sprites that will change: {_spritesThatWillChange}"
             );
         }
 
-        private void ApplySettings()
+        internal void ApplySettings()
         {
             List<(string fullFilePath, string relativePath)> targetFiles = GetTargetSpritePaths();
             int spriteCount = 0;
@@ -405,57 +410,62 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 return;
             }
 
-            using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
+            try
             {
-                List<SpriteSettingsApplierAPI.PreparedProfile> prepared =
-                    SpriteSettingsApplierAPI.PrepareProfiles(currentSettings);
-                double lastUpdateTime = EditorApplication.timeSinceStartup;
-
-                for (int i = 0; i < targetFiles.Count; i++)
+                using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
                 {
-                    string filePath = targetFiles[i].relativePath;
-                    double now = EditorApplication.timeSinceStartup;
-                    bool shouldUpdate =
-                        i == 0
-                        || i == targetFiles.Count - 1
-                        || i % 50 == 0
-                        || 0.2 < now - lastUpdateTime;
-                    if (
-                        shouldUpdate
-                        && Utils.EditorUi.CancelableProgress(
-                            "Applying Sprite Settings",
-                            $"Processing '{Path.GetFileName(filePath)}' ({i + 1}/{targetFiles.Count})",
-                            (float)(i + 1) / targetFiles.Count
-                        )
-                    )
-                    {
-                        _applyCanceled = true;
-                        break;
-                    }
-                    if (shouldUpdate)
-                    {
-                        lastUpdateTime = now;
-                    }
+                    List<SpriteSettingsApplierAPI.PreparedProfile> prepared =
+                        SpriteSettingsApplierAPI.PrepareProfiles(currentSettings);
+                    double lastUpdateTime = EditorApplication.timeSinceStartup;
 
-                    if (
-                        SpriteSettingsApplierAPI.TryUpdateTextureSettings(
-                            filePath,
-                            prepared,
-                            out TextureImporter textureImporter,
-                            _settingsBuffer
-                        )
-                    )
+                    for (int i = 0; i < targetFiles.Count; i++)
                     {
-                        if (textureImporter != null)
+                        string filePath = targetFiles[i].relativePath;
+                        double now = EditorApplication.timeSinceStartup;
+                        bool shouldUpdate =
+                            i == 0
+                            || i == targetFiles.Count - 1
+                            || i % 50 == 0
+                            || 0.2 < now - lastUpdateTime;
+                        if (
+                            shouldUpdate
+                            && Utils.EditorUi.CancelableProgress(
+                                "Applying Sprite Settings",
+                                $"Processing '{Path.GetFileName(filePath)}' ({i + 1}/{targetFiles.Count})",
+                                (float)(i + 1) / targetFiles.Count
+                            )
+                        )
                         {
-                            updatedImporters.Add(textureImporter);
-                            ++spriteCount;
+                            _applyCanceled = true;
+                            break;
+                        }
+                        if (shouldUpdate)
+                        {
+                            lastUpdateTime = now;
+                        }
+
+                        if (
+                            SpriteSettingsApplierAPI.TryUpdateTextureSettings(
+                                filePath,
+                                prepared,
+                                out TextureImporter textureImporter,
+                                _settingsBuffer
+                            )
+                        )
+                        {
+                            if (textureImporter != null)
+                            {
+                                updatedImporters.Add(textureImporter);
+                                ++spriteCount;
+                            }
                         }
                     }
                 }
             }
-
-            Utils.EditorUi.ClearProgress();
+            finally
+            {
+                Utils.EditorUi.ClearProgress();
+            }
             foreach (TextureImporter importer in updatedImporters)
             {
                 importer.SaveAndReimport();

--- a/Editor/Sprites/SpriteSheetExtractor.cs
+++ b/Editor/Sprites/SpriteSheetExtractor.cs
@@ -7698,7 +7698,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             newImporter.SaveAndReimport();
         }
 
-        private void ReplaceSpriteReferences()
+        internal void ReplaceSpriteReferences()
         {
             if (_discoveredSheets == null || _discoveredSheets.Count == 0)
             {
@@ -7878,7 +7878,6 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 }
 
                 AssetDatabase.SaveAssets();
-                Utils.EditorUi.ClearProgress();
 
                 this.Log(
                     $"Reference replacement complete. Modified assets: {modifiedAssets}. Mapped pairs: {mapping.Count}."
@@ -7887,6 +7886,10 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             catch (Exception e)
             {
                 this.LogError($"Error during reference replacement", e);
+            }
+            finally
+            {
+                Utils.EditorUi.ClearProgress();
             }
         }
 

--- a/Editor/Sprites/TextureResizerWizard.cs
+++ b/Editor/Sprites/TextureResizerWizard.cs
@@ -159,201 +159,206 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             string outputDirAssetPath =
                 outputFolder != null ? AssetDatabase.GetAssetPath(outputFolder) : null;
 
-            using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
+            try
             {
-                for (int idx = 0; idx < textures.Count; ++idx)
+                using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
                 {
-                    Texture2D texture = textures[idx];
-                    string assetPath = AssetDatabase.GetAssetPath(texture);
-                    if (string.IsNullOrEmpty(assetPath))
+                    for (int idx = 0; idx < textures.Count; ++idx)
                     {
-                        continue;
-                    }
-
-                    // Only process PNGs by default to avoid corrupting non-PNG assets.
-                    if (
-                        !string.Equals(
-                            Path.GetExtension(assetPath),
-                            ".png",
-                            StringComparison.OrdinalIgnoreCase
-                        )
-                    )
-                    {
-                        ++skippedWrongExt;
-                        continue;
-                    }
-
-                    bool cancel = Utils.EditorUi.CancelableProgress(
-                        "Resizing Textures",
-                        $"Processing {texture.name} ({idx + 1}/{textures.Count})",
-                        (float)(idx + 1) / textures.Count
-                    );
-                    if (cancel)
-                    {
-                        break;
-                    }
-
-                    ++processed;
-
-                    TextureImporter tImporter =
-                        AssetImporter.GetAtPath(assetPath) as TextureImporter;
-                    if (tImporter == null)
-                    {
-                        continue;
-                    }
-
-                    bool originalReadable = tImporter.isReadable;
-                    Texture2D working = texture;
-                    try
-                    {
-                        if (!originalReadable)
+                        Texture2D texture = textures[idx];
+                        string assetPath = AssetDatabase.GetAssetPath(texture);
+                        if (string.IsNullOrEmpty(assetPath))
                         {
-                            // Pause asset editing so SaveAndReimport completes before the texture is read.
-                            using (AssetDatabaseBatchHelper.PauseBatch())
-                            {
-                                tImporter.isReadable = true;
-                                tImporter.SaveAndReimport();
-
-                                working = AssetDatabase.LoadAssetAtPath<Texture2D>(assetPath);
-                            }
-                        }
-
-                        int origW = working.width;
-                        int origH = working.height;
-
-                        (int targetW, int targetH) = ComputeFinalSize(
-                            origW,
-                            origH,
-                            numResizes,
-                            pixelsPerUnit,
-                            widthMultiplier,
-                            heightMultiplier
-                        );
-
-                        targetW = Mathf.Clamp(targetW, 1, 16384);
-                        targetH = Mathf.Clamp(targetH, 1, 16384);
-
-                        if (targetW == working.width && targetH == working.height)
-                        {
-                            ++skippedZeroDelta;
                             continue;
                         }
 
-                        // If writing to separate folder, avoid mutating the original asset in memory.
-                        Texture2D resizeSource = working;
-                        Texture2D scratch = null;
-                        bool useScratch = !string.IsNullOrEmpty(outputDirAssetPath);
-                        if (useScratch)
+                        // Only process PNGs by default to avoid corrupting non-PNG assets.
+                        if (
+                            !string.Equals(
+                                Path.GetExtension(assetPath),
+                                ".png",
+                                StringComparison.OrdinalIgnoreCase
+                            )
+                        )
                         {
-                            scratch = new Texture2D(
-                                working.width,
-                                working.height,
-                                TextureFormat.RGBA32,
-                                false
-                            );
-                            scratch.SetPixels(working.GetPixels());
-                            scratch.Apply(false);
-                            resizeSource = scratch;
+                            ++skippedWrongExt;
+                            continue;
                         }
 
+                        bool cancel = Utils.EditorUi.CancelableProgress(
+                            "Resizing Textures",
+                            $"Processing {texture.name} ({idx + 1}/{textures.Count})",
+                            (float)(idx + 1) / textures.Count
+                        );
+                        if (cancel)
+                        {
+                            break;
+                        }
+
+                        ++processed;
+
+                        TextureImporter tImporter =
+                            AssetImporter.GetAtPath(assetPath) as TextureImporter;
+                        if (tImporter == null)
+                        {
+                            continue;
+                        }
+
+                        bool originalReadable = tImporter.isReadable;
+                        Texture2D working = texture;
                         try
                         {
-                            switch (scalingResizeAlgorithm)
+                            if (!originalReadable)
                             {
-                                case ResizeAlgorithm.Bilinear:
-                                    TextureScale.Bilinear(resizeSource, targetW, targetH);
-                                    break;
-                                case ResizeAlgorithm.Point:
-                                    TextureScale.Point(resizeSource, targetW, targetH);
-                                    break;
-                                default:
-                                    throw new InvalidEnumArgumentException(
-                                        nameof(scalingResizeAlgorithm),
-                                        (int)scalingResizeAlgorithm,
-                                        typeof(ResizeAlgorithm)
-                                    );
+                                // Pause asset editing so SaveAndReimport completes before the texture is read.
+                                using (AssetDatabaseBatchHelper.PauseBatch())
+                                {
+                                    tImporter.isReadable = true;
+                                    tImporter.SaveAndReimport();
+
+                                    working = AssetDatabase.LoadAssetAtPath<Texture2D>(assetPath);
+                                }
                             }
 
-                            if (dryRun)
+                            int origW = working.width;
+                            int origH = working.height;
+
+                            (int targetW, int targetH) = ComputeFinalSize(
+                                origW,
+                                origH,
+                                numResizes,
+                                pixelsPerUnit,
+                                widthMultiplier,
+                                heightMultiplier
+                            );
+
+                            targetW = Mathf.Clamp(targetW, 1, 16384);
+                            targetH = Mathf.Clamp(targetH, 1, 16384);
+
+                            if (targetW == working.width && targetH == working.height)
                             {
-                                this.Log(
-                                    $"[DryRun] Would resize {texture.name} to [{targetW}x{targetH}]"
-                                );
-                                ++resized;
+                                ++skippedZeroDelta;
                                 continue;
                             }
 
-                            byte[] bytes = resizeSource.EncodeToPNG();
-
-                            string finalAssetPath = assetPath;
-                            if (!string.IsNullOrEmpty(outputDirAssetPath))
+                            // If writing to separate folder, avoid mutating the original asset in memory.
+                            Texture2D resizeSource = working;
+                            Texture2D scratch = null;
+                            bool useScratch = !string.IsNullOrEmpty(outputDirAssetPath);
+                            if (useScratch)
                             {
-                                string fileName = Path.GetFileName(assetPath);
-                                finalAssetPath = Path.Combine(outputDirAssetPath, fileName)
-                                    .SanitizePath();
-                                EnsureDirectory(finalAssetPath);
+                                scratch = new Texture2D(
+                                    working.width,
+                                    working.height,
+                                    TextureFormat.RGBA32,
+                                    false
+                                );
+                                scratch.SetPixels(working.GetPixels());
+                                scratch.Apply(false);
+                                resizeSource = scratch;
                             }
 
-                            string fullDest = ToFullPath(finalAssetPath);
-                            string tempPath = fullDest + ".tmp";
-
-                            File.WriteAllBytes(tempPath, bytes);
-
-                            if (File.Exists(fullDest))
+                            try
                             {
-                                string backupPath = fullDest + ".bak";
-                                File.Replace(tempPath, fullDest, backupPath, true);
-                                // Best-effort cleanup of backup to avoid clutter in VCS; keep if replace failed.
-                                try
+                                switch (scalingResizeAlgorithm)
                                 {
-                                    File.Delete(backupPath);
+                                    case ResizeAlgorithm.Bilinear:
+                                        TextureScale.Bilinear(resizeSource, targetW, targetH);
+                                        break;
+                                    case ResizeAlgorithm.Point:
+                                        TextureScale.Point(resizeSource, targetW, targetH);
+                                        break;
+                                    default:
+                                        throw new InvalidEnumArgumentException(
+                                            nameof(scalingResizeAlgorithm),
+                                            (int)scalingResizeAlgorithm,
+                                            typeof(ResizeAlgorithm)
+                                        );
                                 }
-                                catch { }
-                            }
-                            else
-                            {
-                                File.Move(tempPath, fullDest);
-                            }
 
-                            anyChanges = true;
-                            ++resized;
-                            this.Log(
-                                $"Resized {texture.name} from [{origW}x{origH}] to [{targetW}x{targetH}]"
-                            );
+                                if (dryRun)
+                                {
+                                    this.Log(
+                                        $"[DryRun] Would resize {texture.name} to [{targetW}x{targetH}]"
+                                    );
+                                    ++resized;
+                                    continue;
+                                }
+
+                                byte[] bytes = resizeSource.EncodeToPNG();
+
+                                string finalAssetPath = assetPath;
+                                if (!string.IsNullOrEmpty(outputDirAssetPath))
+                                {
+                                    string fileName = Path.GetFileName(assetPath);
+                                    finalAssetPath = Path.Combine(outputDirAssetPath, fileName)
+                                        .SanitizePath();
+                                    EnsureDirectory(finalAssetPath);
+                                }
+
+                                string fullDest = ToFullPath(finalAssetPath);
+                                string tempPath = fullDest + ".tmp";
+
+                                File.WriteAllBytes(tempPath, bytes);
+
+                                if (File.Exists(fullDest))
+                                {
+                                    string backupPath = fullDest + ".bak";
+                                    File.Replace(tempPath, fullDest, backupPath, true);
+                                    // Best-effort cleanup of backup to avoid clutter in VCS; keep if replace failed.
+                                    try
+                                    {
+                                        File.Delete(backupPath);
+                                    }
+                                    catch { }
+                                }
+                                else
+                                {
+                                    File.Move(tempPath, fullDest);
+                                }
+
+                                anyChanges = true;
+                                ++resized;
+                                this.Log(
+                                    $"Resized {texture.name} from [{origW}x{origH}] to [{targetW}x{targetH}]"
+                                );
+                            }
+                            finally
+                            {
+                                if (scratch != null)
+                                {
+                                    DestroyImmediate(scratch);
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            ++errors;
+                            this.LogError($"Failed to resize {texture.name}.", e);
                         }
                         finally
                         {
-                            if (scratch != null)
+                            if (tImporter.isReadable != originalReadable)
                             {
-                                DestroyImmediate(scratch);
-                            }
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        ++errors;
-                        this.LogError($"Failed to resize {texture.name}.", e);
-                    }
-                    finally
-                    {
-                        if (tImporter.isReadable != originalReadable)
-                        {
-                            // Pause asset editing so restoring importer settings takes effect immediately.
-                            using (AssetDatabaseBatchHelper.PauseBatch())
-                            {
-                                try
+                                // Pause asset editing so restoring importer settings takes effect immediately.
+                                using (AssetDatabaseBatchHelper.PauseBatch())
                                 {
-                                    tImporter.isReadable = originalReadable;
-                                    tImporter.SaveAndReimport();
+                                    try
+                                    {
+                                        tImporter.isReadable = originalReadable;
+                                        tImporter.SaveAndReimport();
+                                    }
+                                    catch { }
                                 }
-                                catch { }
                             }
                         }
                     }
                 }
             }
-
-            Utils.EditorUi.ClearProgress();
+            finally
+            {
+                Utils.EditorUi.ClearProgress();
+            }
 
             if (anyChanges)
             {

--- a/Editor/Sprites/TextureSettingsApplierWindow.cs
+++ b/Editor/Sprites/TextureSettingsApplierWindow.cs
@@ -503,6 +503,9 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             }
         }
 
+        /// <summary>
+        /// Counts pending texture changes and clears progress when the scan ends or fails.
+        /// </summary>
         public void CalculateStats()
         {
             using PooledResource<List<string>> targetsLease = Buffers<string>.List.Get(
@@ -519,34 +522,43 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
 
             TextureSettingsApplierAPI.Config config = BuildConfig();
             double last = EditorApplication.timeSinceStartup;
-            for (int i = 0; i < targets.Count; i++)
+            try
             {
-                string rel = targets[i];
-                double now = EditorApplication.timeSinceStartup;
-                if (i == 0 || i == targets.Count - 1 || i % 50 == 0 || 0.2 < now - last)
+                for (int i = 0; i < targets.Count; i++)
                 {
-                    Utils.EditorUi.ShowProgress(
-                        "Calculating Stats",
-                        $"Checking '{Path.GetFileName(rel)}' ({i + 1}/{_totalTexturesToProcess})",
-                        (float)(i + 1) / Math.Max(1, _totalTexturesToProcess)
-                    );
-                    last = now;
-                }
-                if (
-                    TextureSettingsApplierAPI.WillTextureSettingsChange(
-                        rel,
-                        in config,
-                        _settingsBuffer
+                    string rel = targets[i];
+                    double now = EditorApplication.timeSinceStartup;
+                    if (i == 0 || i == targets.Count - 1 || i % 50 == 0 || 0.2 < now - last)
+                    {
+                        Utils.EditorUi.ShowProgress(
+                            "Calculating Stats",
+                            $"Checking '{Path.GetFileName(rel)}' ({i + 1}/{_totalTexturesToProcess})",
+                            (float)(i + 1) / Math.Max(1, _totalTexturesToProcess)
+                        );
+                        last = now;
+                    }
+                    if (
+                        TextureSettingsApplierAPI.WillTextureSettingsChange(
+                            rel,
+                            in config,
+                            _settingsBuffer
+                        )
                     )
-                )
-                {
-                    _texturesThatWillChange++;
-                    _assetsThatWillChange.Add(rel);
+                    {
+                        _texturesThatWillChange++;
+                        _assetsThatWillChange.Add(rel);
+                    }
                 }
             }
-            Utils.EditorUi.ClearProgress();
+            finally
+            {
+                Utils.EditorUi.ClearProgress();
+            }
         }
 
+        /// <summary>
+        /// Applies texture settings, retaining completed changes on cancellation and clearing progress on failure.
+        /// </summary>
         public void ApplySettings()
         {
             if (
@@ -595,49 +607,58 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             int count = 0;
             using PooledResource<List<TextureImporter>> changedResource =
                 Buffers<TextureImporter>.List.Get(out List<TextureImporter> changed);
-            using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
+            try
             {
-                double lastUpdate = EditorApplication.timeSinceStartup;
-                for (int i = 0; i < targets.Count; i++)
+                using (AssetDatabaseBatchHelper.BeginBatch(refreshOnDispose: false))
                 {
-                    string path = targets[i];
-                    double now = EditorApplication.timeSinceStartup;
-                    bool shouldUpdate =
-                        i == 0 || i == targets.Count - 1 || i % 50 == 0 || 0.2 < now - lastUpdate;
-                    if (
-                        shouldUpdate
-                        && EditorUi.CancelableProgress(
-                            "Applying Texture Settings",
-                            $"Processing '{Path.GetFileName(path)}' ({i + 1}/{targets.Count})",
-                            (float)(i + 1) / Math.Max(1, targets.Count)
+                    double lastUpdate = EditorApplication.timeSinceStartup;
+                    for (int i = 0; i < targets.Count; i++)
+                    {
+                        string path = targets[i];
+                        double now = EditorApplication.timeSinceStartup;
+                        bool shouldUpdate =
+                            i == 0
+                            || i == targets.Count - 1
+                            || i % 50 == 0
+                            || 0.2 < now - lastUpdate;
+                        if (
+                            shouldUpdate
+                            && EditorUi.CancelableProgress(
+                                "Applying Texture Settings",
+                                $"Processing '{Path.GetFileName(path)}' ({i + 1}/{targets.Count})",
+                                (float)(i + 1) / Math.Max(1, targets.Count)
+                            )
                         )
-                    )
-                    {
-                        break;
-                    }
-                    if (shouldUpdate)
-                    {
-                        lastUpdate = now;
-                    }
-
-                    if (
-                        TextureSettingsApplierAPI.TryUpdateTextureSettings(
-                            path,
-                            in config,
-                            out TextureImporter importer,
-                            _settingsBuffer
-                        )
-                    )
-                    {
-                        if (importer != null)
                         {
-                            changed.Add(importer);
-                            ++count;
+                            break;
+                        }
+                        if (shouldUpdate)
+                        {
+                            lastUpdate = now;
+                        }
+
+                        if (
+                            TextureSettingsApplierAPI.TryUpdateTextureSettings(
+                                path,
+                                in config,
+                                out TextureImporter importer,
+                                _settingsBuffer
+                            )
+                        )
+                        {
+                            if (importer != null)
+                            {
+                                changed.Add(importer);
+                                ++count;
+                            }
                         }
                     }
                 }
             }
-            EditorUi.ClearProgress();
+            finally
+            {
+                EditorUi.ClearProgress();
+            }
             foreach (UnityEditor.TextureImporter changedElement in changed)
             {
                 changedElement.SaveAndReimport();

--- a/Editor/Utils/EditorUi.cs
+++ b/Editor/Utils/EditorUi.cs
@@ -14,6 +14,9 @@ namespace WallstopStudios.UnityHelpers.Editor.Utils
         private static bool _suppressManual;
         private static bool _suppressAuto;
 
+        internal static Func<bool> ProgressForTesting;
+        internal static Action ProgressClearedForTesting;
+
         public static bool Suppress
         {
             get => _suppressManual || _suppressAuto;
@@ -80,6 +83,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Utils
 
         public static void ShowProgress(string title, string info, float progress)
         {
+            ProgressForTesting?.Invoke();
             if (Suppress)
             {
                 return;
@@ -89,6 +93,10 @@ namespace WallstopStudios.UnityHelpers.Editor.Utils
 
         public static bool CancelableProgress(string title, string info, float progress)
         {
+            if (ProgressForTesting != null)
+            {
+                return ProgressForTesting();
+            }
             if (Suppress)
             {
                 return false;
@@ -99,6 +107,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Utils
         public static void ClearProgress()
         {
             EditorUtility.ClearProgressBar();
+            ProgressClearedForTesting?.Invoke();
         }
 
         public static string OpenFilePanel(string title, string directory, string extension)

--- a/Runtime/Core/DataStructure/KDTree2D.cs
+++ b/Runtime/Core/DataStructure/KDTree2D.cs
@@ -23,6 +23,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
     /// </example>
     /// <typeparam name="T">Element type contained in the tree.</typeparam>
     /// <remarks>
+    /// <para>Non-finite positions are excluded from the index. The original <c>elements</c> snapshot and source insertion identities are retained.</para>
     /// Pros: Very fast nearest neighbor performance; good for static or batched updates.
     /// Cons: Immutable structure by design; rebuild when positions change frequently.
     /// Semantics: For identical input data and queries, KdTree2D (balanced or unbalanced)
@@ -61,7 +62,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
         /// Builds a 2D k-d tree from elements using a transformer to extract 2D positions.
         /// </summary>
         /// <param name="points">Source elements.</param>
-        /// <param name="elementTransformer">Maps element to its 2D position.</param>
+        /// <param name="elementTransformer">Maps element to its 2D position; non-finite positions are excluded from the index.</param>
         /// <param name="bucketSize">Max elements per leaf. Minimum 1.</param>
         /// <param name="balanced">If true, builds a balanced tree by median selection; otherwise uses a quick split strategy.</param>
         /// <exception cref="ArgumentNullException">Thrown when points or elementTransformer are null.</exception>
@@ -90,11 +91,16 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
             float maxX = float.NegativeInfinity;
             float maxY = float.NegativeInfinity;
 
+            int indexedCount = 0;
             for (int i = 0; i < elementCount; ++i)
             {
                 T element = elements[i];
                 Vector2 position = elementTransformer(element);
                 _entries[i] = new Entry(element, position);
+                if (!SpatialQueryMath.IsFinite(position))
+                {
+                    continue;
+                }
 
                 if (position.x < minX)
                 {
@@ -113,9 +119,10 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
                     maxY = position.y;
                 }
 
-                _indices[i] = i;
+                _indices[indexedCount++] = i;
             }
 
+            elementCount = indexedCount;
             Bounds bounds = CreateBounds(minX, maxX, minY, maxY);
 
             if (elementCount == 0)

--- a/Runtime/Core/DataStructure/KDTree3D.cs
+++ b/Runtime/Core/DataStructure/KDTree3D.cs
@@ -23,6 +23,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
     /// </example>
     /// <typeparam name="T">Element type contained in the tree.</typeparam>
     /// <remarks>
+    /// <para>Non-finite positions are excluded from the index. The original <c>elements</c> snapshot and source insertion identities are retained.</para>
     /// <para>Pros: Very fast nearest neighbor performance; good for static or batched updates.</para>
     /// <para>Cons: Immutable structure by design; rebuild when positions change frequently.</para>
     /// <para>Semantics: Due to algorithmic choices (axis-aligned splitting, half-open containment checks,
@@ -65,7 +66,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
         /// Builds a 3D k-d tree from elements using a transformer to extract 3D positions.
         /// </summary>
         /// <param name="points">Source elements.</param>
-        /// <param name="elementTransformer">Maps element to its 3D position.</param>
+        /// <param name="elementTransformer">Maps element to its 3D position; non-finite positions are excluded from the index.</param>
         /// <param name="bucketSize">Max elements per leaf. Minimum 1.</param>
         /// <param name="balanced">If true, builds a balanced tree by median selection; otherwise uses a quick split strategy.</param>
         /// <exception cref="ArgumentNullException">Thrown when points or elementTransformer are null.</exception>
@@ -98,6 +99,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
             float maxY = float.NegativeInfinity;
             float maxZ = float.NegativeInfinity;
 
+            int indexedCount = 0;
             for (int i = 0; i < elementCount; ++i)
             {
                 T element = elements[i];
@@ -105,6 +107,10 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
                 _positionsX[i] = position.x;
                 _positionsY[i] = position.y;
                 _positionsZ[i] = position.z;
+                if (!SpatialQueryMath.IsFinite(position))
+                {
+                    continue;
+                }
 
                 if (position.x < minX)
                 {
@@ -131,9 +137,10 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
                     maxZ = position.z;
                 }
 
-                _indices[i] = i;
+                _indices[indexedCount++] = i;
             }
 
+            elementCount = indexedCount;
             Bounds bounds = CreateBounds(minX, maxX, minY, maxY, minZ, maxZ);
 
             if (elementCount == 0)

--- a/Runtime/Core/DataStructure/OctTree3D.cs
+++ b/Runtime/Core/DataStructure/OctTree3D.cs
@@ -22,6 +22,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
     /// </example>
     /// <typeparam name="T">Element type contained in the tree.</typeparam>
     /// <remarks>
+    /// <para>Non-finite positions are excluded from the index. The original <c>elements</c> snapshot and source insertion identities are retained.</para>
     /// <para>Pros: Good all-around performance for 3D point queries, range queries, and approximate nearest neighbor searches.</para>
     /// <para>Cons: Immutable structure by design; rebuild when positions change frequently.</para>
     /// <para>Semantics: OctTree3D uses octant subdivision and inclusive half-open containment checks with internal
@@ -53,7 +54,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
         /// Builds an oct tree from elements using a transformer to extract 3D positions.
         /// </summary>
         /// <param name="points">Source elements.</param>
-        /// <param name="elementTransformer">Maps elements to positions; NaN positions are excluded from the index.</param>
+        /// <param name="elementTransformer">Maps elements to positions; non-finite positions are excluded from the index.</param>
         /// <param name="boundary">Optional precomputed bounds. If null, or if it cannot describe a
         /// region because an edge is NaN or its max sits below its min, bounds are computed from
         /// the points.</param>
@@ -99,7 +100,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
                 T element = elements[i];
                 Vector3 position = elementTransformer(element);
                 _entries[i] = new Entry(element, position);
-                if (SpatialQueryMath.IsNaN(position))
+                if (!SpatialQueryMath.IsFinite(position))
                 {
                     continue;
                 }

--- a/Runtime/Core/DataStructure/QuadTree2D.cs
+++ b/Runtime/Core/DataStructure/QuadTree2D.cs
@@ -33,6 +33,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
     /// </example>
     /// <typeparam name="T">Element type contained in the tree.</typeparam>
     /// <remarks>
+    /// <para>Non-finite positions are excluded from the index. The original <c>elements</c> snapshot and source insertion identities are retained.</para>
     /// Pros: Excellent query performance for static data, low allocations for repeated queries, deterministic iteration.
     /// Cons: Immutable structure; rebuild when positions change. Prefer <c>SpatialHash2D</c> for frequently moving, uniformly distributed data.
     /// Semantics: For identical input data and queries, QuadTree2D and KdTree2D (balanced/unbalanced)
@@ -69,7 +70,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
         /// Builds a QuadTree from elements using a transformer to extract 2D positions.
         /// </summary>
         /// <param name="points">Source elements.</param>
-        /// <param name="elementTransformer">Maps element to its 2D position.</param>
+        /// <param name="elementTransformer">Maps element to its 2D position; non-finite positions are excluded from the index.</param>
         /// <param name="boundary">Optional precomputed bounds. If null, or if it cannot describe a
         /// region because an edge is NaN or its max sits below its min, bounds are computed from
         /// the points.</param>
@@ -100,28 +101,30 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
             Bounds bounds = hasUsableBoundary ? boundary.Value : default;
             bool anyPoints = hasUsableBoundary;
 
+            int indexedCount = 0;
             for (int i = 0; i < elementCount; ++i)
             {
                 T element = elements[i];
                 Vector2 position = elementTransformer(element);
                 _entries[i] = new Entry(element, position);
-                // Bounds.Encapsulate propagates NaN, which would hide finite siblings under an invalid root.
-                if (SpatialQueryMath.IsFinite(position))
+                if (!SpatialQueryMath.IsFinite(position))
                 {
-                    if (anyPoints)
-                    {
-                        bounds.Encapsulate(position);
-                    }
-                    else
-                    {
-                        bounds = new Bounds(position, new Vector3(0f, 0f, 1f));
-                        anyPoints = true;
-                    }
+                    continue;
+                }
+                if (anyPoints)
+                {
+                    bounds.Encapsulate(position);
+                }
+                else
+                {
+                    bounds = new Bounds(position, new Vector3(0f, 0f, 1f));
+                    anyPoints = true;
                 }
 
-                _indices[i] = i;
+                _indices[indexedCount++] = i;
             }
 
+            elementCount = indexedCount;
             if (anyPoints)
             {
                 Vector3 size = bounds.size;
@@ -159,7 +162,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
         /// <summary>
         /// Builds a QuadTree directly from entries containing values and positions.
         /// </summary>
-        /// <param name="entries">Collection of values with positions.</param>
+        /// <param name="entries">Collection of values with positions; non-finite positions are excluded from the index.</param>
         /// <param name="boundary">Optional precomputed bounds. If null, or if it cannot describe a
         /// region because an edge is NaN or its max sits below its min, bounds are computed from
         /// the entries.</param>
@@ -199,29 +202,31 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
             ImmutableArray<T>.Builder builder = ImmutableArray.CreateBuilder<T>(elementCount);
             Bounds bounds = hasUsableBoundary ? boundary.Value : default;
             bool anyPoints = hasUsableBoundary;
+            int indexedCount = 0;
             for (int i = 0; i < elementCount; ++i)
             {
                 Entry entry = entryList[i];
                 _entries[i] = entry;
                 builder.Add(entry.value);
                 Vector2 position = entry.position;
-                // Bounds.Encapsulate propagates NaN, which would hide finite siblings under an invalid root.
-                if (SpatialQueryMath.IsFinite(position))
+                if (!SpatialQueryMath.IsFinite(position))
                 {
-                    if (anyPoints)
-                    {
-                        bounds.Encapsulate(position);
-                    }
-                    else
-                    {
-                        bounds = new Bounds(position, new Vector3(0f, 0f, 1f));
-                        anyPoints = true;
-                    }
+                    continue;
+                }
+                if (anyPoints)
+                {
+                    bounds.Encapsulate(position);
+                }
+                else
+                {
+                    bounds = new Bounds(position, new Vector3(0f, 0f, 1f));
+                    anyPoints = true;
                 }
 
-                _indices[i] = i;
+                _indices[indexedCount++] = i;
             }
 
+            elementCount = indexedCount;
             if (anyPoints)
             {
                 Vector3 size = bounds.size;

--- a/Runtime/Core/DataStructure/RTree2D.cs
+++ b/Runtime/Core/DataStructure/RTree2D.cs
@@ -24,6 +24,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
     /// </example>
     /// <typeparam name="T">Element type.</typeparam>
     /// <remarks>
+    /// <para>Bounds with non-finite edges or inverted extents are excluded from the index. The original <c>elements</c> snapshot and source insertion identities are retained.</para>
     /// Pros: Great for sized objects (sprites, colliders) with area; supports fast rectangle and radius queries.
     /// Cons: Immutable; rebuild when element bounds change.
     /// Semantics: RTree2D indexes rectangles (AABBs) rather than points; as such its query results intentionally
@@ -59,7 +60,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
         /// Builds an R-Tree from elements using a transformer that returns each element's bounds.
         /// </summary>
         /// <param name="points">Source elements.</param>
-        /// <param name="elementTransformer">Maps element to an axis-aligned bounding box in world space.</param>
+        /// <param name="elementTransformer">Maps element to world bounds; non-finite edges or inverted bounds are excluded from the index.</param>
         /// <param name="bucketSize">Max elements per leaf.</param>
         /// <param name="branchFactor">Approximate number of children per internal node (≥2).</param>
         /// <exception cref="ArgumentNullException">Thrown when points or elementTransformer are null.</exception>
@@ -85,26 +86,29 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
             float minY = float.MaxValue;
             float maxX = float.MinValue;
             float maxY = float.MinValue;
-            bool hasElements = false;
+            int indexedCount = 0;
 
             for (int i = 0; i < elementCount; ++i)
             {
                 T element = elements[i];
 
                 Bounds elementBounds = transformer(element);
+                if (
+                    !SpatialQueryMath.IsFinite(elementBounds.min)
+                    || !SpatialQueryMath.IsFinite(elementBounds.max)
+                    || SpatialQueryMath.IsInvalidQueryBounds(elementBounds)
+                )
+                {
+                    continue;
+                }
                 ElementData data = default;
                 data._value = element;
                 data._bounds = elementBounds;
                 data._center = elementBounds.center;
                 data._insertionIndex = i;
-                elementData[i] = data;
+                elementData[indexedCount++] = data;
                 Vector3 min = elementBounds.min;
                 Vector3 max = elementBounds.max;
-
-                if (!hasElements)
-                {
-                    hasElements = true;
-                }
 
                 if (min.x < minX)
                 {
@@ -124,6 +128,8 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
                 }
             }
 
+            elementCount = indexedCount;
+            bool hasElements = 0 < elementCount;
             Bounds bounds = hasElements
                 ? new Bounds(
                     new Vector3(minX + (maxX - minX) / 2, minY + (maxY - minY) / 2, 0f),

--- a/Runtime/Core/DataStructure/RTree3D.cs
+++ b/Runtime/Core/DataStructure/RTree3D.cs
@@ -23,6 +23,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
     /// </example>
     /// <typeparam name="T">Element type.</typeparam>
     /// <remarks>
+    /// <para>Bounds with non-finite edges or inverted extents are excluded from the index. The original <c>elements</c> snapshot and source insertion identities are retained.</para>
     /// <para>Pros: Great for sized 3D objects (meshes, volumes) with fast box and radius intersection queries.</para>
     /// <para>Cons: Immutable; rebuild when element bounds change.</para>
     /// <para>Semantics: RTree3D indexes 3D bounds (AABBs), not points, and aggregates at node level using bounding volumes.
@@ -56,7 +57,7 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
         /// Builds an R-Tree from elements using a transformer that returns each element's 3D bounds.
         /// </summary>
         /// <param name="points">Source elements.</param>
-        /// <param name="elementTransformer">Maps elements to bounds; NaN edges or inverted bounds are excluded from the index.</param>
+        /// <param name="elementTransformer">Maps elements to bounds; non-finite edges or inverted bounds are excluded from the index.</param>
         /// <param name="bucketSize">Max elements per leaf.</param>
         /// <param name="branchFactor">Approximate number of children per internal node (≥2).</param>
         /// <exception cref="ArgumentNullException">Thrown when points or elementTransformer are null.</exception>
@@ -91,7 +92,11 @@ namespace WallstopStudios.UnityHelpers.Core.DataStructure
                 T element = elements[i];
 
                 Bounds elementBounds = transformer(element);
-                if (SpatialQueryMath.IsInvalidQueryBounds(elementBounds))
+                if (
+                    !SpatialQueryMath.IsFinite(elementBounds.min)
+                    || !SpatialQueryMath.IsFinite(elementBounds.max)
+                    || SpatialQueryMath.IsInvalidQueryBounds(elementBounds)
+                )
                 {
                     continue;
                 }

--- a/Tests/Editor/EditorProgressCleanupTests.cs
+++ b/Tests/Editor/EditorProgressCleanupTests.cs
@@ -1,0 +1,241 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests
+{
+#if UNITY_EDITOR
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using NUnit.Framework;
+    using UnityEditor;
+    using UnityEngine;
+    using WallstopStudios.UnityHelpers.Editor;
+    using WallstopStudios.UnityHelpers.Editor.Sprites;
+    using WallstopStudios.UnityHelpers.Editor.Utils;
+    using WallstopStudios.UnityHelpers.Tests.Core;
+
+    [TestFixture]
+    [Category("Slow")]
+    [Category("Integration")]
+    public sealed class EditorProgressCleanupTests : CommonTestBase
+    {
+        private const string Root = "Assets/Temp/EditorProgressCleanupTests";
+
+        [TestCase(typeof(SpriteSettingsApplierWindow), true)]
+        [TestCase(typeof(SpriteSettingsApplierWindow), false)]
+        [TestCase(typeof(TextureSettingsApplierWindow), true)]
+        [TestCase(typeof(TextureSettingsApplierWindow), false)]
+        [TestCase(typeof(ScriptableSpriteAtlasEditor), false)]
+        [TestCase(typeof(ScriptableSpriteAtlasEditor), true)]
+        [TestCase(typeof(PrefabChecker), false)]
+        [TestCase(typeof(TextureResizerWizard), false)]
+        [TestCase(typeof(SpriteSheetExtractor), false)]
+        public void ProcessingExceptionClearsProgress(Type windowType, bool calculateStats)
+        {
+            Action operation = PrepareOperation(windowType, calculateStats);
+            InvalidOperationException expected = new("Injected processing failure");
+            int shown = 0;
+            int cleared = 0;
+            Func<bool> previousProgress = EditorUi.ProgressForTesting;
+            Action previousClear = EditorUi.ProgressClearedForTesting;
+            try
+            {
+                EditorUi.ProgressForTesting = () =>
+                {
+                    ++shown;
+                    throw expected;
+                };
+                EditorUi.ProgressClearedForTesting = () => ++cleared;
+
+                if (windowType == typeof(SpriteSheetExtractor))
+                {
+                    ExpectError(LogType.Error, "Error during reference replacement");
+                    Assert.DoesNotThrow(() => operation());
+                }
+                else
+                {
+                    InvalidOperationException actual = Assert.Throws<InvalidOperationException>(
+                        () =>
+                            operation()
+                    );
+                    Assert.AreSame(
+                        expected,
+                        actual,
+                        "Cleanup must preserve the processing exception."
+                    );
+                }
+                Assert.AreEqual(1, shown, "The operation must reach a progress display.");
+                Assert.AreEqual(
+                    1,
+                    cleared,
+                    "A failed operation must clear its progress exactly once."
+                );
+            }
+            finally
+            {
+                EditorUi.ProgressForTesting = previousProgress;
+                EditorUi.ProgressClearedForTesting = previousClear;
+            }
+        }
+
+        [TestCase(typeof(SpriteSettingsApplierWindow))]
+        [TestCase(typeof(TextureSettingsApplierWindow))]
+        [TestCase(typeof(PrefabChecker))]
+        [TestCase(typeof(TextureResizerWizard))]
+        [TestCase(typeof(SpriteSheetExtractor))]
+        public void CancellationClearsProgress(Type windowType)
+        {
+            Action operation = PrepareOperation(windowType, calculateStats: false);
+            int shown = 0;
+            int cleared = 0;
+            Func<bool> previousProgress = EditorUi.ProgressForTesting;
+            Action previousClear = EditorUi.ProgressClearedForTesting;
+            try
+            {
+                EditorUi.ProgressForTesting = () =>
+                {
+                    ++shown;
+                    return true;
+                };
+                EditorUi.ProgressClearedForTesting = () => ++cleared;
+
+                Assert.DoesNotThrow(() => operation());
+
+                Assert.AreEqual(
+                    1,
+                    shown,
+                    "Cancellation must stop before another asset is processed."
+                );
+                Assert.AreEqual(1, cleared, "Cancellation must clear its progress exactly once.");
+            }
+            finally
+            {
+                EditorUi.ProgressForTesting = previousProgress;
+                EditorUi.ProgressClearedForTesting = previousClear;
+            }
+        }
+
+        private Action PrepareOperation(Type windowType, bool calculateStats)
+        {
+            EnsureFolder(Root);
+            if (windowType == typeof(PrefabChecker))
+            {
+                string prefabPath = Root + "/subject.prefab";
+                TrackAssetPath(prefabPath);
+                GameObject source = Track(new GameObject("ProgressCleanupSubject"));
+                PrefabUtility.SaveAsPrefabAsset(source, prefabPath);
+                PrefabChecker window = Track(ScriptableObject.CreateInstance<PrefabChecker>());
+                window._assetPaths.Clear();
+                window._assetPaths.Add(Root);
+                return window.RunChecksImproved;
+            }
+
+            if (windowType == typeof(ScriptableSpriteAtlasEditor) && !calculateStats)
+            {
+                string configPath = Root + "/subject.asset";
+                TrackAssetPath(configPath);
+                ScriptableSpriteAtlas config = Track(
+                    ScriptableObject.CreateInstance<ScriptableSpriteAtlas>()
+                );
+                AssetDatabase.CreateAsset(config, configPath);
+                ScriptableSpriteAtlasEditor window = Track(
+                    ScriptableObject.CreateInstance<ScriptableSpriteAtlasEditor>()
+                );
+                window.LoadAtlasConfigs();
+                return window.GenerateAllAtlases;
+            }
+
+            string texturePath = Root + "/subject.png";
+            TrackAssetPath(texturePath);
+            Texture2D sourceTexture = Track(new Texture2D(2, 2));
+            File.WriteAllBytes(texturePath, sourceTexture.EncodeToPNG());
+            AssetDatabase.ImportAsset(texturePath, ImportAssetOptions.ForceSynchronousImport);
+            TextureImporter importer = AssetImporter.GetAtPath(texturePath) as TextureImporter;
+            Assert.IsTrue(importer != null, "The fixture texture must have an importer.");
+            importer.textureType = TextureImporterType.Sprite;
+            importer.spriteImportMode = SpriteImportMode.Single;
+            importer.SaveAndReimport();
+
+            if (windowType == typeof(SpriteSheetExtractor))
+            {
+                string extractedPath = Root + "/subject_000.png";
+                TrackAssetPath(extractedPath);
+                Assert.IsTrue(AssetDatabase.CopyAsset(texturePath, extractedPath));
+                AssetDatabase.ImportAsset(extractedPath, ImportAssetOptions.ForceSynchronousImport);
+                Sprite original = AssetDatabase.LoadAssetAtPath<Sprite>(texturePath);
+                Sprite extracted = AssetDatabase.LoadAssetAtPath<Sprite>(extractedPath);
+                Assert.IsTrue(original != null, "The original sprite must be imported.");
+                Assert.IsTrue(extracted != null, "The replacement sprite must be imported.");
+                string prefabPath = Root + "/subject.prefab";
+                TrackAssetPath(prefabPath);
+                GameObject source = Track(new GameObject("ProgressCleanupSubject"));
+                PrefabUtility.SaveAsPrefabAsset(source, prefabPath);
+
+                SpriteSheetExtractor window = Track(
+                    ScriptableObject.CreateInstance<SpriteSheetExtractor>()
+                );
+                window._outputDirectory = AssetDatabase.LoadAssetAtPath<DefaultAsset>(Root);
+                window._discoveredSheets = new List<SpriteSheetExtractor.SpriteSheetEntry>
+                {
+                    new()
+                    {
+                        _assetPath = texturePath,
+                        _isSelected = true,
+                        _sprites = new List<SpriteSheetExtractor.SpriteEntryData>
+                        {
+                            new() { _originalName = original.name, _isSelected = true },
+                        },
+                    },
+                };
+                return window.ReplaceSpriteReferences;
+            }
+
+            if (windowType == typeof(ScriptableSpriteAtlasEditor))
+            {
+                Sprite sprite = AssetDatabase.LoadAssetAtPath<Sprite>(texturePath);
+                Assert.IsTrue(sprite != null, "The fixture must contain an imported sprite.");
+                ScriptableSpriteAtlas config = Track(
+                    ScriptableObject.CreateInstance<ScriptableSpriteAtlas>()
+                );
+                config.spritesToPack.Add(sprite);
+                ScriptableSpriteAtlasEditor window = Track(
+                    ScriptableObject.CreateInstance<ScriptableSpriteAtlasEditor>()
+                );
+                return () => window.ForceUncompressedSourceSprites(config);
+            }
+
+            if (windowType == typeof(SpriteSettingsApplierWindow))
+            {
+                Sprite sprite = AssetDatabase.LoadAssetAtPath<Sprite>(texturePath);
+                Assert.IsTrue(sprite != null, "The fixture must contain an imported sprite.");
+                SpriteSettingsApplierWindow window = Track(
+                    ScriptableObject.CreateInstance<SpriteSettingsApplierWindow>()
+                );
+                window.sprites.Add(sprite);
+                window.SerializedStateForTesting.Update();
+                return calculateStats ? window.CalculateStats : window.ApplySettings;
+            }
+
+            Texture2D texture = AssetDatabase.LoadAssetAtPath<Texture2D>(texturePath);
+            Assert.IsTrue(texture != null, "The fixture must contain an imported texture.");
+            if (windowType == typeof(TextureResizerWizard))
+            {
+                TextureResizerWizard window = Track(
+                    ScriptableObject.CreateInstance<TextureResizerWizard>()
+                );
+                window.textures.Add(texture);
+                return window.OnWizardCreate;
+            }
+
+            Assert.AreEqual(typeof(TextureSettingsApplierWindow), windowType);
+            TextureSettingsApplierWindow textureWindow = Track(
+                ScriptableObject.CreateInstance<TextureSettingsApplierWindow>()
+            );
+            textureWindow.textures.Add(texture);
+            textureWindow.requireChangesBeforeApply = false;
+            return calculateStats ? textureWindow.CalculateStats : textureWindow.ApplySettings;
+        }
+    }
+#endif
+}

--- a/Tests/Editor/EditorProgressCleanupTests.cs.meta
+++ b/Tests/Editor/EditorProgressCleanupTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8256ae57143da89917d9d8abaee97ed2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/DataStructures/SpatialTreeStoredGeometryTests.cs
+++ b/Tests/Runtime/DataStructures/SpatialTreeStoredGeometryTests.cs
@@ -1,0 +1,302 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.DataStructures
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using UnityEngine;
+    using WallstopStudios.UnityHelpers.Core.DataStructure;
+
+    [TestFixture]
+    [Category("Fast")]
+    public sealed class SpatialTreeStoredGeometryTests
+    {
+        private static IEnumerable<TestCaseData> InvalidGeometryCases()
+        {
+            string[] variants =
+            {
+                "Kd2Balanced",
+                "Kd2Unbalanced",
+                "Quad",
+                "QuadEntries",
+                "R2",
+                "Kd3Balanced",
+                "Kd3Unbalanced",
+                "Oct",
+                "R3",
+            };
+            float[] invalidValues =
+            {
+                float.PositiveInfinity,
+                float.NegativeInfinity,
+                float.NaN,
+                -1f,
+            };
+            int[] bucketSizes = { 1, 32 };
+            int[] finiteCounts = { 0, 1, 12 };
+            foreach (string variant in variants)
+            {
+                int dimensions = IsThreeDimensional(variant) || variant == "R2" ? 3 : 2;
+                foreach (float invalidValue in invalidValues)
+                {
+                    for (int axis = 0; axis < dimensions; ++axis)
+                    {
+                        foreach (int bucketSize in bucketSizes)
+                        {
+                            foreach (int finiteCount in finiteCounts)
+                            {
+                                int[] insertionIndices =
+                                    finiteCount == 0 ? new[] { 0 }
+                                    : finiteCount == 1 ? new[] { 0, 1 }
+                                    : new[] { 0, finiteCount / 2, finiteCount };
+                                foreach (int insertionIndex in insertionIndices)
+                                {
+                                    if (!float.IsFinite(invalidValue))
+                                    {
+                                        yield return new TestCaseData(
+                                            variant,
+                                            axis,
+                                            invalidValue,
+                                            bucketSize,
+                                            finiteCount,
+                                            insertionIndex,
+                                            false
+                                        );
+                                    }
+                                    if (variant == "R2" || variant == "R3")
+                                    {
+                                        yield return new TestCaseData(
+                                            variant,
+                                            axis,
+                                            invalidValue,
+                                            bucketSize,
+                                            finiteCount,
+                                            insertionIndex,
+                                            true
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [TestCaseSource(nameof(InvalidGeometryCases))]
+        [Timeout(10000)]
+        public void InvalidStoredGeometryPreservesFiniteSourceIdentities(
+            string variant,
+            int axis,
+            float invalidValue,
+            int bucketSize,
+            int finiteCount,
+            int insertionIndex,
+            bool invalidSize
+        )
+        {
+            int[] source = new int[finiteCount + 1];
+            Vector3[] positions = new Vector3[source.Length];
+            Bounds[] bounds = new Bounds[source.Length];
+            List<int> expected = new();
+            for (int index = 0; index < source.Length; ++index)
+            {
+                source[index] = index;
+                Vector3 position = Vector3.zero;
+                Vector3 size = Vector3.zero;
+                if (index == insertionIndex)
+                {
+                    if (invalidSize)
+                    {
+                        size[axis] = invalidValue;
+                    }
+                    else
+                    {
+                        position[axis] = invalidValue;
+                    }
+                }
+                else
+                {
+                    if (1 < finiteCount)
+                    {
+                        int dimensions = IsThreeDimensional(variant) ? 3 : 2;
+                        position[(index / 2) % dimensions] = index % 2 == 0 ? -1f : 1f;
+                    }
+                    expected.Add(index);
+                }
+                positions[index] = position;
+                bounds[index] = new Bounds(position, size);
+            }
+
+            object tree = CreateTree(variant, source, positions, bounds, bucketSize);
+            List<int> actual = new() { -1 };
+            Bounds finiteQuery = new(Vector3.zero, Vector3.one * 4f);
+            Bounds infiniteQuery = new(
+                Vector3.zero,
+                new Vector3(float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity)
+            );
+            if (tree is ISpatialTree2D<int> tree2D)
+            {
+                tree2D.GetElementsInRange(Vector2.zero, 1f, actual);
+                CollectionAssert.AreEquivalent(expected, actual, "Finite radius");
+                tree2D.GetElementsInRange(Vector2.zero, float.PositiveInfinity, actual);
+                CollectionAssert.AreEquivalent(expected, actual, "Infinite radius");
+                tree2D.GetElementsInBounds(finiteQuery, actual);
+                CollectionAssert.AreEquivalent(expected, actual, "Finite query bounds");
+                tree2D.GetElementsInBounds(infiniteQuery, actual);
+                CollectionAssert.AreEquivalent(expected, actual, "Infinite query bounds");
+                tree2D.GetApproximateNearestNeighbors(Vector2.zero, source.Length + 1, actual);
+            }
+            else
+            {
+                ISpatialTree3D<int> tree3D = (ISpatialTree3D<int>)tree;
+                tree3D.GetElementsInRange(Vector3.zero, 1f, actual);
+                CollectionAssert.AreEquivalent(expected, actual, "Finite radius");
+                tree3D.GetElementsInRange(Vector3.zero, float.PositiveInfinity, actual);
+                CollectionAssert.AreEquivalent(expected, actual, "Infinite radius");
+                tree3D.GetElementsInBounds(finiteQuery, actual);
+                CollectionAssert.AreEquivalent(expected, actual, "Finite query bounds");
+                tree3D.GetElementsInBounds(infiniteQuery, actual);
+                CollectionAssert.AreEquivalent(expected, actual, "Infinite query bounds");
+                tree3D.GetApproximateNearestNeighbors(Vector3.zero, source.Length + 1, actual);
+            }
+            CollectionAssert.AreEqual(
+                expected,
+                actual,
+                "Nearest preserves insertion order for equidistant elements"
+            );
+        }
+
+        [TestCase("R2", 0)]
+        [TestCase("R2", 1)]
+        [TestCase("R2", 2)]
+        [TestCase("R3", 0)]
+        [TestCase("R3", 1)]
+        [TestCase("R3", 2)]
+        public void OverflowedStoredBoundsExcludeOnlyTheirSourceEntry(string variant, int axis)
+        {
+            int[] source = { 0, 1, 2 };
+            Vector3[] positions = { Vector3.zero, Vector3.zero, Vector3.zero };
+            Vector3 center = Vector3.zero;
+            center[axis] = float.MaxValue;
+            Vector3 size = Vector3.zero;
+            size[axis] = float.MaxValue;
+            Bounds[] bounds =
+            {
+                new(Vector3.zero, Vector3.zero),
+                new(center, size),
+                new(Vector3.zero, Vector3.zero),
+            };
+            Assert.IsTrue(
+                float.IsPositiveInfinity(bounds[1].max[axis]),
+                "The stored edge must overflow"
+            );
+            object tree = CreateTree(variant, source, positions, bounds, 1);
+            List<int> actual = new() { -1 };
+            Bounds query = new(Vector3.zero, Vector3.one);
+            if (tree is RTree2D<int> r2)
+            {
+                r2.GetElementsWithCentersInBounds(query, actual);
+            }
+            else
+            {
+                ((RTree3D<int>)tree).GetElementsWithCentersInBounds(query, actual);
+            }
+            CollectionAssert.AreEquivalent(new[] { 0, 2 }, actual);
+        }
+
+        [Test]
+        public void ExplicitInfiniteOctTreeBoundaryPreservesFinitePoints()
+        {
+            Vector3[] points = { Vector3.left, new(float.PositiveInfinity, 0f, 0f), Vector3.right };
+            Bounds boundary = new(
+                Vector3.zero,
+                new Vector3(float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity)
+            );
+            OctTree3D<Vector3> tree = new(points, static point => point, boundary, bucketSize: 1);
+            List<Vector3> actual = new();
+            tree.GetElementsInRange(Vector3.zero, float.PositiveInfinity, actual);
+            CollectionAssert.AreEquivalent(new[] { Vector3.left, Vector3.right }, actual);
+            tree.GetElementsInBounds(boundary, actual);
+            CollectionAssert.AreEquivalent(new[] { Vector3.left, Vector3.right }, actual);
+        }
+
+        private static bool IsThreeDimensional(string variant)
+        {
+            return variant == "Kd3Balanced"
+                || variant == "Kd3Unbalanced"
+                || variant == "Oct"
+                || variant == "R3";
+        }
+
+        private static object CreateTree(
+            string variant,
+            int[] source,
+            Vector3[] positions,
+            Bounds[] bounds,
+            int bucketSize
+        )
+        {
+            switch (variant)
+            {
+                case "Kd2Balanced":
+                case "Kd2Unbalanced":
+                    KdTree2D<int> kd2 = new(
+                        source,
+                        index => positions[index],
+                        bucketSize,
+                        variant == "Kd2Balanced"
+                    );
+                    CollectionAssert.AreEqual(source, kd2.elements, "Source snapshot");
+                    return kd2;
+                case "Quad":
+                    QuadTree2D<int> quad = new(
+                        source,
+                        index => positions[index],
+                        bucketSize: bucketSize
+                    );
+                    CollectionAssert.AreEqual(source, quad.elements, "Source snapshot");
+                    return quad;
+                case "QuadEntries":
+                    List<QuadTree2D<int>.Entry> entries = new();
+                    foreach (int index in source)
+                    {
+                        entries.Add(new QuadTree2D<int>.Entry(index, positions[index]));
+                    }
+                    QuadTree2D<int> directQuad = new(entries, bucketSize: bucketSize);
+                    CollectionAssert.AreEqual(source, directQuad.elements, "Source snapshot");
+                    return directQuad;
+                case "R2":
+                    RTree2D<int> r2 = new(source, index => bounds[index], bucketSize);
+                    CollectionAssert.AreEqual(source, r2.elements, "Source snapshot");
+                    return r2;
+                case "Kd3Balanced":
+                case "Kd3Unbalanced":
+                    KdTree3D<int> kd3 = new(
+                        source,
+                        index => positions[index],
+                        bucketSize,
+                        variant == "Kd3Balanced"
+                    );
+                    CollectionAssert.AreEqual(source, kd3.elements, "Source snapshot");
+                    return kd3;
+                case "Oct":
+                    OctTree3D<int> oct = new(
+                        source,
+                        index => positions[index],
+                        bucketSize: bucketSize
+                    );
+                    CollectionAssert.AreEqual(source, oct.elements, "Source snapshot");
+                    return oct;
+                case "R3":
+                    RTree3D<int> r3 = new(source, index => bounds[index], bucketSize);
+                    CollectionAssert.AreEqual(source, r3.elements, "Source snapshot");
+                    return r3;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(variant));
+            }
+        }
+    }
+}

--- a/Tests/Runtime/DataStructures/SpatialTreeStoredGeometryTests.cs.meta
+++ b/Tests/Runtime/DataStructures/SpatialTreeStoredGeometryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee5b6c6a1ebaa13c476c65bdfb8e49ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/features/editor-tools/editor-tools-guide.md
+++ b/docs/features/editor-tools/editor-tools-guide.md
@@ -1742,6 +1742,13 @@ Shared across the windows: folder fields accept dragged Project-window folders, 
 are remembered per tool and offered again next time, and long operations report progress in the
 console rather than blocking silently.
 
+Progress bars close even when an operation, asset save, or batch cleanup fails. This includes
+prefab checks, sprite atlas generation and source settings, sprite and texture settings, texture
+resizing, sprite reference replacement, and animation copy or delete operations. Canceling a prefab
+scan keeps findings already collected; canceling a settings batch saves the importer changes already
+processed. A processing error still stops the operation and may leave earlier changes applied.
+Reimport and generated-file side effects are not a transaction and cannot be fully reversed with Undo.
+
 ---
 
 ### What writes to disk

--- a/docs/features/spatial/spatial-tree-semantics.md
+++ b/docs/features/spatial/spatial-tree-semantics.md
@@ -130,24 +130,32 @@ The partitioning behaviour is still available, under a name that says what it do
 
 ### Invalid Input
 
-| Input                                                       | Result                                                                                                                                                                                              |
-| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Negative radius                                             | Cleared, empty                                                                                                                                                                                      |
-| `NaN` radius                                                | Cleared, empty                                                                                                                                                                                      |
-| Zero radius                                                 | Exact matches only (distance 0)                                                                                                                                                                     |
-| Zero radius on `RTree2D` / `RTree3D`                        | Elements whose box the query point touches, and only those: the distance to an element's box is compared exactly, with no epsilon widening the circle                                               |
-| `+Infinity` radius                                          | Every eligible element, without walking the grid                                                                                                                                                    |
-| Non-finite query center                                     | Cleared, empty                                                                                                                                                                                      |
-| Bounds with a `NaN` edge, or a max below its min            | Cleared, empty                                                                                                                                                                                      |
-| Zero-size bounds                                            | The elements sitting on it — for the R-trees, every element whose box touches the point, which for `p => new Bounds(p, Vector3.zero)` is `p`                                                        |
-| `count <= 0` for nearest-neighbor                           | Cleared, empty                                                                                                                                                                                      |
-| A radius above ~1.8446744e19                                | The exact answer: squaring one saturates `float`, so the distance filter falls back to double precision rather than admitting everything                                                            |
-| A stored NaN coordinate                                     | Range and nearest queries exclude entries with NaN distances. `OctTree3D` excludes NaN positions from its index; `RTree3D` excludes malformed bounds. Both retain the original `elements` snapshot. |
-| An infinite stored coordinate in an immutable tree          | Unsupported construction input: it can make node bounds invalid and hide finite entries. Validate coordinates before building the tree.                                                             |
-| A tree `boundary` with a `NaN` edge, or a max below its min | Ignored, as if it were null: `QuadTree2D` and `OctTree3D` compute their bounds from the points instead                                                                                              |
+| Input                                                       | Result                                                                                                                                                                |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Negative radius                                             | Cleared, empty                                                                                                                                                        |
+| `NaN` radius                                                | Cleared, empty                                                                                                                                                        |
+| Zero radius                                                 | Exact matches only (distance 0)                                                                                                                                       |
+| Zero radius on `RTree2D` / `RTree3D`                        | Elements whose box the query point touches, and only those: the distance to an element's box is compared exactly, with no epsilon widening the circle                 |
+| `+Infinity` radius                                          | Every eligible element, without walking the grid                                                                                                                      |
+| Non-finite query center                                     | Cleared, empty                                                                                                                                                        |
+| Bounds with a `NaN` edge, or a max below its min            | Cleared, empty                                                                                                                                                        |
+| Zero-size bounds                                            | The elements sitting on it — for the R-trees, every element whose box touches the point, which for `p => new Bounds(p, Vector3.zero)` is `p`                          |
+| `count <= 0` for nearest-neighbor                           | Cleared, empty                                                                                                                                                        |
+| A radius above ~1.8446744e19                                | The exact answer: squaring one saturates `float`, so the distance filter falls back to double precision rather than admitting everything                              |
+| A stored NaN coordinate                                     | Immutable trees exclude the entry from the index while retaining the original `elements` snapshot and source insertion identity.                                      |
+| An infinite stored coordinate in an immutable tree          | Excluded from the index without hiding finite siblings. Point positions must be finite; R-tree bounds must have finite, ordered edges, including their z edges in 2D. |
+| A tree `boundary` with a `NaN` edge, or a max below its min | Ignored, as if it were null: `QuadTree2D` and `OctTree3D` compute their bounds from the points instead                                                                |
+
+Filtering does not renumber source identities or remove entries from the public `elements` snapshot.
+The transformer is evaluated once per source element; an entirely invalid source builds an empty index.
+Finite inputs that overflow during aggregate bounds arithmetic remain a separate limitation
+([#720](https://github.com/Ambiguous-Interactive/unity-helpers/issues/720)); this validation excludes
+non-finite authored geometry and computed element edges.
 
 An explicit infinite boundary is separate from infinite stored coordinates: `OctTree3D` accepts a
 valid infinite boundary around finite points and keeps the region in one leaf when its center is nonfinite.
+Query bounds with a finite center and infinite extents remain supported by every immutable tree,
+as do positive-infinity query radii; bounds with NaN edges remain invalid.
 
 The spatial hashes reject bad construction and bad data up front rather than storing it:
 

--- a/docs/features/spatial/spatial-trees-2d-guide.md
+++ b/docs/features/spatial/spatial-trees-2d-guide.md
@@ -261,8 +261,8 @@ START: Do your objects move frequently?
   radius, or a nonfinite query center, returns that cleared empty list; a `+Infinity` radius is
   supported. Nearest-neighbor excludes NaN distances and returns `min(count, eligibleElementCount)`
   entries ordered by distance and then insertion index; _which_ equidistant elements are in that
-  set differs by family. Validate coordinates before constructing an immutable tree: infinite
-  stored coordinates can invalidate node bounds and hide finite entries. See
+  set differs by family. Constructors exclude non-finite stored positions or bounds edges from the index while
+  retaining the original `elements` snapshot and source identities. See
   [Query Contract](./spatial-tree-semantics.md#query-contract) for the full table.
 
 For deeper details, performance data, and diagrams, see:

--- a/docs/features/spatial/spatial-trees-3d-guide.md
+++ b/docs/features/spatial/spatial-trees-3d-guide.md
@@ -149,7 +149,7 @@ void Update()
 
 - Points vs. Bounds: KDTree3D/OctTree3D are point‑based; RTree3D is bounds‑based.
 - Boundary inclusion: 3D variants can differ at exact boundaries. Normalize to half‑open or add small epsilons. All three treat a bounds query's max face as inclusive, so a zero-size box still finds the points on it — including an `RTree3D` element built from `p => new Bounds(p, Vector3.zero)`, whose center is exactly `p`.
-- Results are a multiset, and the destination list is cleared exactly once. A negative or `NaN` radius, or a nonfinite query center, returns that cleared empty list; a `+Infinity` radius is supported. Nearest-neighbor excludes NaN distances and returns `min(count, eligibleElementCount)` entries ordered by distance and then insertion index. Validate coordinates before constructing an immutable tree: infinite stored coordinates can invalidate node bounds and hide finite entries. See [Query Contract](./spatial-tree-semantics.md#query-contract) for the full table.
+- Results are a multiset, and the destination list is cleared exactly once. A negative or `NaN` radius, or a nonfinite query center, returns that cleared empty list; a `+Infinity` radius is supported. Nearest-neighbor excludes NaN distances and returns `min(count, eligibleElementCount)` entries ordered by distance and then insertion index. Constructors exclude non-finite stored positions or bounds edges from the index while retaining the original `elements` snapshot and source identities. See [Query Contract](./spatial-tree-semantics.md#query-contract) for the full table.
 - For details and performance data, see:
   - [3D Performance Benchmarks](../../performance/spatial-tree-3d-performance.md)
   - [Spatial Tree Semantics](./spatial-tree-semantics.md)


### PR DESCRIPTION
**Why:** Invalid stored coordinates can make valid spatial entries disappear from queries.

**What:**

- Preserve finite entries and source identities in every immutable tree.
- Clear editor progress bars after errors and cancellation.
- Reduce Git downloads for package export jobs.

Fixes #718
Fixes #699
Fixes #705

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spatial tree construction and query eligibility changed for invalid coordinates across multiple runtime structures; editor changes are localized but touch many asset-mutating tools where partial apply on cancel remains possible.
> 
> **Overview**
> Fixes cases where **non-finite stored geometry** (NaN/Infinity positions or malformed R-tree bounds) could corrupt spatial tree bounds and hide otherwise valid entries. Immutable **Kd/Quad/Oct/R-trees** now skip those entries when building the index while keeping the public `elements` snapshot and source insertion identities unchanged; docs and semantics tables are updated to match.
> 
> **Editor batch tools** (prefab checker, sprite/texture settings, atlas generation, resizer, reference replacement, animation copy/delete, fit-texture-size) now clear `EditorUi` progress in `finally` blocks—often **before** fallible saves/disposal—so stuck progress bars do not survive errors or cancellation. `EditorUi` exposes test hooks, with integration tests covering exception and cancel paths.
> 
> Release and Unity test workflows use **shallow checkout** (`fetch-depth: 1`) where only the export tree is needed, reducing Git download size for package jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f276a57eb56c220878a6d9634b121886d3ffd7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->