### PR TITLE
Preserve exact component bindings

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -11,7 +11,7 @@ Procedural skills are in the [skills/](./skills/) directory.
 **Repository**: <https://github.com/wallstop/unity-helpers>
 **Root Namespace**: `WallstopStudios.UnityHelpers`
 
-**Design Principles**: Zero boilerplate, performance-proven (13,000+ tests, IL2CPP/WebGL compatible), DRY architecture, self-documenting code (minimal comments, descriptive names).
+**Design Principles**: Zero boilerplate, performance-proven (14,000+ tests, IL2CPP/WebGL compatible), DRY architecture, self-documenting code (minimal comments, descriptive names).
 
 ---
 

--- a/.llm/skills/create-csharp-file.md
+++ b/.llm/skills/create-csharp-file.md
@@ -338,6 +338,17 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
 
 See [integrate-optional-dependency](./integrate-optional-dependency.md) for complete patterns.
 
+### 11. Default Construction of Configuration Objects
+
+Public reference-type options, limits, or configuration objects intended to support default
+construction need a real public parameterless constructor. When a configured constructor defines
+the defaults, delegate the parameterless constructor to it with explicit intended defaults.
+An all-optional constructor permits `new Options()` but does not
+satisfy `where T : new()`; verify that contract through a generic factory test asserting the defaults.
+Apply this rule to default configuration contracts, not unrelated attributes, required-input types,
+Unity objects, structs, or resource-owning services. For structs, define what zero-initialized
+`default` means separately; it bypasses constructor logic.
+
 ---
 
 ## Post-Creation Steps (MANDATORY)

--- a/.llm/skills/defensive-editor-programming.md
+++ b/.llm/skills/defensive-editor-programming.md
@@ -79,6 +79,12 @@ the internal `EditorUi` callbacks, restoring both callbacks in `finally`
 
 ### Code Samples
 
+Dispose owned `SerializedObject` and `SerializedProperty` instances before destroying their target.
+Record ownership as each pending wrapper is created so failed initialization can release it. Cached
+wrappers need the same cleanup on invalidation and window disable; clearing a dictionary only drops
+managed references. Mixed preview caches must distinguish copied textures from Unity-owned
+`AssetPreview` textures and destroy only their own copies ([#734](https://github.com/Ambiguous-Interactive/unity-helpers/issues/734)).
+
 Detailed code patterns are in dedicated sample files:
 
 - [SerializedProperty Safety](./code-samples/editor-serialized-property-safety.md) - Safe property access, height calculation, nested property access

--- a/.llm/skills/git-staging-helpers.md
+++ b/.llm/skills/git-staging-helpers.md
@@ -66,8 +66,18 @@ Verifies git is on PATH. Throws if not found.
 Returns an object with:
 
 - `Directory` - Path to `.git` directory
-- `IndexLockPath` - Full path to `.git/index.lock`
+- `IndexLockPath` - Absolute effective index path returned by `git rev-parse --git-path index`, plus `.lock`
 - `RepositoryRoot` - Root of the repository
+
+Resolve the effective index each time repository information is requested. `git commit --only`
+gives hooks a temporary `GIT_INDEX_FILE` while the parent holds the main index lock. Check the
+temporary index's lock; never remove or wait on the parent's lock. The same rule supports alternate
+indexes and linked worktrees while retaining contention checks for their actual index writers.
+PowerShell resolves that path without requiring the index to exist, so a later `Set-Location`
+cannot redirect a captured lock path. Temporary-repository regression suites clear Git's local
+environment variables before setup: a hook's inherited `GIT_INDEX_FILE`, `GIT_DIR`, or
+`GIT_WORK_TREE` must never make a fixture stage into its caller's repository. Tests that exercise
+an alternate index set their own variables after isolation.
 
 ### `Wait-ForGitIndexLock`
 

--- a/.llm/skills/unity-mcp-fixture-runner.md
+++ b/.llm/skills/unity-mcp-fixture-runner.md
@@ -12,6 +12,15 @@ For timing, allocation and staleness gates, see
 [unity-mcp-measurement](./unity-mcp-measurement.md). For the licensed Docker legs, see
 [unity-devcontainer-testing](./unity-devcontainer-testing.md).
 
+### Match regression evidence to the required test mode
+
+When acceptance requires EditMode and PlayMode, verify that the target regression is discovered
+and passes in each requested mode. A green Editor suite does not cover an oracle selected only
+from a Runtime test assembly. Inspect assembly selection and the actual NUnit case results before
+claiming coverage. Share the oracle through runtime-capable test support with thin fixtures in
+each required assembly; let the real TestRunnerApi perform setup, parameter expansion and teardown.
+Skipped or inconclusive target cases do not satisfy the requirement, even when the overall job passes.
+
 ## The RunCommand contract, measured on 2026-08-27 (editor 6000.4.6f1)
 
 The host is the `com.unity.ai.assistant` package inside the editor (a throw stack names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add reusable protobuf read limits for encoded bytes, length-delimited fields, tag counts and nesting. See [Serialization](./docs/features/serialization/serialization.md) ([#647](https://github.com/Ambiguous-Interactive/unity-helpers/issues/647)).
 - Add opt-in exact sprite-art colliders, reusable alpha-mask reading and pixel-boundary tracing, with alpha and minimum-area controls. See [Sprite Colliders](./docs/features/inspector/utility-components.md) ([#715](https://github.com/Ambiguous-Interactive/unity-helpers/issues/715)).
 - Add editor-only sprite keyframe times and threshold-based last-motion detection, with renderer-path filtering and selectable bounds edges. See [Sprite Animation Motion](./docs/features/editor-tools/sprite-animation-motion.md) ([#717](https://github.com/Ambiguous-Interactive/unity-helpers/issues/717)).
 - Add cross-assembly WallstopProto subtypes with static dispatch, inherited private-member support, and collision checks at compilation, project assembly and startup ([#612](https://github.com/Ambiguous-Interactive/unity-helpers/issues/612)).
@@ -203,6 +204,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix exact relational component matching when `AllowInterfaces` is disabled, including concrete types that are not sealed ([#733](https://github.com/Ambiguous-Interactive/unity-helpers/issues/733)).
+- Fix editor windows and collection drawers retaining owned serialized state and copied previews after refresh, close or failed initialization; shared Unity previews remain available ([#734](https://github.com/Ambiguous-Interactive/unity-helpers/issues/734)).
 - Fix cleared runtime singletons being returned again before frame-end destruction. Immediate lookup selects a live replacement or respects `NeverCreate` ([#729](https://github.com/Ambiguous-Interactive/unity-helpers/issues/729)).
 - Fix finite extreme coordinates disappearing from spatial queries or choosing farther nearest neighbors. Immutable trees preserve accepted finite entries across overflowing bounds and distance calculations ([#720](https://github.com/Ambiguous-Interactive/unity-helpers/issues/720)).
 - Fix runtime and ScriptableObject singleton reset callbacks interrupting cleanup or recursively invoking themselves. Reset completes after callback failures and rejects worker-thread access before changing state ([#723](https://github.com/Ambiguous-Interactive/unity-helpers/issues/723)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add reusable protobuf read limits for encoded bytes, length-delimited fields, tag counts and nesting. See [Serialization](./docs/features/serialization/serialization.md) ([#647](https://github.com/Ambiguous-Interactive/unity-helpers/issues/647)).
+- Add reusable protobuf read limits for encoded bytes, length-delimited fields, tag counts and nesting, with a parameterless constructor for generic factories. See [Serialization](./docs/features/serialization/serialization.md) ([#647](https://github.com/Ambiguous-Interactive/unity-helpers/issues/647)).
 - Add opt-in exact sprite-art colliders, reusable alpha-mask reading and pixel-boundary tracing, with alpha and minimum-area controls. See [Sprite Colliders](./docs/features/inspector/utility-components.md) ([#715](https://github.com/Ambiguous-Interactive/unity-helpers/issues/715)).
 - Add editor-only sprite keyframe times and threshold-based last-motion detection, with renderer-path filtering and selectable bounds edges. See [Sprite Animation Motion](./docs/features/editor-tools/sprite-animation-motion.md) ([#717](https://github.com/Ambiguous-Interactive/unity-helpers/issues/717)).
 - Add cross-assembly WallstopProto subtypes with static dispatch, inherited private-member support, and collision checks at compilation, project assembly and startup ([#612](https://github.com/Ambiguous-Interactive/unity-helpers/issues/612)).

--- a/Editor/AnimationEventEditor.cs
+++ b/Editor/AnimationEventEditor.cs
@@ -187,11 +187,30 @@ namespace WallstopStudios.UnityHelpers.Editor
         private bool _controlFrameTime;
         private string _animationSearchString = string.Empty;
 
-        private readonly Dictionary<Sprite, Texture2D> _spriteTextureCache = new();
+        internal readonly Dictionary<Sprite, Texture2D> _spriteTextureCache = new();
+        internal readonly HashSet<Texture2D> _ownedSpriteTextures = new();
 
         private int _selectedFrameIndex = -1;
 
         private int _focusedEventIndex = -1;
+
+        private void OnDisable()
+        {
+            ReleaseSpritePreviews();
+        }
+
+        internal void ReleaseSpritePreviews()
+        {
+            foreach (Texture2D texture in _ownedSpriteTextures)
+            {
+                if (texture != null)
+                {
+                    DestroyImmediate(texture);
+                }
+            }
+            _ownedSpriteTextures.Clear();
+            _spriteTextureCache.Clear();
+        }
 
         private void OnGUI()
         {
@@ -313,7 +332,12 @@ namespace WallstopStudios.UnityHelpers.Editor
 
                 EditorGUILayout.PrefixLabel("Frame " + frame);
 
-                AnimationEventSpritePreviewRenderer.Draw(item, _viewModel, _spriteTextureCache);
+                AnimationEventSpritePreviewRenderer.Draw(
+                    item,
+                    _viewModel,
+                    _spriteTextureCache,
+                    _ownedSpriteTextures
+                );
 
                 using (new EditorGUI.IndentLevelScope())
                 {
@@ -486,9 +510,9 @@ namespace WallstopStudios.UnityHelpers.Editor
 
         private void RefreshAnimationEvents(AnimationClip clip = null)
         {
-            _spriteTextureCache.Clear();
+            ReleaseSpritePreviews();
             _focusedEventIndex = -1;
-            _viewModel.LoadClip(clip ?? _viewModel.CurrentClip);
+            _viewModel.LoadClip(clip != null ? clip : _viewModel.CurrentClip);
             _selectedFrameIndex = _viewModel.CurrentClip == null ? -1 : MaxFrameIndex;
         }
 

--- a/Editor/AnimationEventSpritePreviewRenderer.cs
+++ b/Editor/AnimationEventSpritePreviewRenderer.cs
@@ -17,10 +17,11 @@ namespace WallstopStudios.UnityHelpers.Editor
         public static void Draw(
             AnimationEventItem item,
             AnimationEventEditorViewModel viewModel,
-            Dictionary<Sprite, Texture2D> spriteTextureCache
+            Dictionary<Sprite, Texture2D> spriteTextureCache,
+            HashSet<Texture2D> ownedTextures
         )
         {
-            SetupPreviewData(item, viewModel, spriteTextureCache);
+            SetupPreviewData(item, viewModel, spriteTextureCache, ownedTextures);
 
             string spriteName = item.sprite == null ? string.Empty : item.sprite.name;
             if (item.texture != null)
@@ -44,7 +45,8 @@ namespace WallstopStudios.UnityHelpers.Editor
         private static void SetupPreviewData(
             AnimationEventItem item,
             AnimationEventEditorViewModel viewModel,
-            Dictionary<Sprite, Texture2D> spriteTextureCache
+            Dictionary<Sprite, Texture2D> spriteTextureCache,
+            HashSet<Texture2D> ownedTextures
         )
         {
             if (item.texture != null)
@@ -108,6 +110,7 @@ namespace WallstopStudios.UnityHelpers.Editor
             }
 
             Texture2D copied = CopyTexture(maybeRect.Value, sprite.texture);
+            _ = ownedTextures.Add(copied);
             item.texture = copied;
             spriteTextureCache[sprite] = copied;
         }
@@ -172,7 +175,7 @@ namespace WallstopStudios.UnityHelpers.Editor
             return lastSpriteAtOrBeforeEvent != null;
         }
 
-        private static Texture2D CopyTexture(Rect textureRect, Texture2D sourceTexture)
+        internal static Texture2D CopyTexture(Rect textureRect, Texture2D sourceTexture)
         {
             int width = Mathf.CeilToInt(textureRect.width);
             int height = Mathf.CeilToInt(textureRect.height);
@@ -182,20 +185,28 @@ namespace WallstopStudios.UnityHelpers.Editor
                 filterMode = FilterMode.Point,
             };
 
-            Vector2 offset = textureRect.position;
-            int offsetX = Mathf.CeilToInt(offset.x);
-            int offsetY = Mathf.CeilToInt(offset.y);
-            for (int x = 0; x < width; x++)
+            try
             {
-                for (int y = 0; y < height; y++)
+                Vector2 offset = textureRect.position;
+                int offsetX = Mathf.CeilToInt(offset.x);
+                int offsetY = Mathf.CeilToInt(offset.y);
+                for (int x = 0; x < width; x++)
                 {
-                    Color pixel = sourceTexture.GetPixel(offsetX + x, offsetY + y);
-                    texture.SetPixel(x, y, pixel);
+                    for (int y = 0; y < height; y++)
+                    {
+                        Color pixel = sourceTexture.GetPixel(offsetX + x, offsetY + y);
+                        texture.SetPixel(x, y, pixel);
+                    }
                 }
-            }
 
-            texture.Apply();
-            return texture;
+                texture.Apply();
+                return texture;
+            }
+            catch
+            {
+                UnityEngine.Object.DestroyImmediate(texture);
+                throw;
+            }
         }
     }
 #endif

--- a/Editor/CustomDrawers/SerializableDictionaryPropertyDrawer.cs
+++ b/Editor/CustomDrawers/SerializableDictionaryPropertyDrawer.cs
@@ -6388,7 +6388,7 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
             {
                 object clone = CloneComplexValue(pendingValue, valueType);
                 wrapper.SetValue(clone);
-                SerializedObject serialized = new(wrapper);
+                using SerializedObject serialized = new(wrapper);
                 SerializedProperty wrapperProperty = wrapper.FindValueProperty(serialized);
                 if (wrapperProperty == null)
                 {
@@ -7640,42 +7640,64 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
                 ? pending.valueWrapperProperty
                 : pending.keyWrapperProperty;
 
-            if (wrapper == null)
+            bool initialized = false;
+            try
             {
-                wrapper = ScriptableObject.CreateInstance<PendingValueWrapper>();
-                wrapper.hideFlags = PendingWrapperHideFlags;
-                serialized = null;
-                property = null;
-            }
+                if (wrapper == null)
+                {
+                    ReleasePendingWrapper(pending, isValueField);
+                    wrapper = ScriptableObject.CreateInstance<PendingValueWrapper>();
+                    if (isValueField)
+                    {
+                        pending.valueWrapper = wrapper;
+                    }
+                    else
+                    {
+                        pending.keyWrapper = wrapper;
+                    }
+                    wrapper.hideFlags = PendingWrapperHideFlags;
+                    serialized = null;
+                    property = null;
+                }
 
-            if (serialized == null)
+                if (serialized == null)
+                {
+                    serialized = new SerializedObject(wrapper);
+                    if (isValueField)
+                    {
+                        pending.valueWrapperSerialized = serialized;
+                    }
+                    else
+                    {
+                        pending.keyWrapperSerialized = serialized;
+                    }
+                    property = wrapper.FindValueProperty(serialized);
+                    if (isValueField)
+                    {
+                        pending.valueWrapperProperty = property;
+                    }
+                    else
+                    {
+                        pending.keyWrapperProperty = property;
+                    }
+                }
+
+                if (property == null)
+                {
+                    return PendingWrapperContext.Empty;
+                }
+
+                serialized.Update();
+                initialized = true;
+                return new PendingWrapperContext(wrapper, serialized, property);
+            }
+            finally
             {
-                serialized = new SerializedObject(wrapper);
-                property = wrapper.FindValueProperty(serialized);
+                if (!initialized)
+                {
+                    ReleasePendingWrapper(pending, isValueField);
+                }
             }
-
-            if (property == null)
-            {
-                ReleasePendingWrapper(pending, isValueField);
-                return PendingWrapperContext.Empty;
-            }
-
-            if (isValueField)
-            {
-                pending.valueWrapper = wrapper;
-                pending.valueWrapperSerialized = serialized;
-                pending.valueWrapperProperty = property;
-            }
-            else
-            {
-                pending.keyWrapper = wrapper;
-                pending.keyWrapperSerialized = serialized;
-                pending.keyWrapperProperty = property;
-            }
-
-            serialized.Update();
-
-            return new PendingWrapperContext(wrapper, serialized, property);
         }
 
         private static void SyncPendingWrapperManagedReference(
@@ -7694,20 +7716,22 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
             context.Serialized.Update();
         }
 
-        private static void ReleasePendingWrapper(PendingEntry pending, bool isValueField)
+        internal static void ReleasePendingWrapper(PendingEntry pending, bool isValueField)
         {
             if (pending == null)
             {
                 return;
             }
 
+            PendingValueWrapper wrapper = isValueField ? pending.valueWrapper : pending.keyWrapper;
+            SerializedObject serialized = isValueField
+                ? pending.valueWrapperSerialized
+                : pending.keyWrapperSerialized;
+            SerializedProperty property = isValueField
+                ? pending.valueWrapperProperty
+                : pending.keyWrapperProperty;
             if (isValueField)
             {
-                if (pending.valueWrapper != null)
-                {
-                    Object.DestroyImmediate(pending.valueWrapper);
-                }
-
                 pending.valueWrapper = null;
                 pending.valueWrapperSerialized = null;
                 pending.valueWrapperProperty = null;
@@ -7716,15 +7740,29 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
             }
             else
             {
-                if (pending.keyWrapper != null)
-                {
-                    Object.DestroyImmediate(pending.keyWrapper);
-                }
-
                 pending.keyWrapper = null;
                 pending.keyWrapperSerialized = null;
                 pending.keyWrapperProperty = null;
                 pending.keyWrapperDirty = true;
+            }
+
+            try
+            {
+                property?.Dispose();
+            }
+            finally
+            {
+                try
+                {
+                    serialized?.Dispose();
+                }
+                finally
+                {
+                    if (wrapper != null)
+                    {
+                        Object.DestroyImmediate(wrapper);
+                    }
+                }
             }
         }
 

--- a/Editor/CustomDrawers/SerializableSetPropertyDrawer.cs
+++ b/Editor/CustomDrawers/SerializableSetPropertyDrawer.cs
@@ -2698,7 +2698,7 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
             pending.valueWrapperDirty = false;
         }
 
-        private static PendingWrapperContext EnsurePendingWrapper(
+        internal static PendingWrapperContext EnsurePendingWrapper(
             PendingEntry pending,
             Type elementType
         )
@@ -2712,49 +2712,77 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
             SerializedObject serialized = pending.valueWrapperSerialized;
             SerializedProperty property = pending.valueWrapperProperty;
 
-            if (wrapper == null)
+            bool initialized = false;
+            try
             {
-                wrapper = ScriptableObject.CreateInstance<PendingValueWrapper>();
-                wrapper.hideFlags = HideFlags.HideAndDontSave;
-                serialized = null;
-                property = null;
-            }
+                if (wrapper == null)
+                {
+                    ReleasePendingWrapper(pending);
+                    wrapper = ScriptableObject.CreateInstance<PendingValueWrapper>();
+                    pending.valueWrapper = wrapper;
+                    wrapper.hideFlags = HideFlags.HideAndDontSave;
+                    serialized = null;
+                    property = null;
+                }
 
-            if (serialized == null)
+                if (serialized == null)
+                {
+                    serialized = new SerializedObject(wrapper);
+                    pending.valueWrapperSerialized = serialized;
+                    property = wrapper.FindValueProperty(serialized);
+                    pending.valueWrapperProperty = property;
+                }
+
+                if (property == null)
+                {
+                    return PendingWrapperContext.Empty;
+                }
+
+                serialized.Update();
+                initialized = true;
+                return new PendingWrapperContext(wrapper, serialized, property);
+            }
+            finally
             {
-                serialized = new SerializedObject(wrapper);
-                property = wrapper.FindValueProperty(serialized);
+                if (!initialized)
+                {
+                    ReleasePendingWrapper(pending);
+                }
             }
-
-            if (property == null)
-            {
-                ReleasePendingWrapper(pending);
-                return PendingWrapperContext.Empty;
-            }
-
-            pending.valueWrapper = wrapper;
-            pending.valueWrapperSerialized = serialized;
-            pending.valueWrapperProperty = property;
-            serialized.Update();
-            return new PendingWrapperContext(wrapper, serialized, property);
         }
 
-        private static void ReleasePendingWrapper(PendingEntry pending)
+        internal static void ReleasePendingWrapper(PendingEntry pending)
         {
             if (pending == null)
             {
                 return;
             }
 
-            if (pending.valueWrapper != null)
-            {
-                Object.DestroyImmediate(pending.valueWrapper);
-            }
-
+            PendingValueWrapper wrapper = pending.valueWrapper;
+            SerializedObject serialized = pending.valueWrapperSerialized;
+            SerializedProperty property = pending.valueWrapperProperty;
             pending.valueWrapper = null;
             pending.valueWrapperSerialized = null;
             pending.valueWrapperProperty = null;
             pending.valueWrapperDirty = true;
+            try
+            {
+                property?.Dispose();
+            }
+            finally
+            {
+                try
+                {
+                    serialized?.Dispose();
+                }
+                finally
+                {
+                    if (wrapper != null)
+                    {
+                        Object.DestroyImmediate(wrapper);
+                    }
+                }
+            }
         }
 
         internal bool TryCommitPendingEntry(
@@ -7325,7 +7353,7 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
             }
         }
 
-        private readonly struct PendingWrapperContext
+        internal readonly struct PendingWrapperContext
         {
             public static readonly PendingWrapperContext Empty = new(null, null, null);
 

--- a/Editor/CustomDrawers/WInLineEditorDrawer.cs
+++ b/Editor/CustomDrawers/WInLineEditorDrawer.cs
@@ -818,6 +818,7 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
         {
             Editor editor = InLineEditorShared.GetOrCreateEditor(value);
             SerializedObject analysisObject = GetSerializedObjectForAnalysis(editor, value);
+            using SerializedObject ownedAnalysisObject = editor == null ? analysisObject : null;
             bool hasSerializedData = analysisObject != null;
             bool hasSimpleLayout =
                 hasSerializedData && SerializedObjectHasOnlySimpleProperties(analysisObject);
@@ -1172,6 +1173,7 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomDrawers
             sb.AppendLine($"--- Inspector Height ---");
             Editor editor = InLineEditorShared.GetOrCreateEditor(value);
             SerializedObject analysisObject = GetSerializedObjectForAnalysis(editor, value);
+            using SerializedObject ownedAnalysisObject = editor == null ? analysisObject : null;
             bool hasSerializedData = analysisObject != null;
             bool hasSimpleLayout =
                 hasSerializedData && SerializedObjectHasOnlySimpleProperties(analysisObject);

--- a/Editor/FitTextureSizeWindow.cs
+++ b/Editor/FitTextureSizeWindow.cs
@@ -63,6 +63,7 @@ namespace WallstopStudios.UnityHelpers.Editor
         internal List<Object> _textureSourcePaths = new();
         private Vector2 _scrollPosition = Vector2.zero;
         private SerializedObject _serializedObject;
+        internal SerializedObject SerializedStateForTesting => _serializedObject;
         private SerializedProperty _textureSourcePathsProperty;
         private int _potentialChangeCount = -1;
         private int _potentialGrowCount;
@@ -120,6 +121,7 @@ namespace WallstopStudios.UnityHelpers.Editor
 
         private void OnEnable()
         {
+            ReleaseSerializedState();
             _serializedObject = new SerializedObject(this);
             _textureSourcePathsProperty = _serializedObject.FindProperty(
                 nameof(_textureSourcePaths)
@@ -142,6 +144,18 @@ namespace WallstopStudios.UnityHelpers.Editor
                 _textureSourcePaths.Add(defaultFolder);
                 _serializedObject.Update();
             }
+        }
+
+        private void OnDisable()
+        {
+            ReleaseSerializedState();
+        }
+
+        private void ReleaseSerializedState()
+        {
+            _textureSourcePathsProperty = null;
+            _serializedObject?.Dispose();
+            _serializedObject = null;
         }
 
         private void OnGUI()

--- a/Editor/Settings/UnityHelpersSettings.cs
+++ b/Editor/Settings/UnityHelpersSettings.cs
@@ -4886,7 +4886,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Settings
                 _waitInstructionBufferMaxDistinctEntries
             );
 
-            SerializedObject assetSerialized = new(asset);
+            using SerializedObject assetSerialized = new(asset);
             SerializedProperty applyOnLoadProperty = assetSerialized.FindProperty(
                 UnityHelpersBufferSettingsAsset.ApplyOnLoadPropertyName
             );

--- a/Editor/Sprites/ScriptableSpriteAtlasEditor.cs
+++ b/Editor/Sprites/ScriptableSpriteAtlasEditor.cs
@@ -105,13 +105,38 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             LoadAtlasConfigs();
         }
 
+        private void OnDisable()
+        {
+            ReleaseSerializedConfigs();
+            _atlasConfigs.Clear();
+            _scanResultsCache.Clear();
+            _foldoutStates.Clear();
+        }
+
+        private void ReleaseSerializedConfigs()
+        {
+            foreach (SerializedObject serialized in _serializedConfigs.Values)
+            {
+                serialized?.Dispose();
+            }
+            _serializedConfigs.Clear();
+        }
+
+        internal SerializedObject GetSerializedConfig(ScriptableSpriteAtlas config)
+        {
+            return _serializedConfigs.GetOrAdd(
+                config,
+                static newConfig => new SerializedObject(newConfig)
+            );
+        }
+
         internal void LoadAtlasConfigs()
         {
             _atlasConfigs.Clear();
             Dictionary<ScriptableSpriteAtlas, ScanResult> existingScanCache = new(
                 _scanResultsCache
             );
-            _serializedConfigs.Clear();
+            ReleaseSerializedConfigs();
             _scanResultsCache.Clear();
 
             string[] guids = AssetDatabase.FindAssets("t:ScriptableSpriteAtlas");
@@ -136,11 +161,25 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                     {
                         _scanResultsCache.TryAdd(config, _ => new ScanResult());
                     }
-                    _serializedConfigs.TryAdd(config, newConfig => new SerializedObject(newConfig));
+                    _ = GetSerializedConfig(config);
                     _foldoutStates.TryAdd(config, true);
                 }
             }
             _atlasConfigs = _atlasConfigs.OrderBy(c => c.name).ToList();
+            using (Buffers<ScriptableSpriteAtlas>.List.Get(out List<ScriptableSpriteAtlas> removed))
+            {
+                foreach (ScriptableSpriteAtlas config in _foldoutStates.Keys)
+                {
+                    if (!_serializedConfigs.ContainsKey(config))
+                    {
+                        removed.Add(config);
+                    }
+                }
+                foreach (ScriptableSpriteAtlas config in removed)
+                {
+                    _ = _foldoutStates.Remove(config);
+                }
+            }
         }
 
         private void OnGUI()
@@ -247,10 +286,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 if (expanded)
                 {
                     using EditorGUI.IndentLevelScope indentScope = new();
-                    SerializedObject serializedConfig = _serializedConfigs.GetOrAdd(
-                        config,
-                        static newConfig => new SerializedObject(newConfig)
-                    );
+                    SerializedObject serializedConfig = GetSerializedConfig(config);
                     serializedConfig.Update();
                     EditorGUI.BeginChangeCheck();
 
@@ -1223,7 +1259,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 return;
             }
 
-            SerializedObject so = new(config);
+            using SerializedObject so = new(config);
             SerializedProperty spritesListProp = so.FindProperty(
                 nameof(ScriptableSpriteAtlas.spritesToPack)
             );
@@ -1276,7 +1312,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 return;
             }
 
-            SerializedObject so = new(config);
+            using SerializedObject so = new(config);
             SerializedProperty spritesListProp = so.FindProperty(
                 nameof(ScriptableSpriteAtlas.spritesToPack)
             );
@@ -1726,7 +1762,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                 return;
             }
 
-            SerializedObject so = new(config);
+            using SerializedObject so = new(config);
             SerializedProperty spritesListProp = so.FindProperty(
                 nameof(ScriptableSpriteAtlas.spritesToPack)
             );

--- a/Editor/Sprites/SpriteCropper.cs
+++ b/Editor/Sprites/SpriteCropper.cs
@@ -468,7 +468,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                                     continue;
                                 }
                                 bool objectModified = false;
-                                SerializedObject so = new(o);
+                                using SerializedObject so = new(o);
                                 SerializedProperty it = so.GetIterator();
                                 bool enter = true;
                                 while (it.NextVisible(enter))

--- a/Editor/Sprites/SpriteSheetExtractor.cs
+++ b/Editor/Sprites/SpriteSheetExtractor.cs
@@ -7841,7 +7841,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
                                 continue;
                             }
 
-                            SerializedObject so = new(o);
+                            using SerializedObject so = new(o);
                             SerializedProperty it = so.GetIterator();
                             bool enter = true;
                             while (it.NextVisible(enter))

--- a/Generator~/WallstopStudios.UnityHelpers.EditorTestCheck/WallstopStudios.UnityHelpers.EditorTestCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.EditorTestCheck/WallstopStudios.UnityHelpers.EditorTestCheck.csproj
@@ -7,7 +7,7 @@
     Why this exists. Three check projects existed and between them they missed one tree:
     `TypeCheck` compiles `Runtime/**`, `EditorCheck` compiles `Runtime/**` + `Editor/**`, and
     `TestCheck` compiles `Runtime/**` + `Tests/Core/**` + `Tests/Runtime/**`. NOTHING compiled
-    `Tests/Editor/**` - 655 files across 28 feature-scoped assemblies - so an editmode fixture was
+    `Tests/Editor/**` - 807 files across 28 feature-scoped assemblies - so an editmode fixture was
     type-checked by exactly one thing, a Unity matrix leg roughly fifty minutes away. It has been
     paid for: `WPROTO044` on `FloatListCache` in
     `Tests/Editor/CustomDrawers/TestTypes/NestedCollectionSerializationTypes.cs` (#613) was the one
@@ -68,7 +68,7 @@
 
     ================================ WHAT IT COMPILES ================================
 
-    614 of the 655 files under `Tests/Editor/`, plus the four trees they bind:
+    764 of the 807 files under `Tests/Editor/`, plus the four trees they bind:
 
       * `Runtime/**` and `Editor/**`, with TypeCheck's and EditorCheck's exclusions, because every
         editmode asmdef references `WallstopStudios.UnityHelpers` and all but three reference
@@ -125,7 +125,7 @@
 
     ============================ WHAT IT DOES NOT COVER ============================
 
-    41 of the 655 files under `Tests/Editor/` are excluded, in FOUR groups, every one of them
+    43 of the 807 files under `Tests/Editor/` are excluded, in FIVE groups, every one of them
     removed ONE PER LINE WITH ITS REASON below rather than through a semicolon-packed `Exclude`, so
     each reason travels with the exclusion it explains. Not one of them is excluded because the
     fixture is wrong:
@@ -145,8 +145,11 @@
          `UnityEngine.Texture2D`. `UnityEngine.Modules` publishes the PLAYER reference assemblies, so
          the member is absent here and present in every editor, including 2021.3. Six bind it
          directly; four are pure cascades of the two shared fixtures among those six.
-      4. 2 files that bind `FitTextureSizeWindow`, which EditorCheck excludes because
-         `TextureImporter.GetSourceTextureWidthAndHeight` postdates 2021.1.
+      4. 3 files that bind `FitTextureSizeWindow` or `AnimationEventEditor`, which EditorCheck
+         excludes because their APIs postdate 2021.1. Native ownership tests cannot bind the
+         name-only animation shim.
+      5. 1 uGUI cascade, `MatchColliderToSpriteEditorTests`, whose component and custom editor
+         are excluded from the source projects because their UI references are unavailable here.
 
     Also not covered, deliberately:
 
@@ -382,15 +385,15 @@
     <Compile Include="$(RepoRoot)/Tests/Runtime/TestTypes/**/*.cs" />
     <Compile Include="$(RepoRoot)/Tests/Runtime/TestDoubles/**/*.cs" />
     <!--
-      The tree this project exists for: 614 of the 655 files under `Tests/Editor/`. GROUP 1 of the
-      four exclusion groups is the only one expressed as an `Exclude`, because it is a whole
+      The tree this project exists for: 764 of the 807 files under `Tests/Editor/`. GROUP 1 of the
+      five exclusion groups is the only one expressed as an `Exclude`, because it is a whole
       directory with one reason rather than a list of files with their own.
     -->
     <Compile
       Include="$(RepoRoot)/Tests/Editor/**/*.cs"
       Exclude="$(RepoRoot)/Tests/Editor/Integrations/**/*.cs"
     />
-    <!-- CASCADE ONLY. Exercises the uGUI-dependent component and custom editor excluded above. -->
+    <!-- GROUP 5, 1 file: CASCADE ONLY. Exercises the uGUI-dependent component and custom editor excluded above. -->
     <Compile Remove="$(RepoRoot)/Tests/Editor/Utils/MatchColliderToSpriteEditorTests.cs" />
     <!--
       GROUP 2, 22 files: CASCADE ONLY off the two editor drawers removed above, which are themselves
@@ -472,12 +475,15 @@
     <!-- CASCADE ONLY: names `SharedSpriteTestFixtures`. -->
     <Compile Remove="$(RepoRoot)/Tests/Editor/Sprites/SpriteSheetExtractor/SpriteTestAssemblySetup.cs" />
     <!--
-      GROUP 4, 2 files: CASCADE ONLY off `Editor/FitTextureSizeWindow.cs`, removed above because
+      GROUP 4, 3 files: cascade off the native windows removed above because
       `TextureImporter.GetSourceTextureWidthAndHeight` postdates the 2021.1.14 editor pin. The window
       declares both `FitTextureSizeWindow` and the `FitMode` enum these two bind.
     -->
     <Compile Remove="$(RepoRoot)/Tests/Editor/Windows/FitTextureSizeMathTests.cs" />
     <Compile Remove="$(RepoRoot)/Tests/Editor/Windows/FitTextureSizeWindowTests.cs" />
+    <!-- Native window lifetimes bind both excluded FitTextureSizeWindow and AnimationEventEditor.
+         Run these fixtures in Unity; the name-only animation shim cannot verify ownership. -->
+    <Compile Remove="$(RepoRoot)/Tests/Editor/EditorWindowNativeResourceTests.cs" />
   </ItemGroup>
   <!--
     Both pins announce themselves on every compile, for the reason ../UnityReferenceAssemblies.props

--- a/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/WallstopStudios.UnityHelpers.Proto.Generator.Tests.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.Proto.Generator.Tests/WallstopStudios.UnityHelpers.Proto.Generator.Tests.csproj
@@ -33,6 +33,7 @@
          dimension through them, so the harness needs the real file rather than a stand-in. -->
     <Compile Include="$(RepoRoot)/Runtime/Core/Serialization/SerializationCapacityLimits.cs" />
     <Compile Include="$(RepoRoot)/Tests/Runtime/Serialization/WProtoEnumFormatterTests.cs" />
+    <Compile Include="$(RepoRoot)/Tests/Runtime/Serialization/WProtoReadLimitsTests.cs" />
     <!-- SerializableValueTuple implements it explicitly, so the file is not optional here. This
          project names its Runtime sources one by one rather than globbing, which is why a new
          dependency of one of them fails HERE and nowhere else. -->

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Unity Helpers provides tested utilities for common Unity patterns. Benchmarks sh
 - 🎮 **Designer-friendly** effects system (buffs/debuffs as ScriptableObjects)
 - 🌳 **O(log n)** spatial queries instead of O(n) loops
 - 🛠️ **20+ editor tools** that automate sprite/animation workflows
-- ✅ **13,000+ tests**
+- ✅ **14,000+ tests**
 
 ---
 
@@ -378,7 +378,7 @@ Common Unity development patterns like GetComponent calls, spatial queries, and 
 **Built for Real Projects:**
 
 - ✅ **Tested** in shipped commercial games
-- ✅ **13,000+ automated tests** catch edge cases before you hit them
+- ✅ **14,000+ automated tests** catch edge cases before you hit them
 - ✅ **Zero external dependencies**: protobuf-net is bundled for binary serialization
 - ✅ **IL2CPP/WebGL ready** with optimized SINGLE_THREADED paths
 - ✅ **MIT Licensed** - use freely in commercial projects

--- a/Runtime/Core/Attributes/BaseRelationalComponentAttribute.cs
+++ b/Runtime/Core/Attributes/BaseRelationalComponentAttribute.cs
@@ -107,7 +107,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
 
         /// <summary>
         /// When true (default), allows searching by interface or base type and resolves matching components.
-        /// Set to false to restrict assignment to exact concrete component types only.
+        /// Set to false to match only the exact concrete type, including nonsealed types; interfaces and derived types are excluded.
         /// </summary>
         public bool AllowInterfaces { get; set; } = true;
     }
@@ -347,7 +347,10 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
                             resolvedElementType.IsInterface
                             || (
                                 !resolvedElementType.IsSealed
-                                && resolvedElementType != typeof(Component)
+                                && (
+                                    resolvedElementType != typeof(Component)
+                                    || !attribute.AllowInterfaces
+                                )
                             )
                         );
 
@@ -419,7 +422,10 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
                     elementType != null
                     && (
                         elementType.IsInterface
-                        || (!elementType.IsSealed && elementType != typeof(Component))
+                        || (
+                            !elementType.IsSealed
+                            && (elementType != typeof(Component) || !attribute.AllowInterfaces)
+                        )
                     );
 
                 FilterParameters filters = new(attribute);
@@ -675,7 +681,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
                 return 0;
             }
 
-            if (isInterface && !attribute.AllowInterfaces)
+            if (elementType.IsInterface && !attribute.AllowInterfaces)
             {
                 components.Clear();
                 return 0;
@@ -754,20 +760,22 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
         )
         {
             bool requiresPostProcessing = filters.RequiresPostProcessing;
+            bool requiresExactType = !allowInterfaces && !elementType.IsSealed;
 
-            if (isInterface && !allowInterfaces)
+            if (elementType.IsInterface && !allowInterfaces)
             {
                 singleComponent = default;
                 return false;
             }
 
-            if (!requiresPostProcessing && !isInterface)
+            if (!requiresPostProcessing && !isInterface && !requiresExactType)
             {
                 return component.TryGetComponent(elementType, out singleComponent);
             }
 
             if (
                 component.TryGetComponent(elementType, out singleComponent)
+                && (!requiresExactType || singleComponent.GetType() == elementType)
                 && (
                     !requiresPostProcessing
                     || PassesStateAndFilters(singleComponent, filters, filterDisabledComponents)
@@ -780,7 +788,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
             if (scratch != null)
             {
                 // Unity clears caller-buffer component queries, including zero-match results.
-                component.GetComponents(elementType, scratch);
+                GetComponentsOfType(component, elementType, isInterface, allowInterfaces, scratch);
                 return TryFirstMatchingComponent(
                     scratch,
                     filters,
@@ -792,7 +800,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
             using PooledResource<List<Component>> pooled = Buffers<Component>.List.Get(
                 out List<Component> components
             );
-            component.GetComponents(elementType, components);
+            GetComponentsOfType(component, elementType, isInterface, allowInterfaces, components);
             return TryFirstMatchingComponent(
                 components,
                 filters,
@@ -809,8 +817,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
             List<Component> buffer
         )
         {
-            // Unity type queries resolve interfaces and base classes directly; no managed membership pass is needed.
-            if (isInterface && !allowInterfaces)
+            if (elementType.IsInterface && !allowInterfaces)
             {
                 buffer.Clear();
                 return buffer;
@@ -818,6 +825,22 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
 
             // Unity clears caller-buffer component queries, including zero-match results.
             component.GetComponents(elementType, buffer);
+            if (!allowInterfaces && !elementType.IsSealed)
+            {
+                int writeIndex = 0;
+                for (int index = 0; index < buffer.Count; index++)
+                {
+                    Component candidate = buffer[index];
+                    if (candidate != null && candidate.GetType() == elementType)
+                    {
+                        buffer[writeIndex++] = candidate;
+                    }
+                }
+                if (writeIndex < buffer.Count)
+                {
+                    buffer.RemoveRange(writeIndex, buffer.Count - writeIndex);
+                }
+            }
             return buffer;
         }
 

--- a/Runtime/Core/Attributes/ParentComponentAttribute.cs
+++ b/Runtime/Core/Attributes/ParentComponentAttribute.cs
@@ -586,7 +586,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
         )
         {
             buffer.Clear();
-            if (isInterface && attribute.AllowInterfaces)
+            if (isInterface)
             {
                 Transform current = root;
                 int depth = 0;

--- a/Runtime/Core/Attributes/SiblingComponentAttribute.cs
+++ b/Runtime/Core/Attributes/SiblingComponentAttribute.cs
@@ -312,7 +312,7 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
         {
             SiblingComponentAttribute attribute = metadata.attribute;
 
-            if (metadata.isInterface && !attribute.AllowInterfaces)
+            if (metadata.elementType.IsInterface && !attribute.AllowInterfaces)
             {
                 return false;
             }

--- a/Runtime/Core/Serialization/WallstopProto/WProtoFacade.cs
+++ b/Runtime/Core/Serialization/WallstopProto/WProtoFacade.cs
@@ -148,12 +148,28 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// <paramref name="data"/>. This is the <b>only</b> exception this method raises for a
         /// malformed, truncated or hostile payload, and the fuzz suite asserts it: a corrupt save
         /// file has to arrive as one catchable error rather than as whatever the byte that broke
-        /// happened to break. See <see cref="TryDeserializeAs{T}"/> for why it is not reported as
+        /// happened to break. See <see cref="TryDeserializeAs{T}(ReadOnlySpan{byte}, Type, out T)"/> for why it is not reported as
         /// <c>false</c>.
         /// </exception>
         public static bool TryDeserialize<T>(ReadOnlySpan<byte> data, out T value)
         {
             return TryDeserializeAs(data, typeof(T), out value);
+        }
+
+        /// <summary>Deserializes a registered type using the supplied wire limits.</summary>
+        /// <typeparam name="T">The declared type.</typeparam>
+        /// <param name="data">The payload.</param>
+        /// <param name="limits">Immutable per-region limits; null uses the default limits.</param>
+        /// <param name="value">Receives the decoded value, or default when unhandled.</param>
+        /// <returns>True when WallstopProto served the request; false only for an unregistered type.</returns>
+        /// <exception cref="InvalidOperationException">The registered formatter refuses the payload or its limits.</exception>
+        public static bool TryDeserialize<T>(
+            ReadOnlySpan<byte> data,
+            WProtoReadLimits limits,
+            out T value
+        )
+        {
+            return TryDeserializeAs(data, typeof(T), limits, out value);
         }
 
         /// <summary>
@@ -179,18 +195,37 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// </remarks>
         public static bool TryDeserializeAs<T>(ReadOnlySpan<byte> data, Type concrete, out T value)
         {
+            return TryDeserializeAs(data, concrete, null, out value);
+        }
+
+        /// <summary>Deserializes a registered concrete type using the supplied wire limits.</summary>
+        /// <typeparam name="T">The declared type.</typeparam>
+        /// <param name="data">The payload.</param>
+        /// <param name="concrete">The requested concrete type.</param>
+        /// <param name="limits">Immutable per-region limits; null uses the default limits.</param>
+        /// <param name="value">Receives the decoded value, or default when unhandled.</param>
+        /// <returns>True when WallstopProto served the request; false only for an unregistered type.</returns>
+        /// <exception cref="InvalidOperationException">The registered formatter refuses the payload or its limits.</exception>
+        public static bool TryDeserializeAs<T>(
+            ReadOnlySpan<byte> data,
+            Type concrete,
+            WProtoReadLimits limits,
+            out T value
+        )
+        {
             if (!TryResolveForRead(concrete, out IWProtoFormatter<T> formatter))
             {
                 value = default;
                 return false;
             }
 
-            WProtoReader reader = new WProtoReader(data);
+            WProtoReader reader = new WProtoReader(data, limits);
             WProtoReader expected = reader;
             try
             {
                 if (
-                    WProtoReader.ReadCompleted(
+                    !reader.Malformed
+                    && WProtoReader.ReadCompleted(
                         formatter.TryRead(ref reader, out value),
                         in reader,
                         in expected

--- a/Runtime/Core/Serialization/WallstopProto/WProtoReadLimits.cs
+++ b/Runtime/Core/Serialization/WallstopProto/WProtoReadLimits.cs
@@ -1,0 +1,50 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
+{
+    /// <summary>Configures immutable wire-size, field-count, and recursion limits for a read.</summary>
+    /// <remarks>
+    /// Limits apply to each reader region, including merged sub-messages. Field counts include
+    /// unknown and duplicate tags and group terminators, but not untagged packed elements.
+    /// These limits bound encoded input, not the size of objects a custom formatter constructs.
+    /// </remarks>
+    public sealed class WProtoReadLimits
+    {
+        internal static readonly WProtoReadLimits Default = new WProtoReadLimits();
+
+        /// <summary>Creates limits, treating negative values as zero and capping nesting at 64.</summary>
+        /// <param name="maximumMessageBytes">Maximum bytes in a root or nested reader region.</param>
+        /// <param name="maximumLengthDelimitedBytes">Maximum bytes in any length-delimited field.</param>
+        /// <param name="maximumFieldCount">Maximum tags read in one region, including skipped groups.</param>
+        /// <param name="maximumNestingDepth">Maximum combined sub-message and group depth.</param>
+        public WProtoReadLimits(
+            int maximumMessageBytes = int.MaxValue,
+            int maximumLengthDelimitedBytes = int.MaxValue,
+            int maximumFieldCount = int.MaxValue,
+            int maximumNestingDepth = WProtoReader.MaxNestingDepth
+        )
+        {
+            MaximumMessageBytes = maximumMessageBytes < 0 ? 0 : maximumMessageBytes;
+            MaximumLengthDelimitedBytes =
+                maximumLengthDelimitedBytes < 0 ? 0 : maximumLengthDelimitedBytes;
+            MaximumFieldCount = maximumFieldCount < 0 ? 0 : maximumFieldCount;
+            MaximumNestingDepth =
+                maximumNestingDepth < 0 ? 0
+                : WProtoReader.MaxNestingDepth < maximumNestingDepth ? WProtoReader.MaxNestingDepth
+                : maximumNestingDepth;
+        }
+
+        /// <summary>Maximum encoded bytes in a root or nested reader region.</summary>
+        public int MaximumMessageBytes { get; }
+
+        /// <summary>Maximum bytes in a length-delimited field, including unknown and packed fields.</summary>
+        public int MaximumLengthDelimitedBytes { get; }
+
+        /// <summary>Maximum tags in one reader region, including duplicate and unknown tags.</summary>
+        public int MaximumFieldCount { get; }
+
+        /// <summary>Maximum combined sub-message and group depth, never above 64.</summary>
+        public int MaximumNestingDepth { get; }
+    }
+}

--- a/Runtime/Core/Serialization/WallstopProto/WProtoReadLimits.cs
+++ b/Runtime/Core/Serialization/WallstopProto/WProtoReadLimits.cs
@@ -13,6 +13,10 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
     {
         internal static readonly WProtoReadLimits Default = new WProtoReadLimits();
 
+        /// <summary>Creates default wire limits with nesting bounded to 64.</summary>
+        public WProtoReadLimits()
+            : this(int.MaxValue, int.MaxValue, int.MaxValue, WProtoReader.MaxNestingDepth) { }
+
         /// <summary>Creates limits, treating negative values as zero and capping nesting at 64.</summary>
         /// <param name="maximumMessageBytes">Maximum bytes in a root or nested reader region.</param>
         /// <param name="maximumLengthDelimitedBytes">Maximum bytes in any length-delimited field.</param>

--- a/Runtime/Core/Serialization/WallstopProto/WProtoReadLimits.cs.meta
+++ b/Runtime/Core/Serialization/WallstopProto/WProtoReadLimits.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 026359b7bad0cb1ec15a647835f67f14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Core/Serialization/WallstopProto/WProtoReader.cs
+++ b/Runtime/Core/Serialization/WallstopProto/WProtoReader.cs
@@ -44,6 +44,8 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
 
         private readonly ReadOnlySpan<byte> _buffer;
         private readonly int _depth;
+        private readonly WProtoReadLimits _limits;
+        private int _fieldCount;
         private int _position;
         private bool _malformed;
 
@@ -52,7 +54,14 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// </summary>
         /// <param name="buffer">The encoded bytes; an empty span reads as an empty message.</param>
         public WProtoReader(ReadOnlySpan<byte> buffer)
-            : this(buffer, 0) { }
+            : this(buffer, 0, WProtoReadLimits.Default) { }
+
+        /// <summary>Initializes a reader with limits checked before consuming fields or creating nested readers.</summary>
+        /// <param name="buffer">The encoded bytes.</param>
+        /// <param name="limits">Immutable per-region limits; null uses the default limits.</param>
+        /// <remarks>A region exceeding the byte limit starts malformed, with no bytes consumed.</remarks>
+        public WProtoReader(ReadOnlySpan<byte> buffer, WProtoReadLimits limits)
+            : this(buffer, 0, limits ?? WProtoReadLimits.Default) { }
 
         /// <summary>
         /// Initializes a reader over a sub-message payload already carved out of <paramref name="parent"/>.
@@ -76,20 +85,26 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// </remarks>
         public WProtoReader(ReadOnlySpan<byte> buffer, in WProtoReader parent)
         {
-            bool exhausted = parent._malformed || MaxNestingDepth <= parent._depth;
+            _limits = parent._limits ?? WProtoReadLimits.Default;
+            bool exhausted = parent._malformed || _limits.MaximumNestingDepth <= parent._depth;
             _buffer = exhausted ? default : buffer;
-            _depth = exhausted ? MaxNestingDepth : parent._depth + 1;
+            _depth = exhausted ? _limits.MaximumNestingDepth : parent._depth + 1;
             _position = 0;
-            _malformed = exhausted;
+            _fieldCount = 0;
+            _malformed = exhausted || _limits.MaximumMessageBytes < buffer.Length;
         }
 
-        private WProtoReader(ReadOnlySpan<byte> buffer, int depth)
+        private WProtoReader(ReadOnlySpan<byte> buffer, int depth, WProtoReadLimits limits)
         {
             _buffer = buffer;
             _depth = depth;
+            _limits = limits;
             _position = 0;
-            _malformed = false;
+            _fieldCount = 0;
+            _malformed = limits.MaximumMessageBytes < buffer.Length;
         }
+
+        private WProtoReadLimits Limits => _limits ?? WProtoReadLimits.Default;
 
         /// <summary>
         /// How many enclosing sub-messages this reader sits inside; 0 for a top-level message.
@@ -117,6 +132,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// <param name="wireType">Receives the wire type, or -1 on failure.</param>
         /// <returns><c>true</c> when a valid key was read; <c>false</c> at end of input or on a malformed key.</returns>
         /// <remarks>
+        /// Reaching the configured field count refuses the next tag before consuming it.
         /// A clean end of input returns <c>false</c> without latching <see cref="Malformed"/>, so
         /// <c>while (reader.TryReadTag(...))</c> terminates normally on a well-formed message.
         /// </remarks>
@@ -124,6 +140,14 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         {
             if (_malformed || End)
             {
+                fieldNumber = 0;
+                wireType = -1;
+                return false;
+            }
+
+            if (Limits.MaximumFieldCount <= _fieldCount)
+            {
+                _malformed = true;
                 fieldNumber = 0;
                 wireType = -1;
                 return false;
@@ -147,6 +171,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
                 return false;
             }
 
+            _fieldCount++;
             fieldNumber = number;
             wireType = type;
             return true;
@@ -482,20 +507,20 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// </remarks>
         public bool TryReadMessage(out WProtoReader nested)
         {
-            if (MaxNestingDepth <= _depth)
+            if (Limits.MaximumNestingDepth <= _depth)
             {
                 _malformed = true;
-                nested = new WProtoReader(default, MaxNestingDepth);
+                nested = new WProtoReader(default, _depth, Limits) { _malformed = true };
                 return false;
             }
 
             if (!TryReadBytes(out ReadOnlySpan<byte> payload))
             {
-                nested = new WProtoReader(default, _depth + 1);
+                nested = new WProtoReader(default, _depth + 1, Limits) { _malformed = true };
                 return false;
             }
 
-            nested = new WProtoReader(payload, _depth + 1);
+            nested = new WProtoReader(payload, _depth + 1, Limits);
             return true;
         }
 
@@ -524,11 +549,11 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         {
             if (!TryReadBytes(out ReadOnlySpan<byte> payload))
             {
-                packed = new WProtoReader(default, _depth);
+                packed = new WProtoReader(default, _depth, Limits) { _malformed = true };
                 return false;
             }
 
-            packed = new WProtoReader(payload, _depth);
+            packed = new WProtoReader(payload, _depth, Limits);
             return true;
         }
 
@@ -630,6 +655,13 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
                 return false;
             }
 
+            if (nested.Malformed)
+            {
+                _malformed = true;
+                value = default;
+                return false;
+            }
+
             WProtoReader expected = nested;
             if (ReadCompleted(formatter.TryRead(ref nested, out value), in nested, in expected))
             {
@@ -664,14 +696,21 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
             out T value
         )
         {
-            if (formatter == null || _malformed || MaxNestingDepth <= _depth)
+            if (formatter == null || _malformed || Limits.MaximumNestingDepth <= _depth)
             {
                 _malformed = true;
                 value = default;
                 return false;
             }
 
-            WProtoReader nested = new WProtoReader(payload, _depth + 1);
+            WProtoReader nested = new WProtoReader(payload, _depth + 1, Limits);
+            if (nested.Malformed)
+            {
+                _malformed = true;
+                value = default;
+                return false;
+            }
+
             WProtoReader expected = nested;
             if (ReadCompleted(formatter.TryRead(ref nested, out value), in nested, in expected))
             {
@@ -709,14 +748,21 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
             out T value
         )
         {
-            if (formatter == null || _malformed || MaxNestingDepth <= _depth)
+            if (formatter == null || _malformed || Limits.MaximumNestingDepth <= _depth)
             {
                 _malformed = true;
                 value = default;
                 return false;
             }
 
-            WProtoReader nested = new WProtoReader(payload, _depth + 1);
+            WProtoReader nested = new WProtoReader(payload, _depth + 1, Limits);
+            if (nested.Malformed)
+            {
+                _malformed = true;
+                value = default;
+                return false;
+            }
+
             WProtoReader expected = nested;
             bool read = formatter is IWProtoMergeFormatter<T> merging
                 ? merging.TryReadInto(ref nested, seed, out value)
@@ -738,6 +784,8 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         )
         {
             return formatterSucceeded
+                && !expected.Malformed
+                && ReferenceEquals(reader.Limits, expected.Limits)
                 && !reader.Malformed
                 && reader.End
                 && reader.Depth == expected.Depth
@@ -753,7 +801,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
         /// Reads a length prefix.
         /// </summary>
         /// <param name="length">Receives the length, or 0 on failure.</param>
-        /// <returns><c>true</c> when a length that fits the remaining input was read.</returns>
+        /// <returns><c>true</c> when a length fits the remaining input and the configured length-delimited limit.</returns>
         public bool TryReadLength(out int length)
         {
             // Reject lengths above 32 bits before truncation can turn them into plausible lengths.
@@ -763,7 +811,11 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
                 return false;
             }
 
-            if (int.MaxValue < raw || (uint)Remaining < raw)
+            if (
+                int.MaxValue < raw
+                || (uint)Remaining < raw
+                || (uint)Limits.MaximumLengthDelimitedBytes < raw
+            )
             {
                 _malformed = true;
                 length = 0;
@@ -836,7 +888,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto
 
         private bool TrySkipGroup(int groupFieldNumber, int depth)
         {
-            if (MaxNestingDepth <= depth)
+            if (Limits.MaximumNestingDepth <= depth)
             {
                 _malformed = true;
                 return false;

--- a/Tests/Core/RelationalExactBindingTestBase.cs
+++ b/Tests/Core/RelationalExactBindingTestBase.cs
@@ -1,0 +1,173 @@
+// MIT License - Copyright (c) 2025 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using UnityEngine;
+    using WallstopStudios.UnityHelpers.Core.Attributes;
+    using WallstopStudios.UnityHelpers.Core.Helper;
+    using WallstopStudios.UnityHelpers.Tests.Core.TestTypes;
+
+    /// <summary>
+    /// Shares the direct-query exact-binding oracle across EditMode and PlayMode fixtures.
+    /// </summary>
+    public abstract class RelationalExactBindingTestBase : CommonTestBase
+    {
+        protected void VerifyExactTypeAssignment(int depth, bool inactive, int capability)
+        {
+            using IDisposable scope = ReflectionHelpers.OverrideReflectionCapabilities(
+                capability == 0,
+                capability == 1
+            );
+            SiblingComponentExtensions.ClearCachedFieldMetadata();
+            ParentComponentExtensions.ClearCachedFieldMetadata();
+            ChildComponentExtensions.ClearCachedFieldMetadata();
+            ReflectionHelpers.ClearFieldSetterCache();
+            GameObject root = CreateExactTypeCandidates("ExactRoot");
+            GameObject ancestor = root;
+            for (int level = 1; level < depth; level++)
+            {
+                GameObject next = CreateExactTypeCandidates("ExactAncestor");
+                next.transform.SetParent(ancestor.transform);
+                ancestor = next;
+            }
+            GameObject owner = CreateExactTypeCandidates("ExactOwner");
+            owner.transform.SetParent(ancestor.transform);
+            RelationalExactTypeTester tester = owner.AddComponent<RelationalExactTypeTester>();
+            GameObject first = CreateExactTypeCandidates("ExactFirstChild");
+            first.transform.SetParent(owner.transform);
+            GameObject grandchild = CreateExactTypeCandidates("ExactGrandchild");
+            grandchild.transform.SetParent(first.transform);
+            GameObject second = CreateExactTypeCandidates("ExactSecondChild");
+            second.transform.SetParent(owner.transform);
+            root.SetActive(!inactive);
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            CreateExactTypeCandidates("ExactUnrelated");
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            second.transform.SetAsFirstSibling();
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            foreach (RelationalExactComponent candidate in ExactComponentsOn(first.transform))
+            {
+                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
+            }
+            foreach (RelationalExactComponent candidate in ExactComponentsOn(second.transform))
+            {
+                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
+            }
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            foreach (
+                RelationalExactComponent candidate in root.GetComponentsInChildren<RelationalExactComponent>(
+                    true
+                )
+            )
+            {
+                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
+            }
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+        }
+
+        private GameObject CreateExactTypeCandidates(string name)
+        {
+            GameObject candidate = Track(new GameObject(name));
+            candidate.AddComponent<RelationalExactDerivedComponent>();
+            candidate.AddComponent<RelationalExactComponent>();
+            candidate.AddComponent<RelationalExactComponent>();
+            return candidate;
+        }
+
+        private static void AssertExactTypeAssignmentMatchesDirectQueries(
+            RelationalExactTypeTester tester
+        )
+        {
+            List<RelationalExactComponent> sibling = ExactComponentsOn(tester.transform);
+            List<RelationalExactComponent> parent = new();
+            Transform ancestor = tester.transform.parent;
+            while (ancestor != null)
+            {
+                parent.AddRange(ExactComponentsOn(ancestor));
+                ancestor = ancestor.parent;
+            }
+            List<RelationalExactComponent> child = new();
+            Queue<Transform> pending = new();
+            foreach (Transform directChild in tester.transform)
+            {
+                pending.Enqueue(directChild);
+            }
+            while (0 < pending.Count)
+            {
+                Transform current = pending.Dequeue();
+                child.AddRange(ExactComponentsOn(current));
+                foreach (Transform descendant in current)
+                {
+                    pending.Enqueue(descendant);
+                }
+            }
+            tester.AssignRelationalComponents();
+            Assert.AreSame(sibling.Count == 0 ? null : sibling[0], tester.siblingExactSingle);
+            CollectionAssert.AreEqual(sibling, tester.siblingExactArray);
+            CollectionAssert.AreEqual(sibling, tester.siblingExactList);
+            CollectionAssert.AreEquivalent(sibling, tester.siblingExactSet);
+            Assert.IsTrue(tester.siblingBaseSingle == null);
+            CollectionAssert.IsEmpty(tester.siblingBaseArray);
+            CollectionAssert.IsEmpty(tester.siblingBaseList);
+            CollectionAssert.IsEmpty(tester.siblingBaseSet);
+            Assert.IsTrue(tester.siblingComponentSingle == null);
+            CollectionAssert.IsEmpty(tester.siblingComponentArray);
+            CollectionAssert.IsEmpty(tester.siblingComponentList);
+            CollectionAssert.IsEmpty(tester.siblingComponentSet);
+            Assert.IsTrue(tester.siblingInterfaceSingle == null);
+            CollectionAssert.IsEmpty(tester.siblingInterfaceArray);
+            CollectionAssert.IsEmpty(tester.siblingInterfaceList);
+            CollectionAssert.IsEmpty(tester.siblingInterfaceSet);
+            Assert.AreSame(parent.Count == 0 ? null : parent[0], tester.parentExactSingle);
+            CollectionAssert.AreEqual(parent, tester.parentExactArray);
+            CollectionAssert.AreEqual(parent, tester.parentExactList);
+            CollectionAssert.AreEquivalent(parent, tester.parentExactSet);
+            Assert.IsTrue(tester.parentBaseSingle == null);
+            CollectionAssert.IsEmpty(tester.parentBaseArray);
+            CollectionAssert.IsEmpty(tester.parentBaseList);
+            CollectionAssert.IsEmpty(tester.parentBaseSet);
+            Assert.IsTrue(tester.parentComponentSingle == null);
+            CollectionAssert.IsEmpty(tester.parentComponentArray);
+            CollectionAssert.IsEmpty(tester.parentComponentList);
+            CollectionAssert.IsEmpty(tester.parentComponentSet);
+            Assert.IsTrue(tester.parentInterfaceSingle == null);
+            CollectionAssert.IsEmpty(tester.parentInterfaceArray);
+            CollectionAssert.IsEmpty(tester.parentInterfaceList);
+            CollectionAssert.IsEmpty(tester.parentInterfaceSet);
+            Assert.AreSame(child.Count == 0 ? null : child[0], tester.childExactSingle);
+            CollectionAssert.AreEqual(child, tester.childExactArray);
+            CollectionAssert.AreEqual(child, tester.childExactList);
+            CollectionAssert.AreEquivalent(child, tester.childExactSet);
+            Assert.IsTrue(tester.childBaseSingle == null);
+            CollectionAssert.IsEmpty(tester.childBaseArray);
+            CollectionAssert.IsEmpty(tester.childBaseList);
+            CollectionAssert.IsEmpty(tester.childBaseSet);
+            Assert.IsTrue(tester.childComponentSingle == null);
+            CollectionAssert.IsEmpty(tester.childComponentArray);
+            CollectionAssert.IsEmpty(tester.childComponentList);
+            CollectionAssert.IsEmpty(tester.childComponentSet);
+            Assert.IsTrue(tester.childInterfaceSingle == null);
+            CollectionAssert.IsEmpty(tester.childInterfaceArray);
+            CollectionAssert.IsEmpty(tester.childInterfaceList);
+            CollectionAssert.IsEmpty(tester.childInterfaceSet);
+        }
+
+        private static List<RelationalExactComponent> ExactComponentsOn(Transform owner)
+        {
+            List<RelationalExactComponent> expected = new();
+            foreach (Component candidate in owner.GetComponents<Component>())
+            {
+                if (candidate != null && candidate.GetType() == typeof(RelationalExactComponent))
+                {
+                    expected.Add((RelationalExactComponent)candidate);
+                }
+            }
+            return expected;
+        }
+    }
+}

--- a/Tests/Core/RelationalExactBindingTestBase.cs.meta
+++ b/Tests/Core/RelationalExactBindingTestBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00fc08f1b013da4b1544dad04310c5db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/TestTypes/RelationalExactComponent.cs
+++ b/Tests/Core/TestTypes/RelationalExactComponent.cs
@@ -1,0 +1,12 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Core.TestTypes
+{
+    using UnityEngine;
+
+    public class RelationalExactComponent : MonoBehaviour, ITestInterface
+    {
+        public string GetTestValue() => nameof(RelationalExactComponent);
+    }
+}

--- a/Tests/Core/TestTypes/RelationalExactComponent.cs.meta
+++ b/Tests/Core/TestTypes/RelationalExactComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8f3e7a230229ec953fbbeadb63dbb27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/TestTypes/RelationalExactDerivedComponent.cs
+++ b/Tests/Core/TestTypes/RelationalExactDerivedComponent.cs
@@ -1,0 +1,9 @@
+// MIT License - Copyright (c) 2025 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Core.TestTypes
+{
+    using UnityEngine;
+
+    public class RelationalExactDerivedComponent : RelationalExactComponent { }
+}

--- a/Tests/Core/TestTypes/RelationalExactDerivedComponent.cs.meta
+++ b/Tests/Core/TestTypes/RelationalExactDerivedComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68d55d83ca127edcb0b791657785f271
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/TestTypes/RelationalExactTypeTester.cs
+++ b/Tests/Core/TestTypes/RelationalExactTypeTester.cs
@@ -1,0 +1,156 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Core.TestTypes
+{
+    using System.Collections.Generic;
+    using UnityEngine;
+    using WallstopStudios.UnityHelpers.Core.Attributes;
+
+    public sealed class RelationalExactTypeTester : MonoBehaviour
+    {
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public RelationalExactComponent siblingExactSingle;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public RelationalExactComponent[] siblingExactArray;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public List<RelationalExactComponent> siblingExactList;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public HashSet<RelationalExactComponent> siblingExactSet;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public MonoBehaviour siblingBaseSingle;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public MonoBehaviour[] siblingBaseArray;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public List<MonoBehaviour> siblingBaseList;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public HashSet<MonoBehaviour> siblingBaseSet;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public Component siblingComponentSingle;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public Component[] siblingComponentArray;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public List<Component> siblingComponentList;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public HashSet<Component> siblingComponentSet;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public ITestInterface siblingInterfaceSingle;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public ITestInterface[] siblingInterfaceArray;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public List<ITestInterface> siblingInterfaceList;
+
+        [SiblingComponent(AllowInterfaces = false, Optional = true)]
+        public HashSet<ITestInterface> siblingInterfaceSet;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public RelationalExactComponent parentExactSingle;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public RelationalExactComponent[] parentExactArray;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public List<RelationalExactComponent> parentExactList;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public HashSet<RelationalExactComponent> parentExactSet;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public MonoBehaviour parentBaseSingle;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public MonoBehaviour[] parentBaseArray;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public List<MonoBehaviour> parentBaseList;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public HashSet<MonoBehaviour> parentBaseSet;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public Component parentComponentSingle;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public Component[] parentComponentArray;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public List<Component> parentComponentList;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public HashSet<Component> parentComponentSet;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public ITestInterface parentInterfaceSingle;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public ITestInterface[] parentInterfaceArray;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public List<ITestInterface> parentInterfaceList;
+
+        [ParentComponent(OnlyAncestors = true, AllowInterfaces = false, Optional = true)]
+        public HashSet<ITestInterface> parentInterfaceSet;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public RelationalExactComponent childExactSingle;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public RelationalExactComponent[] childExactArray;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public List<RelationalExactComponent> childExactList;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public HashSet<RelationalExactComponent> childExactSet;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public MonoBehaviour childBaseSingle;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public MonoBehaviour[] childBaseArray;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public List<MonoBehaviour> childBaseList;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public HashSet<MonoBehaviour> childBaseSet;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public Component childComponentSingle;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public Component[] childComponentArray;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public List<Component> childComponentList;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public HashSet<Component> childComponentSet;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public ITestInterface childInterfaceSingle;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public ITestInterface[] childInterfaceArray;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public List<ITestInterface> childInterfaceList;
+
+        [ChildComponent(OnlyDescendants = true, AllowInterfaces = false, Optional = true)]
+        public HashSet<ITestInterface> childInterfaceSet;
+    }
+}

--- a/Tests/Core/TestTypes/RelationalExactTypeTester.cs.meta
+++ b/Tests/Core/TestTypes/RelationalExactTypeTester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c31c3af17afa400b80272ffeeaef74b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/Attributes/RelationalExactBindingTests.cs
+++ b/Tests/Editor/Attributes/RelationalExactBindingTests.cs
@@ -1,0 +1,23 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Editor.Attributes
+{
+    using NUnit.Framework;
+    using WallstopStudios.UnityHelpers.Tests.Core;
+
+    [TestFixture]
+    [NUnit.Framework.Category("Fast")]
+    public sealed class RelationalExactBindingTests : RelationalExactBindingTestBase
+    {
+        [Test]
+        public void ExactTypeAssignmentMatchesDirectQueriesAcrossShapesAndCacheStates(
+            [Values(1, 4)] int depth,
+            [Values(false, true)] bool inactive,
+            [Values(0, 1, 2)] int capability
+        )
+        {
+            VerifyExactTypeAssignment(depth, inactive, capability);
+        }
+    }
+}

--- a/Tests/Editor/Attributes/RelationalExactBindingTests.cs.meta
+++ b/Tests/Editor/Attributes/RelationalExactBindingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf74819c6df5defadc095e2626a8d75b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/CustomDrawers/SerializableDictionaryPropertyDrawerTests.cs
+++ b/Tests/Editor/CustomDrawers/SerializableDictionaryPropertyDrawerTests.cs
@@ -84,6 +84,194 @@ namespace WallstopStudios.UnityHelpers.Tests.CustomDrawers
             }
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void PendingWrapperReleaseDisposesViewWhileUnownedTargetRemainsAlive(
+            bool isValueField
+        )
+        {
+            SerializableDictionaryPropertyDrawer.PendingEntry pending = new();
+            try
+            {
+                SerializableDictionaryPropertyDrawer.PendingWrapperContext context =
+                    SerializableDictionaryPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ColorData),
+                        isValueField
+                    );
+                PendingValueWrapper wrapper = Track(context.Wrapper);
+                SerializedObject serialized = TrackDisposable(context.Serialized);
+                if (isValueField)
+                {
+                    pending.valueWrapper = null;
+                }
+                else
+                {
+                    pending.keyWrapper = null;
+                }
+
+                SerializableDictionaryPropertyDrawer.ReleasePendingWrapper(pending, isValueField);
+
+                Assert.IsTrue(
+                    wrapper != null,
+                    "A missing owner reference must not destroy a borrowed target."
+                );
+                Assert.Catch(
+                    () => serialized.Update(),
+                    "The native view must be disposed even when its target remains alive."
+                );
+            }
+            finally
+            {
+                SerializableDictionaryPropertyDrawer.ReleasePendingWrapper(pending, isValueField);
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void PendingWrapperReleaseDisposesOwnedViewAndPreservesBorrowedContext(
+            bool isValueField
+        )
+        {
+            SerializableDictionaryPropertyDrawer.PendingEntry pending = new();
+            try
+            {
+                SerializableDictionaryPropertyDrawer.PendingWrapperContext context =
+                    SerializableDictionaryPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ColorData),
+                        isValueField
+                    );
+                Assert.IsTrue(context.Wrapper != null);
+                Assert.IsTrue(context.Serialized != null);
+                SerializedObject serialized = TrackDisposable(context.Serialized);
+                PendingValueWrapper wrapper = context.Wrapper;
+                SerializableDictionaryPropertyDrawer.PendingWrapperContext borrowed =
+                    SerializableDictionaryPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ColorData),
+                        isValueField
+                    );
+                Assert.AreSame(serialized, borrowed.Serialized);
+                Assert.AreSame(context.Property, borrowed.Property);
+                Assert.DoesNotThrow(() => borrowed.Serialized.Update());
+
+                SerializableDictionaryPropertyDrawer.ReleasePendingWrapper(pending, isValueField);
+
+                Assert.IsTrue(wrapper == null);
+                Assert.IsTrue((isValueField ? pending.valueWrapper : pending.keyWrapper) == null);
+                Assert.IsTrue(
+                    (isValueField ? pending.valueWrapperSerialized : pending.keyWrapperSerialized)
+                        == null
+                );
+                Assert.IsTrue(
+                    (isValueField ? pending.valueWrapperProperty : pending.keyWrapperProperty)
+                        == null
+                );
+                Assert.Catch(() => serialized.Update());
+                Assert.DoesNotThrow(() =>
+                    SerializableDictionaryPropertyDrawer.ReleasePendingWrapper(
+                        pending,
+                        isValueField
+                    )
+                );
+            }
+            finally
+            {
+                SerializableDictionaryPropertyDrawer.ReleasePendingWrapper(pending, isValueField);
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void PendingWrapperMissingPropertyReleasesIncompleteOwnership(bool isValueField)
+        {
+            SerializableDictionaryPropertyDrawer.PendingEntry pending = new();
+            try
+            {
+                SerializableDictionaryPropertyDrawer.PendingWrapperContext context =
+                    SerializableDictionaryPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ColorData),
+                        isValueField
+                    );
+                SerializedObject serialized = TrackDisposable(context.Serialized);
+                PendingValueWrapper wrapper = context.Wrapper;
+                context.Property.Dispose();
+                if (isValueField)
+                {
+                    pending.valueWrapperProperty = null;
+                }
+                else
+                {
+                    pending.keyWrapperProperty = null;
+                }
+
+                SerializableDictionaryPropertyDrawer.PendingWrapperContext failed =
+                    SerializableDictionaryPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ColorData),
+                        isValueField
+                    );
+
+                Assert.IsTrue(failed.Serialized == null);
+                Assert.IsTrue(wrapper == null);
+                Assert.IsTrue(
+                    (isValueField ? pending.valueWrapperSerialized : pending.keyWrapperSerialized)
+                        == null
+                );
+                Assert.Catch(() => serialized.Update());
+            }
+            finally
+            {
+                SerializableDictionaryPropertyDrawer.ReleasePendingWrapper(pending, isValueField);
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void PendingWrapperUpdateFailureReleasesOwnershipAndAllowsRetry(bool isValueField)
+        {
+            SerializableDictionaryPropertyDrawer.PendingEntry pending = new();
+            try
+            {
+                SerializableDictionaryPropertyDrawer.PendingWrapperContext context =
+                    SerializableDictionaryPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ColorData),
+                        isValueField
+                    );
+                PendingValueWrapper wrapper = context.Wrapper;
+                context.Serialized.Dispose();
+
+                Assert.Catch(() =>
+                    SerializableDictionaryPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ColorData),
+                        isValueField
+                    )
+                );
+
+                Assert.IsTrue(wrapper == null);
+                Assert.IsTrue(
+                    (isValueField ? pending.valueWrapperSerialized : pending.keyWrapperSerialized)
+                        == null
+                );
+                SerializableDictionaryPropertyDrawer.PendingWrapperContext retry =
+                    SerializableDictionaryPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ColorData),
+                        isValueField
+                    );
+                Assert.IsTrue(retry.Wrapper != null);
+                Assert.DoesNotThrow(() => retry.Serialized.Update());
+            }
+            finally
+            {
+                SerializableDictionaryPropertyDrawer.ReleasePendingWrapper(pending, isValueField);
+            }
+        }
+
         [Test]
         public void PageSizeClampPreventsExcessiveCacheGrowth()
         {

--- a/Tests/Editor/CustomDrawers/SerializableSetPropertyDrawerTests.cs
+++ b/Tests/Editor/CustomDrawers/SerializableSetPropertyDrawerTests.cs
@@ -83,6 +83,149 @@ namespace WallstopStudios.UnityHelpers.Tests.CustomDrawers
         }
 
         [Test]
+        public void PendingWrapperReleaseDisposesViewWhileUnownedTargetRemainsAlive()
+        {
+            SerializableSetPropertyDrawer.PendingEntry pending = new();
+            try
+            {
+                SerializableSetPropertyDrawer.PendingWrapperContext context =
+                    SerializableSetPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ComplexSetElement)
+                    );
+                PendingValueWrapper wrapper = Track(context.Wrapper);
+                SerializedObject serialized = TrackDisposable(context.Serialized);
+                pending.valueWrapper = null;
+
+                SerializableSetPropertyDrawer.ReleasePendingWrapper(pending);
+
+                Assert.IsTrue(
+                    wrapper != null,
+                    "A missing owner reference must not destroy a borrowed target."
+                );
+                Assert.Catch(
+                    () => serialized.Update(),
+                    "The native view must be disposed even when its target remains alive."
+                );
+            }
+            finally
+            {
+                SerializableSetPropertyDrawer.ReleasePendingWrapper(pending);
+            }
+        }
+
+        [Test]
+        public void PendingWrapperReleaseDisposesOwnedViewAndPreservesBorrowedContext()
+        {
+            SerializableSetPropertyDrawer.PendingEntry pending = new();
+            try
+            {
+                SerializableSetPropertyDrawer.PendingWrapperContext context =
+                    SerializableSetPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ComplexSetElement)
+                    );
+                Assert.IsTrue(context.Wrapper != null);
+                Assert.IsTrue(context.Serialized != null);
+                SerializedObject serialized = TrackDisposable(context.Serialized);
+                PendingValueWrapper wrapper = context.Wrapper;
+                SerializableSetPropertyDrawer.PendingWrapperContext borrowed =
+                    SerializableSetPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ComplexSetElement)
+                    );
+                Assert.AreSame(serialized, borrowed.Serialized);
+                Assert.AreSame(context.Property, borrowed.Property);
+                Assert.DoesNotThrow(() => borrowed.Serialized.Update());
+
+                SerializableSetPropertyDrawer.ReleasePendingWrapper(pending);
+
+                Assert.IsTrue(wrapper == null);
+                Assert.IsTrue(pending.valueWrapper == null);
+                Assert.IsTrue(pending.valueWrapperSerialized == null);
+                Assert.IsTrue(pending.valueWrapperProperty == null);
+                Assert.Catch(() => serialized.Update());
+                Assert.DoesNotThrow(() =>
+                    SerializableSetPropertyDrawer.ReleasePendingWrapper(pending)
+                );
+            }
+            finally
+            {
+                SerializableSetPropertyDrawer.ReleasePendingWrapper(pending);
+            }
+        }
+
+        [Test]
+        public void PendingWrapperMissingPropertyReleasesIncompleteOwnership()
+        {
+            SerializableSetPropertyDrawer.PendingEntry pending = new();
+            try
+            {
+                SerializableSetPropertyDrawer.PendingWrapperContext context =
+                    SerializableSetPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ComplexSetElement)
+                    );
+                SerializedObject serialized = TrackDisposable(context.Serialized);
+                PendingValueWrapper wrapper = context.Wrapper;
+                context.Property.Dispose();
+                pending.valueWrapperProperty = null;
+
+                SerializableSetPropertyDrawer.PendingWrapperContext failed =
+                    SerializableSetPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ComplexSetElement)
+                    );
+
+                Assert.IsTrue(failed.Serialized == null);
+                Assert.IsTrue(wrapper == null);
+                Assert.IsTrue(pending.valueWrapperSerialized == null);
+                Assert.Catch(() => serialized.Update());
+            }
+            finally
+            {
+                SerializableSetPropertyDrawer.ReleasePendingWrapper(pending);
+            }
+        }
+
+        [Test]
+        public void PendingWrapperUpdateFailureReleasesOwnershipAndAllowsRetry()
+        {
+            SerializableSetPropertyDrawer.PendingEntry pending = new();
+            try
+            {
+                SerializableSetPropertyDrawer.PendingWrapperContext context =
+                    SerializableSetPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ComplexSetElement)
+                    );
+                PendingValueWrapper wrapper = context.Wrapper;
+                context.Serialized.Dispose();
+
+                Assert.Catch(() =>
+                    SerializableSetPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ComplexSetElement)
+                    )
+                );
+
+                Assert.IsTrue(wrapper == null);
+                Assert.IsTrue(pending.valueWrapperSerialized == null);
+                SerializableSetPropertyDrawer.PendingWrapperContext retry =
+                    SerializableSetPropertyDrawer.EnsurePendingWrapper(
+                        pending,
+                        typeof(ComplexSetElement)
+                    );
+                Assert.IsTrue(retry.Wrapper != null);
+                Assert.DoesNotThrow(() => retry.Serialized.Update());
+            }
+            finally
+            {
+                SerializableSetPropertyDrawer.ReleasePendingWrapper(pending);
+            }
+        }
+
+        [Test]
         public void GetPropertyHeightClampsPageSize()
         {
             HashSetHost host = CreateScriptableObject<HashSetHost>();

--- a/Tests/Editor/EditorWindowNativeResourceTests.cs
+++ b/Tests/Editor/EditorWindowNativeResourceTests.cs
@@ -1,0 +1,86 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Editor
+{
+#if UNITY_EDITOR
+    using NUnit.Framework;
+    using UnityEditor;
+    using UnityEngine;
+    using WallstopStudios.UnityHelpers.Editor;
+    using WallstopStudios.UnityHelpers.Tests.Core;
+    using Object = UnityEngine.Object;
+
+    /// <summary>Checks resource ownership in windows requiring real Unity editor API references.</summary>
+    [TestFixture]
+    [Category("Fast")]
+    public sealed class EditorWindowNativeResourceTests : CommonTestBase
+    {
+        [Test]
+        public void FitTextureWindowReleasesStateAcrossReopens()
+        {
+            SerializedObject previous = null;
+            for (int cycle = 0; cycle < 3; ++cycle)
+            {
+                FitTextureSizeWindow window = Track(
+                    ScriptableObject.CreateInstance<FitTextureSizeWindow>()
+                );
+                SerializedObject bound = window.SerializedStateForTesting;
+                Assert.IsTrue(bound != null);
+                Assert.AreNotSame(previous, bound);
+                bound.Update();
+                Object.DestroyImmediate(window); // UNH-SUPPRESS: teardown is the subject
+                Assert.IsTrue(window.SerializedStateForTesting == null);
+                Assert.Catch(() => bound.Update());
+                previous = bound;
+            }
+        }
+
+        [TestCase(false, false)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        public void AnimationWindowReleasesOnlyOwnedPreviews(
+            bool closeWindow,
+            bool alreadyDestroyed
+        )
+        {
+            Texture2D borrowed = Track(new Texture2D(4, 4));
+            borrowed.SetPixel(0, 0, Color.magenta);
+            borrowed.Apply();
+            Sprite sprite = Track(Sprite.Create(borrowed, new Rect(0, 0, 4, 4), Vector2.zero));
+            Sprite otherSprite = Track(Sprite.Create(borrowed, new Rect(0, 0, 2, 2), Vector2.zero));
+            Texture2D owned = Track(
+                AnimationEventSpritePreviewRenderer.CopyTexture(new Rect(0, 0, 4, 4), borrowed)
+            );
+            Assert.AreEqual(borrowed.GetPixel(0, 0), owned.GetPixel(0, 0));
+            AnimationEventEditor window = Track(
+                ScriptableObject.CreateInstance<AnimationEventEditor>()
+            );
+            window._spriteTextureCache.Add(sprite, owned);
+            window._spriteTextureCache.Add(otherSprite, borrowed);
+            _ = window._ownedSpriteTextures.Add(owned);
+            if (alreadyDestroyed)
+            {
+                Object.DestroyImmediate(owned); // UNH-SUPPRESS: cleanup of dead previews is the subject
+            }
+
+            if (closeWindow)
+            {
+                Object.DestroyImmediate(window); // UNH-SUPPRESS: teardown is the subject
+            }
+            else
+            {
+                window.ReleaseSpritePreviews();
+                window.ReleaseSpritePreviews();
+            }
+
+            Assert.IsTrue(owned == null);
+            Assert.IsTrue(borrowed != null);
+            Assert.AreEqual(Color.magenta, borrowed.GetPixel(0, 0));
+            Assert.AreEqual(0, window._spriteTextureCache.Count);
+            Assert.AreEqual(0, window._ownedSpriteTextures.Count);
+        }
+    }
+#endif
+}

--- a/Tests/Editor/EditorWindowNativeResourceTests.cs.meta
+++ b/Tests/Editor/EditorWindowNativeResourceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: feab2ff3aceed13f6250692cba264d0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/EditorWindowSerializedStateTests.cs
+++ b/Tests/Editor/EditorWindowSerializedStateTests.cs
@@ -8,16 +8,15 @@ namespace WallstopStudios.UnityHelpers.Tests.Editor
     using NUnit.Framework;
     using UnityEditor;
     using UnityEngine;
+    using WallstopStudios.UnityHelpers.Core.Helper;
+    using WallstopStudios.UnityHelpers.Editor;
     using WallstopStudios.UnityHelpers.Editor.Sprites;
     using WallstopStudios.UnityHelpers.Editor.Tools;
     using WallstopStudios.UnityHelpers.Tests.Core;
     using Object = UnityEngine.Object;
 
     /// <summary>
-    /// Eight editor windows build a <see cref="SerializedObject"/> over themselves in
-    /// <c>OnEnable</c> and none of them released it, so every open-and-close leaked one native
-    /// object and left the window's cached <see cref="SerializedProperty"/> fields pointing into it
-    /// (<see href="https://github.com/Ambiguous-Interactive/unity-helpers/issues/641">#641</see>).
+    /// Verifies editor windows release their serialized state when closed.
     /// </summary>
     /// <remarks>
     /// <para>Using a disposed <see cref="SerializedObject"/> throws, and <b>which</b> exception it
@@ -60,6 +59,53 @@ namespace WallstopStudios.UnityHelpers.Tests.Editor
             AssertSerializedStateLifecycle<SpriteSheetExtractor>(window =>
                 window.SerializedStateForTesting
             );
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void AtlasWindowReleasesCachedSerializedObjects(bool closeWindow)
+        {
+            ScriptableSpriteAtlas config = CreateScriptableObject<ScriptableSpriteAtlas>();
+            ScriptableSpriteAtlasEditor window = Track(
+                ScriptableObject.CreateInstance<ScriptableSpriteAtlasEditor>()
+            );
+            SerializedObject original = window.GetSerializedConfig(config);
+            original.Update();
+            Assert.AreSame(original, window.GetSerializedConfig(config));
+
+            if (closeWindow)
+            {
+                Object.DestroyImmediate(window); // UNH-SUPPRESS: teardown is the subject
+            }
+            else
+            {
+                window.LoadAtlasConfigs();
+            }
+
+            Assert.Catch(() => original.Update());
+            if (!closeWindow)
+            {
+                SerializedObject replacement = window.GetSerializedConfig(config);
+                Assert.AreNotSame(original, replacement);
+                replacement.Update();
+                Object.DestroyImmediate(window); // UNH-SUPPRESS: teardown is the subject
+                Assert.Catch(() => replacement.Update());
+            }
+        }
+
+        [Test]
+        public void FailedAnimationPreviewCopyReleasesTemporaryTexture()
+        {
+            Texture2D source = Track(new Texture2D(4, 4));
+            source.Apply(false, true);
+            Assert.IsFalse(source.isReadable);
+            int before = Resources.FindObjectsOfTypeAll<Texture2D>().Length;
+
+            Assert.Catch(() =>
+                AnimationEventSpritePreviewRenderer.CopyTexture(new Rect(0, 0, 4, 4), source)
+            );
+
+            Assert.AreEqual(before, Resources.FindObjectsOfTypeAll<Texture2D>().Length);
         }
 
         private void AssertSerializedStateLifecycle<TWindow>(

--- a/Tests/Runtime/Attributes/RelationalComponentExtensionsTests.cs
+++ b/Tests/Runtime/Attributes/RelationalComponentExtensionsTests.cs
@@ -4,10 +4,8 @@
 namespace WallstopStudios.UnityHelpers.Tests.Attributes
 {
     using System;
-    using System.Collections.Generic;
     using NUnit.Framework;
     using UnityEngine;
-    using UnityEngine.TestTools;
     using WallstopStudios.UnityHelpers.Core.Attributes;
     using WallstopStudios.UnityHelpers.Core.Helper;
     using WallstopStudios.UnityHelpers.Tests.Core;
@@ -15,7 +13,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Attributes
 
     [TestFixture]
     [NUnit.Framework.Category("Fast")]
-    public sealed class RelationalComponentExtensionsTests : CommonTestBase
+    public sealed class RelationalComponentExtensionsTests : RelationalExactBindingTestBase
     {
         [Test]
         public void ExactTypeAssignmentMatchesDirectQueriesAcrossShapesAndCacheStates(
@@ -24,156 +22,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Attributes
             [Values(0, 1, 2)] int capability
         )
         {
-            using IDisposable scope = ReflectionHelpers.OverrideReflectionCapabilities(
-                capability == 0,
-                capability == 1
-            );
-            SiblingComponentExtensions.ClearCachedFieldMetadata();
-            ParentComponentExtensions.ClearCachedFieldMetadata();
-            ChildComponentExtensions.ClearCachedFieldMetadata();
-            ReflectionHelpers.ClearFieldSetterCache();
-            GameObject root = CreateExactTypeCandidates("ExactRoot");
-            GameObject ancestor = root;
-            for (int level = 1; level < depth; level++)
-            {
-                GameObject next = CreateExactTypeCandidates("ExactAncestor");
-                next.transform.SetParent(ancestor.transform);
-                ancestor = next;
-            }
-            GameObject owner = CreateExactTypeCandidates("ExactOwner");
-            owner.transform.SetParent(ancestor.transform);
-            RelationalExactTypeTester tester = owner.AddComponent<RelationalExactTypeTester>();
-            GameObject first = CreateExactTypeCandidates("ExactFirstChild");
-            first.transform.SetParent(owner.transform);
-            GameObject grandchild = CreateExactTypeCandidates("ExactGrandchild");
-            grandchild.transform.SetParent(first.transform);
-            GameObject second = CreateExactTypeCandidates("ExactSecondChild");
-            second.transform.SetParent(owner.transform);
-            root.SetActive(!inactive);
-            AssertExactTypeAssignmentMatchesDirectQueries(tester);
-            AssertExactTypeAssignmentMatchesDirectQueries(tester);
-            CreateExactTypeCandidates("ExactUnrelated");
-            AssertExactTypeAssignmentMatchesDirectQueries(tester);
-            second.transform.SetAsFirstSibling();
-            AssertExactTypeAssignmentMatchesDirectQueries(tester);
-            foreach (RelationalExactComponent candidate in ExactComponentsOn(first.transform))
-            {
-                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
-            }
-            foreach (RelationalExactComponent candidate in ExactComponentsOn(second.transform))
-            {
-                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
-            }
-            AssertExactTypeAssignmentMatchesDirectQueries(tester);
-            foreach (
-                RelationalExactComponent candidate in root.GetComponentsInChildren<RelationalExactComponent>(
-                    true
-                )
-            )
-            {
-                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
-            }
-            AssertExactTypeAssignmentMatchesDirectQueries(tester);
-        }
-
-        private GameObject CreateExactTypeCandidates(string name)
-        {
-            GameObject candidate = Track(new GameObject(name));
-            candidate.AddComponent<RelationalExactDerivedComponent>();
-            candidate.AddComponent<RelationalExactComponent>();
-            candidate.AddComponent<RelationalExactComponent>();
-            return candidate;
-        }
-
-        private static void AssertExactTypeAssignmentMatchesDirectQueries(
-            RelationalExactTypeTester tester
-        )
-        {
-            List<RelationalExactComponent> sibling = ExactComponentsOn(tester.transform);
-            List<RelationalExactComponent> parent = new();
-            Transform ancestor = tester.transform.parent;
-            while (ancestor != null)
-            {
-                parent.AddRange(ExactComponentsOn(ancestor));
-                ancestor = ancestor.parent;
-            }
-            List<RelationalExactComponent> child = new();
-            Queue<Transform> pending = new();
-            foreach (Transform directChild in tester.transform)
-            {
-                pending.Enqueue(directChild);
-            }
-            while (0 < pending.Count)
-            {
-                Transform current = pending.Dequeue();
-                child.AddRange(ExactComponentsOn(current));
-                foreach (Transform descendant in current)
-                {
-                    pending.Enqueue(descendant);
-                }
-            }
-            tester.AssignRelationalComponents();
-            Assert.AreSame(sibling.Count == 0 ? null : sibling[0], tester.siblingExactSingle);
-            CollectionAssert.AreEqual(sibling, tester.siblingExactArray);
-            CollectionAssert.AreEqual(sibling, tester.siblingExactList);
-            CollectionAssert.AreEquivalent(sibling, tester.siblingExactSet);
-            Assert.IsTrue(tester.siblingBaseSingle == null);
-            CollectionAssert.IsEmpty(tester.siblingBaseArray);
-            CollectionAssert.IsEmpty(tester.siblingBaseList);
-            CollectionAssert.IsEmpty(tester.siblingBaseSet);
-            Assert.IsTrue(tester.siblingComponentSingle == null);
-            CollectionAssert.IsEmpty(tester.siblingComponentArray);
-            CollectionAssert.IsEmpty(tester.siblingComponentList);
-            CollectionAssert.IsEmpty(tester.siblingComponentSet);
-            Assert.IsTrue(tester.siblingInterfaceSingle == null);
-            CollectionAssert.IsEmpty(tester.siblingInterfaceArray);
-            CollectionAssert.IsEmpty(tester.siblingInterfaceList);
-            CollectionAssert.IsEmpty(tester.siblingInterfaceSet);
-            Assert.AreSame(parent.Count == 0 ? null : parent[0], tester.parentExactSingle);
-            CollectionAssert.AreEqual(parent, tester.parentExactArray);
-            CollectionAssert.AreEqual(parent, tester.parentExactList);
-            CollectionAssert.AreEquivalent(parent, tester.parentExactSet);
-            Assert.IsTrue(tester.parentBaseSingle == null);
-            CollectionAssert.IsEmpty(tester.parentBaseArray);
-            CollectionAssert.IsEmpty(tester.parentBaseList);
-            CollectionAssert.IsEmpty(tester.parentBaseSet);
-            Assert.IsTrue(tester.parentComponentSingle == null);
-            CollectionAssert.IsEmpty(tester.parentComponentArray);
-            CollectionAssert.IsEmpty(tester.parentComponentList);
-            CollectionAssert.IsEmpty(tester.parentComponentSet);
-            Assert.IsTrue(tester.parentInterfaceSingle == null);
-            CollectionAssert.IsEmpty(tester.parentInterfaceArray);
-            CollectionAssert.IsEmpty(tester.parentInterfaceList);
-            CollectionAssert.IsEmpty(tester.parentInterfaceSet);
-            Assert.AreSame(child.Count == 0 ? null : child[0], tester.childExactSingle);
-            CollectionAssert.AreEqual(child, tester.childExactArray);
-            CollectionAssert.AreEqual(child, tester.childExactList);
-            CollectionAssert.AreEquivalent(child, tester.childExactSet);
-            Assert.IsTrue(tester.childBaseSingle == null);
-            CollectionAssert.IsEmpty(tester.childBaseArray);
-            CollectionAssert.IsEmpty(tester.childBaseList);
-            CollectionAssert.IsEmpty(tester.childBaseSet);
-            Assert.IsTrue(tester.childComponentSingle == null);
-            CollectionAssert.IsEmpty(tester.childComponentArray);
-            CollectionAssert.IsEmpty(tester.childComponentList);
-            CollectionAssert.IsEmpty(tester.childComponentSet);
-            Assert.IsTrue(tester.childInterfaceSingle == null);
-            CollectionAssert.IsEmpty(tester.childInterfaceArray);
-            CollectionAssert.IsEmpty(tester.childInterfaceList);
-            CollectionAssert.IsEmpty(tester.childInterfaceSet);
-        }
-
-        private static List<RelationalExactComponent> ExactComponentsOn(Transform owner)
-        {
-            List<RelationalExactComponent> expected = new();
-            foreach (Component candidate in owner.GetComponents<Component>())
-            {
-                if (candidate != null && candidate.GetType() == typeof(RelationalExactComponent))
-                {
-                    expected.Add((RelationalExactComponent)candidate);
-                }
-            }
-            return expected;
+            VerifyExactTypeAssignment(depth, inactive, capability);
         }
 
         [Test]

--- a/Tests/Runtime/Attributes/RelationalComponentExtensionsTests.cs
+++ b/Tests/Runtime/Attributes/RelationalComponentExtensionsTests.cs
@@ -4,6 +4,7 @@
 namespace WallstopStudios.UnityHelpers.Tests.Attributes
 {
     using System;
+    using System.Collections.Generic;
     using NUnit.Framework;
     using UnityEngine;
     using UnityEngine.TestTools;
@@ -16,6 +17,165 @@ namespace WallstopStudios.UnityHelpers.Tests.Attributes
     [NUnit.Framework.Category("Fast")]
     public sealed class RelationalComponentExtensionsTests : CommonTestBase
     {
+        [Test]
+        public void ExactTypeAssignmentMatchesDirectQueriesAcrossShapesAndCacheStates(
+            [Values(1, 4)] int depth,
+            [Values(false, true)] bool inactive,
+            [Values(0, 1, 2)] int capability
+        )
+        {
+            using IDisposable scope = ReflectionHelpers.OverrideReflectionCapabilities(
+                capability == 0,
+                capability == 1
+            );
+            SiblingComponentExtensions.ClearCachedFieldMetadata();
+            ParentComponentExtensions.ClearCachedFieldMetadata();
+            ChildComponentExtensions.ClearCachedFieldMetadata();
+            ReflectionHelpers.ClearFieldSetterCache();
+            GameObject root = CreateExactTypeCandidates("ExactRoot");
+            GameObject ancestor = root;
+            for (int level = 1; level < depth; level++)
+            {
+                GameObject next = CreateExactTypeCandidates("ExactAncestor");
+                next.transform.SetParent(ancestor.transform);
+                ancestor = next;
+            }
+            GameObject owner = CreateExactTypeCandidates("ExactOwner");
+            owner.transform.SetParent(ancestor.transform);
+            RelationalExactTypeTester tester = owner.AddComponent<RelationalExactTypeTester>();
+            GameObject first = CreateExactTypeCandidates("ExactFirstChild");
+            first.transform.SetParent(owner.transform);
+            GameObject grandchild = CreateExactTypeCandidates("ExactGrandchild");
+            grandchild.transform.SetParent(first.transform);
+            GameObject second = CreateExactTypeCandidates("ExactSecondChild");
+            second.transform.SetParent(owner.transform);
+            root.SetActive(!inactive);
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            CreateExactTypeCandidates("ExactUnrelated");
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            second.transform.SetAsFirstSibling();
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            foreach (RelationalExactComponent candidate in ExactComponentsOn(first.transform))
+            {
+                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
+            }
+            foreach (RelationalExactComponent candidate in ExactComponentsOn(second.transform))
+            {
+                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
+            }
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+            foreach (
+                RelationalExactComponent candidate in root.GetComponentsInChildren<RelationalExactComponent>(
+                    true
+                )
+            )
+            {
+                UnityEngine.Object.DestroyImmediate(candidate); // UNH-SUPPRESS: Rebinding must discard destroyed candidates before teardown.
+            }
+            AssertExactTypeAssignmentMatchesDirectQueries(tester);
+        }
+
+        private GameObject CreateExactTypeCandidates(string name)
+        {
+            GameObject candidate = Track(new GameObject(name));
+            candidate.AddComponent<RelationalExactDerivedComponent>();
+            candidate.AddComponent<RelationalExactComponent>();
+            candidate.AddComponent<RelationalExactComponent>();
+            return candidate;
+        }
+
+        private static void AssertExactTypeAssignmentMatchesDirectQueries(
+            RelationalExactTypeTester tester
+        )
+        {
+            List<RelationalExactComponent> sibling = ExactComponentsOn(tester.transform);
+            List<RelationalExactComponent> parent = new();
+            Transform ancestor = tester.transform.parent;
+            while (ancestor != null)
+            {
+                parent.AddRange(ExactComponentsOn(ancestor));
+                ancestor = ancestor.parent;
+            }
+            List<RelationalExactComponent> child = new();
+            Queue<Transform> pending = new();
+            foreach (Transform directChild in tester.transform)
+            {
+                pending.Enqueue(directChild);
+            }
+            while (0 < pending.Count)
+            {
+                Transform current = pending.Dequeue();
+                child.AddRange(ExactComponentsOn(current));
+                foreach (Transform descendant in current)
+                {
+                    pending.Enqueue(descendant);
+                }
+            }
+            tester.AssignRelationalComponents();
+            Assert.AreSame(sibling.Count == 0 ? null : sibling[0], tester.siblingExactSingle);
+            CollectionAssert.AreEqual(sibling, tester.siblingExactArray);
+            CollectionAssert.AreEqual(sibling, tester.siblingExactList);
+            CollectionAssert.AreEquivalent(sibling, tester.siblingExactSet);
+            Assert.IsTrue(tester.siblingBaseSingle == null);
+            CollectionAssert.IsEmpty(tester.siblingBaseArray);
+            CollectionAssert.IsEmpty(tester.siblingBaseList);
+            CollectionAssert.IsEmpty(tester.siblingBaseSet);
+            Assert.IsTrue(tester.siblingComponentSingle == null);
+            CollectionAssert.IsEmpty(tester.siblingComponentArray);
+            CollectionAssert.IsEmpty(tester.siblingComponentList);
+            CollectionAssert.IsEmpty(tester.siblingComponentSet);
+            Assert.IsTrue(tester.siblingInterfaceSingle == null);
+            CollectionAssert.IsEmpty(tester.siblingInterfaceArray);
+            CollectionAssert.IsEmpty(tester.siblingInterfaceList);
+            CollectionAssert.IsEmpty(tester.siblingInterfaceSet);
+            Assert.AreSame(parent.Count == 0 ? null : parent[0], tester.parentExactSingle);
+            CollectionAssert.AreEqual(parent, tester.parentExactArray);
+            CollectionAssert.AreEqual(parent, tester.parentExactList);
+            CollectionAssert.AreEquivalent(parent, tester.parentExactSet);
+            Assert.IsTrue(tester.parentBaseSingle == null);
+            CollectionAssert.IsEmpty(tester.parentBaseArray);
+            CollectionAssert.IsEmpty(tester.parentBaseList);
+            CollectionAssert.IsEmpty(tester.parentBaseSet);
+            Assert.IsTrue(tester.parentComponentSingle == null);
+            CollectionAssert.IsEmpty(tester.parentComponentArray);
+            CollectionAssert.IsEmpty(tester.parentComponentList);
+            CollectionAssert.IsEmpty(tester.parentComponentSet);
+            Assert.IsTrue(tester.parentInterfaceSingle == null);
+            CollectionAssert.IsEmpty(tester.parentInterfaceArray);
+            CollectionAssert.IsEmpty(tester.parentInterfaceList);
+            CollectionAssert.IsEmpty(tester.parentInterfaceSet);
+            Assert.AreSame(child.Count == 0 ? null : child[0], tester.childExactSingle);
+            CollectionAssert.AreEqual(child, tester.childExactArray);
+            CollectionAssert.AreEqual(child, tester.childExactList);
+            CollectionAssert.AreEquivalent(child, tester.childExactSet);
+            Assert.IsTrue(tester.childBaseSingle == null);
+            CollectionAssert.IsEmpty(tester.childBaseArray);
+            CollectionAssert.IsEmpty(tester.childBaseList);
+            CollectionAssert.IsEmpty(tester.childBaseSet);
+            Assert.IsTrue(tester.childComponentSingle == null);
+            CollectionAssert.IsEmpty(tester.childComponentArray);
+            CollectionAssert.IsEmpty(tester.childComponentList);
+            CollectionAssert.IsEmpty(tester.childComponentSet);
+            Assert.IsTrue(tester.childInterfaceSingle == null);
+            CollectionAssert.IsEmpty(tester.childInterfaceArray);
+            CollectionAssert.IsEmpty(tester.childInterfaceList);
+            CollectionAssert.IsEmpty(tester.childInterfaceSet);
+        }
+
+        private static List<RelationalExactComponent> ExactComponentsOn(Transform owner)
+        {
+            List<RelationalExactComponent> expected = new();
+            foreach (Component candidate in owner.GetComponents<Component>())
+            {
+                if (candidate != null && candidate.GetType() == typeof(RelationalExactComponent))
+                {
+                    expected.Add((RelationalExactComponent)candidate);
+                }
+            }
+            return expected;
+        }
+
         [Test]
         public void AssignmentMatchesDirectQueriesAcrossCacheAndHierarchyChanges(
             [Values(1, 4)] int depth,

--- a/Tests/Runtime/Random/NativePcgRandomTests.cs
+++ b/Tests/Runtime/Random/NativePcgRandomTests.cs
@@ -358,6 +358,42 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             {
                 Assert.AreEqual(expected[i], random.NextUint(), $"Seed {seed}, draw {i}.");
             }
+
+            random = new NativePcgRandom(seed);
+            for (int i = 0; i < expected.Length; i += 2)
+            {
+                ulong expectedWord = ((ulong)expected[i] << 32) | expected[i + 1];
+                Assert.AreEqual(
+                    expectedWord,
+                    random.NextUlong(),
+                    $"Seed {seed}, 64-bit draw {i / 2}."
+                );
+            }
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(31)]
+        [TestCase(32)]
+        [TestCase(33)]
+        public void ValueCopyPreservesPartiallyConsumedBitReservoir(int boolDraws)
+        {
+            NativePcgRandom random = new(12345);
+            for (int i = 0; i < boolDraws; ++i)
+            {
+                random.NextBool();
+            }
+
+            NativePcgRandom copy = random;
+            for (int i = 0; i < 128; ++i)
+            {
+                Assert.AreEqual(random.NextBool(), copy.NextBool());
+                Assert.AreEqual(random.NextUint(), copy.NextUint());
+                Assert.AreEqual(random.NextUlong(), copy.NextUlong());
+                Assert.AreEqual(random.NextFloat(), copy.NextFloat());
+                Assert.AreEqual(random.NextDouble(), copy.NextDouble());
+                Assert.AreEqual(random.NextLong(), copy.NextLong());
+            }
         }
 
         [Test]

--- a/Tests/Runtime/Random/RandomRawStreamCompatibilityTests.cs
+++ b/Tests/Runtime/Random/RandomRawStreamCompatibilityTests.cs
@@ -1,0 +1,580 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
+{
+    using System;
+    using System.Security.Cryptography;
+    using NUnit.Framework;
+    using WallstopStudios.UnityHelpers.Core.Random;
+
+    [TestFixture]
+    [Category("Fast")]
+    public sealed class RandomRawStreamCompatibilityTests
+    {
+        private const int StreamBytes = 1024 * 1024;
+
+        // The host gate checks these frozen hashes against raw-stream-vectors.json; never regenerate them from the candidate.
+        [TestCase(
+            nameof(BlastCircuitRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "f69beb2f87d3f55600d3cc731735752e56f73e84d6825dc8a0c3eee610e66c9f"
+        )]
+        [TestCase(
+            nameof(BlastCircuitRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "067aa58f406c6904197b9fb73125554cc0c7ba1eef291a353da5f9da8b1745dc"
+        )]
+        [TestCase(
+            nameof(BlastCircuitRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "77573e1ed283dcf2058615b1c0783778f2728631873d3b236cd46bff26c836ad"
+        )]
+        [TestCase(
+            nameof(BlastCircuitRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "b5656d450287b3c57cc707fd772c40dde5508804856acf424431e6fc05b4369b"
+        )]
+        [TestCase(
+            nameof(DotNetRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "319c5db84e7ab7cdcc94ecc4b887d7654fe92bb47ba756e159c9f8ba2f378c43"
+        )]
+        [TestCase(
+            nameof(DotNetRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "397a7ec914aa010cb74dc3a36d792b09bc4d6baab48364ddfee3b1ab4a7ddc81"
+        )]
+        [TestCase(
+            nameof(DotNetRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "8c87b0835704418fb6a9d6b054ef731ad6e08c54408e71a5ab782d2af38182fa"
+        )]
+        [TestCase(
+            nameof(DotNetRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "3673774a95f2f5d73bbbed10aca0448925019f7de1c9ed744cdadea47f47a508"
+        )]
+        [TestCase(
+            nameof(FlurryBurstRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "4b2d711e1ed00ec5114ef3dbc2c4ddc0e5638c68fc6276456c71ce73b1337193"
+        )]
+        [TestCase(
+            nameof(FlurryBurstRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "fdab67939ab4a5bebb6bb176d1910a00bb0bf30d7b901d8264fea905cfb26e88"
+        )]
+        [TestCase(
+            nameof(FlurryBurstRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "1794576cdae9bae668768e04e52c3340fc27ada822771d70687a4227a4814ad9"
+        )]
+        [TestCase(
+            nameof(FlurryBurstRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "8df9c108b0968ec000573bef28749694bf88e967c203044105b354744983e21f"
+        )]
+        [TestCase(
+            nameof(IllusionFlow),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "8999a430a85e310b659ede5edacd0619089e40ffec3becd35361a5d815395eed"
+        )]
+        [TestCase(
+            nameof(IllusionFlow),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "f712a3b32b4f002eb680a8d6bd338b0b7972b74788199d715b52e16b4b23deef"
+        )]
+        [TestCase(
+            nameof(IllusionFlow),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "491221de56af4fcbb7977678286d01bf523518f3c755b3ea8d9bd14c9d555bb7"
+        )]
+        [TestCase(
+            nameof(IllusionFlow),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "ea8b53279d9369b01837156ea93aa25f7c39aacf8c88c36c4e5fc27c0199351c"
+        )]
+        [TestCase(
+            nameof(LinearCongruentialGenerator),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "27bf23ba7feac744c52e959837c3beacfe7edfa5ef027347601c4ac90c2425ea"
+        )]
+        [TestCase(
+            nameof(LinearCongruentialGenerator),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "ff37c23885a8b7070bc1f61508e51d0e861848e55ae22e30cf8a04d62bd351b6"
+        )]
+        [TestCase(
+            nameof(LinearCongruentialGenerator),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "ca631aa1e0dcb32f268e95b084672f2f390f5bbb749acc313f0ad0a723059d77"
+        )]
+        [TestCase(
+            nameof(LinearCongruentialGenerator),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "dc460effe866a4995d10f1ca0953e7ef556961c7334fcb92fe46291c12a1036c"
+        )]
+        [TestCase(
+            nameof(PcgRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "11aab2b8e699ef14867699c0d313dbbce22106975b43a61e54cbba1ec3b2e123"
+        )]
+        [TestCase(
+            nameof(PcgRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "c6f350197a86b748c62f49eccc05002f187bf72be433c6f19df83b27e2ca54fe"
+        )]
+        [TestCase(
+            nameof(PcgRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "1c5507b299539910a7dd4c619ed7020a5b23f036c5a8e8212e0b2a130c87b7be"
+        )]
+        [TestCase(
+            nameof(PcgRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "d03083de83dc05cd073f9a65f008b809ed0471f856cff25d46d9325a0e0c7018"
+        )]
+        [TestCase(
+            nameof(PhotonSpinRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "1860e6dfab8763829926cb7b94f49b66c069681fd8916e6c646293617a7790b8"
+        )]
+        [TestCase(
+            nameof(PhotonSpinRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "806262d375e31b81d49bdf5cf811186fec64d7b3c6c384b7be5b7cca9ca48087"
+        )]
+        [TestCase(
+            nameof(PhotonSpinRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "ff9f5d50232181a7028fbc1315846f1d58e8539409d06e6420a7590f3f01fdfa"
+        )]
+        [TestCase(
+            nameof(PhotonSpinRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "f660617bd05f4e236965f1d69f58c3234f3eb4f45348f33f2b6480b382ff20ad"
+        )]
+        [TestCase(
+            nameof(RomuDuo),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "a7acd97e74a5073b8ee6ed804bf31b53fab5983a0a331312e9be2725808da164"
+        )]
+        [TestCase(
+            nameof(RomuDuo),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "a31e5272a08c6ccdbc8b4aca3aa8992d4e59be967a2aa40e6dcf59f0fed9d3e7"
+        )]
+        [TestCase(
+            nameof(RomuDuo),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "f43409409a28c05d65d39cb996adf41c8806e7592ff24d63d686c112bd9a37bc"
+        )]
+        [TestCase(
+            nameof(RomuDuo),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "b0f3f5f8f54636cad93bf1adf730c91db4f6d842fda8fc15c482df1404c5a52c"
+        )]
+        [TestCase(
+            nameof(Sfc64Random),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "a7abe3bc608eb5539e5fc2e49de10d1b58796fe770c9592f9d99dc518119a136"
+        )]
+        [TestCase(
+            nameof(Sfc64Random),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "45f105d13a69c0ebd90acdd191d2ec7e2b3b0725a899b59ef391082d00a58043"
+        )]
+        [TestCase(
+            nameof(Sfc64Random),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "c16e3c5b22145cdbc33929084473c4633927f385fa0c5eb93531b3a7f675fc25"
+        )]
+        [TestCase(
+            nameof(Sfc64Random),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "911e32ffd67048fe47d0514f52f4851e87dff8d0f645a9bdcb2d145a020052a3"
+        )]
+        [TestCase(
+            nameof(SplitMix64),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "68c10f88c109a3c0738f178bdcd5c341bbda86f049c39ac20e55f7219fe442a2"
+        )]
+        [TestCase(
+            nameof(SplitMix64),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "9c956658f43f44a8e64351dbb60e9167f1ec772b21d7c7af85cffa67ac41ded7"
+        )]
+        [TestCase(
+            nameof(SplitMix64),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "a505b1fa22c24c7ec1b548eb4536b66f4d3bed7f649830d2bcbc6b7b939db718"
+        )]
+        [TestCase(
+            nameof(SplitMix64),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "55c00c7448f1933eb17e16dd6611b1b2db6ad8e1ebf3d1d15900e3339d64728d"
+        )]
+        [TestCase(
+            nameof(SquirrelRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "fa8b334eace226d7daa313c536647b5b2cbb199ed1491d1fbe7755b64a8b3d6f"
+        )]
+        [TestCase(
+            nameof(SquirrelRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "6bfdb226be96e78070a73b0436eb025e1dd36a3006e9b3b15fc6a0d50f663870"
+        )]
+        [TestCase(
+            nameof(SquirrelRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "76bdddf6797d9805038531b277d74505b29b1d3df0a2680e1a203f348a36cf58"
+        )]
+        [TestCase(
+            nameof(SquirrelRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "3771bcfaac404d50e20b46fa0433ff52c90620e2cd35d4ef983da571ab8b82ba"
+        )]
+        [TestCase(
+            nameof(StormDropRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "eec7e630762440443d1cad27070750e53960fa3c71726e7d014836c4ead4da5c"
+        )]
+        [TestCase(
+            nameof(StormDropRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "c072142ec11e9d8069b0e1578ce1244677bbc13ebfc56993622726f9ff238dfd"
+        )]
+        [TestCase(
+            nameof(StormDropRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "9ccd800fa0ebeb2448d705cf33e50f784e579043a8a9a9ab6d7c6de85f6e2ab7"
+        )]
+        [TestCase(
+            nameof(StormDropRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "35c65bccc4f52a421f09f9448cbf1317aa4f43acd946d5cc0b2b6f51e509711d"
+        )]
+        [TestCase(
+            nameof(SystemRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "c75052d27c16a98aa7e2b7c2c5f3df8534e94bf487f2bffa36a4ad7684f0062b"
+        )]
+        [TestCase(
+            nameof(SystemRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "be5e278d99984d9be31f9538595f3ff7a24054198d67c5a0418c17f64367d0dc"
+        )]
+        [TestCase(
+            nameof(SystemRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "0c879763fb92d66c3f59242b4b6971c6d6ddb49b48cf9187d93629617b913df3"
+        )]
+        [TestCase(
+            nameof(SystemRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "bbba483a82331856a146bad80ec1d393d4d9c2ca4bb67e7653c2f4098b2a7f03"
+        )]
+        [TestCase(
+            nameof(WaveSplatRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "9638be189df075b1a8c6176ffcb9789934b4e9e256dbecadeaaf8df6475ec62d"
+        )]
+        [TestCase(
+            nameof(WaveSplatRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "acd2e54fd641f95479e50ddf392d7e0b641a490fbc204ab31516572cbe4164f5"
+        )]
+        [TestCase(
+            nameof(WaveSplatRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "421313dcefaefe1441a4dc732db542f49e07be550c73344547d454fff521c288"
+        )]
+        [TestCase(
+            nameof(WaveSplatRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "fd265484a488e4150b0ad2344c495b2dc5c824899c1043fdeee90f0a961125e5"
+        )]
+        [TestCase(
+            nameof(WDoomRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "da4aec9dbcf9a0360b905e6aeda4e86b1fbbebb2cc287946b9456eebe4b300c8"
+        )]
+        [TestCase(
+            nameof(WDoomRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "a6f6e68ff0ed255b63f81e6d90b171e945969a752a86fadf5871d30140a7aeb2"
+        )]
+        [TestCase(
+            nameof(WDoomRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "9d7416c0d8ac2a98d2c4195f38e763179dce36d029f1825f31b6e12ba6a3efee"
+        )]
+        [TestCase(
+            nameof(WDoomRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "5e1be916efe539b65b852735ea9ba45608a2dba7c95fed53b9432aab1c95963e"
+        )]
+        [TestCase(
+            nameof(WyRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "0ddeccfde49feb91ffbdef40c29f891b25f6efb4a5a98a5df570a7a7a8bd51f8"
+        )]
+        [TestCase(
+            nameof(WyRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "18306baecb97a46fdf9eabc15c7581b3e67bcce1b8a6296ce3b3c9f4eeb95265"
+        )]
+        [TestCase(
+            nameof(WyRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "0693b4002d2786f2614aaf3ed954d78dc09629031c5fc37653d19462cbe74c1e"
+        )]
+        [TestCase(
+            nameof(WyRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "64a9a2c6a4c9f61f06608f030c094334ff996515877e2050ce74826f4ff68cc5"
+        )]
+        [TestCase(
+            nameof(XoroShiroRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "3d2714b2e6bb322903142d08c1a99ba2b2e210def7338ff688f03335d9b27511"
+        )]
+        [TestCase(
+            nameof(XoroShiroRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "ac455fbe03ace2d2f7f53d36ad7b51ab7808d0f85e745f9f6408a18a679e6926"
+        )]
+        [TestCase(
+            nameof(XoroShiroRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "71364097953f46d3a5ed91cfb3670bfb3b4623c92fdb5e3e6d786869f97e3988"
+        )]
+        [TestCase(
+            nameof(XoroShiroRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "9777a9e198e4761bff5ab89f618262c760aebb7c3c53e0bfc40f6ee75c8aad09"
+        )]
+        [TestCase(
+            nameof(XorShiftRandom),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "98574c025e9532f508443d3b71e04e4d5a39252e6ef0c41f3a6ef3c06a627cb5"
+        )]
+        [TestCase(
+            nameof(XorShiftRandom),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "d23e7d7a655f54753e9832dbef671d957bbdce7e703d816412a05f365f8bd36e"
+        )]
+        [TestCase(
+            nameof(XorShiftRandom),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "d5ed2948816f848a50f9ce88b0afdd6edc0fce650887b99bc53d769142125116"
+        )]
+        [TestCase(
+            nameof(XorShiftRandom),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "9f679bd194ce17befc473c1b61fc394a8be41515e36a81e7f392c361cc9b759d"
+        )]
+        [TestCase(
+            nameof(Xoshiro128StarStar),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "118fd406f2c74f1263a08b7d61020957e7bec9c9483e47b98aadedb267f23711"
+        )]
+        [TestCase(
+            nameof(Xoshiro128StarStar),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "4641c67aa8b8b3bd391a4411c397735f7396db08191adbc67002259d0ea41400"
+        )]
+        [TestCase(
+            nameof(Xoshiro128StarStar),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "4e5703cc4efcf832fc4e1f19209b6016b152e3270b6df13fbbeb43020899d9e3"
+        )]
+        [TestCase(
+            nameof(Xoshiro128StarStar),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "1f957f29e62baf90efbbf47110d79b6f4e70b031da8215365dd12a238422e84b"
+        )]
+        [TestCase(
+            nameof(Xoshiro256StarStar),
+            32,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "8072f6ae33e090af9973253501481062e698ab7ab3805c3e7d34be46b79dd6fb"
+        )]
+        [TestCase(
+            nameof(Xoshiro256StarStar),
+            32,
+            "12345678-1234-1234-1234-123456789012",
+            "ed746d25042efc202f05193e54dbce6de7f552934ed3746189a7c2df736c5c6b"
+        )]
+        [TestCase(
+            nameof(Xoshiro256StarStar),
+            64,
+            "00010203-0405-0607-0809-0a0b0c0d0e0f",
+            "50b674ded19fc804629a2b70bfb07d6b7c522a74a430b7f81b93af5e5dee2c9d"
+        )]
+        [TestCase(
+            nameof(Xoshiro256StarStar),
+            64,
+            "12345678-1234-1234-1234-123456789012",
+            "0a470a15bf2d97b06abd6244ca3256089720f9702a6b6c61f46751891a9131a5"
+        )]
+        public void RawStreamMatchesFrozenBaseline(
+            string generator,
+            int width,
+            string seedText,
+            string expectedHash
+        )
+        {
+            Guid seed = new(seedText);
+            IRandom random = Create(generator, seed);
+            byte[] bytes = new byte[StreamBytes];
+            int sampleBytes = width / 8;
+            for (int offset = 0; offset < bytes.Length; offset += sampleBytes)
+            {
+                ulong sample = width == 32 ? random.NextUint() : random.NextUlong();
+                for (int index = 0; index < sampleBytes; ++index)
+                {
+                    bytes[offset + index] = unchecked((byte)(sample >> (index * 8)));
+                }
+            }
+
+            using SHA256 hash = SHA256.Create();
+            Assert.IsTrue(hash != null);
+            string actualHash = BitConverter
+                .ToString(hash.ComputeHash(bytes))
+                .Replace("-", "")
+                .ToLowerInvariant();
+            Assert.AreEqual(expectedHash, actualHash, $"{generator}/{width}/{seedText}");
+        }
+
+        private static IRandom Create(string generator, Guid seed)
+        {
+            byte[] seedBytes = seed.ToByteArray();
+            int integerSeed =
+                seedBytes[0] | (seedBytes[1] << 8) | (seedBytes[2] << 16) | (seedBytes[3] << 24);
+            switch (generator)
+            {
+                case nameof(BlastCircuitRandom):
+                    return new BlastCircuitRandom(seed);
+                case nameof(DotNetRandom):
+                    return new DotNetRandom(seed);
+                case nameof(FlurryBurstRandom):
+                    return new FlurryBurstRandom(seed);
+                case nameof(IllusionFlow):
+                    return new IllusionFlow(seed);
+                case nameof(LinearCongruentialGenerator):
+                    return new LinearCongruentialGenerator(seed);
+                case nameof(PcgRandom):
+                    return new PcgRandom(seed);
+                case nameof(PhotonSpinRandom):
+                    return new PhotonSpinRandom(seed);
+                case nameof(RomuDuo):
+                    return new RomuDuo(seed);
+                case nameof(Sfc64Random):
+                    return new Sfc64Random(seed);
+                case nameof(SplitMix64):
+                    return new SplitMix64(seed);
+                case nameof(SquirrelRandom):
+                    return new SquirrelRandom(integerSeed);
+                case nameof(StormDropRandom):
+                    return new StormDropRandom(seed);
+                case nameof(SystemRandom):
+                    return new SystemRandom(integerSeed);
+                case nameof(WaveSplatRandom):
+                    return new WaveSplatRandom(seed);
+                case nameof(WDoomRandom):
+                    return new WDoomRandom(integerSeed);
+                case nameof(WyRandom):
+                    return new WyRandom(seed);
+                case nameof(XoroShiroRandom):
+                    return new XoroShiroRandom(seed);
+                case nameof(XorShiftRandom):
+                    return new XorShiftRandom(seed);
+                case nameof(Xoshiro128StarStar):
+                    return new Xoshiro128StarStar(seed);
+                case nameof(Xoshiro256StarStar):
+                    return new Xoshiro256StarStar(seed);
+                default:
+                    Assert.Fail($"Missing constructor for frozen stream {generator}.");
+                    return null;
+            }
+        }
+    }
+}

--- a/Tests/Runtime/Random/RandomRawStreamCompatibilityTests.cs.meta
+++ b/Tests/Runtime/Random/RandomRawStreamCompatibilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e5f2e1594c4bcffe9816eb148006b12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/Random/UnityRandomTests.cs
+++ b/Tests/Runtime/Random/UnityRandomTests.cs
@@ -28,6 +28,43 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
 
         protected override IRandom NewRandom() => new UnityRandom(DeterministicSeedInt);
 
+        [TestCase(0, 32)]
+        [TestCase(-1, 32)]
+        [TestCase(int.MinValue, 32)]
+        [TestCase(int.MaxValue, 32)]
+        [TestCase(4242, 32)]
+        [TestCase(0, 64)]
+        [TestCase(-1, 64)]
+        [TestCase(int.MinValue, 64)]
+        [TestCase(int.MaxValue, 64)]
+        [TestCase(4242, 64)]
+        [Parallelizable(ParallelScope.None)]
+        public void RawStreamPreservesEngineAdapterDrawOrder(int seed, int width)
+        {
+            using RestorableGlobal<UnityEngine.Random.State>.Scope scope = EngineState.Borrow(
+                UnityEngine.Random.state
+            );
+            UnityEngine.Random.InitState(seed);
+            ulong[] expected = new ulong[1024];
+            for (int i = 0; i < expected.Length; ++i)
+            {
+                uint upper = unchecked((uint)UnityEngine.Random.Range(int.MinValue, int.MaxValue));
+                expected[i] =
+                    width == 32
+                        ? upper
+                        : ((ulong)upper << 32)
+                            | unchecked((uint)UnityEngine.Random.Range(int.MinValue, int.MaxValue));
+            }
+            UnityEngine.Random.State expectedPosition = UnityEngine.Random.state;
+
+            UnityRandom random = new(seed);
+            foreach (ulong word in expected)
+            {
+                Assert.AreEqual(word, width == 32 ? random.NextUint() : random.NextUlong());
+            }
+            Assert.AreEqual(expectedPosition, UnityEngine.Random.state);
+        }
+
         [TestCase(true, 0)]
         [TestCase(true, 1)]
         [TestCase(true, 2)]

--- a/Tests/Runtime/Serialization/WProtoReadLimitsTests.cs
+++ b/Tests/Runtime/Serialization/WProtoReadLimitsTests.cs
@@ -1,0 +1,463 @@
+// MIT License - Copyright (c) 2026 wallstop
+// Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
+
+namespace WallstopStudios.UnityHelpers.Tests.Serialization
+{
+    using System;
+    using NUnit.Framework;
+    using WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto;
+
+    /// <summary>Verifies wire limits before consuming or decoding attacker-controlled regions.</summary>
+    [TestFixture]
+    [Category("Fast")]
+    [Category("Serialization")]
+    public sealed class WProtoReadLimitsTests
+    {
+        [TestCase(-1, false)]
+        [TestCase(0, false)]
+        [TestCase(1, false)]
+        [TestCase(2, true)]
+        [TestCase(int.MaxValue, true)]
+        public void MessageSizeLimitIsInclusiveAndRefusesBeforeConsumption(int limit, bool accepted)
+        {
+            byte[] payload = { 8, 1 };
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumMessageBytes: limit)
+            );
+            Assert.AreEqual(!accepted, reader.Malformed);
+            Assert.AreEqual(0, reader.Position);
+            Assert.AreEqual(accepted, reader.TryReadTag(out int tag, out int wire));
+            Assert.AreEqual(accepted ? 1 : 0, tag);
+            Assert.AreEqual(accepted ? WProtoWireType.Varint : -1, wire);
+        }
+
+        [Test]
+        public void ZeroLimitsPermitAnEmptyRoot()
+        {
+            WProtoReader reader = new WProtoReader(default, new WProtoReadLimits(0, 0, 0, 0));
+            Assert.IsFalse(reader.TryReadTag(out _, out _));
+            Assert.IsFalse(reader.Malformed);
+            Assert.IsTrue(reader.End);
+        }
+
+        [TestCase(nameof(WProtoReader.TryReadBytes), 1, false)]
+        [TestCase(nameof(WProtoReader.TryReadBytes), 2, true)]
+        [TestCase(nameof(WProtoReader.TryReadString), 1, false)]
+        [TestCase(nameof(WProtoReader.TryReadString), 2, true)]
+        [TestCase(nameof(WProtoReader.TryReadMessage), 1, false)]
+        [TestCase(nameof(WProtoReader.TryReadMessage), 2, true)]
+        [TestCase(nameof(WProtoReader.TryReadPackedRun), 1, false)]
+        [TestCase(nameof(WProtoReader.TryReadPackedRun), 2, true)]
+        [TestCase(nameof(WProtoReader.TrySkipField), 1, false)]
+        [TestCase(nameof(WProtoReader.TrySkipField), 2, true)]
+        public void LengthLimitCoversEveryDelimitedRead(string operation, int limit, bool accepted)
+        {
+            byte[] payload = { 2, 8, 1 };
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumLengthDelimitedBytes: limit)
+            );
+            bool actual;
+            switch (operation)
+            {
+                case nameof(WProtoReader.TryReadBytes):
+                    actual = reader.TryReadBytes(out ReadOnlySpan<byte> bytes);
+                    Assert.AreEqual(accepted ? 2 : 0, bytes.Length);
+                    break;
+                case nameof(WProtoReader.TryReadString):
+                    actual = reader.TryReadString(out string text);
+                    Assert.AreEqual(accepted ? "\b\u0001" : null, text);
+                    break;
+                case nameof(WProtoReader.TryReadMessage):
+                    actual = reader.TryReadMessage(out WProtoReader nested);
+                    Assert.AreEqual(!accepted, nested.Malformed);
+                    break;
+                case nameof(WProtoReader.TryReadPackedRun):
+                    actual = reader.TryReadPackedRun(out WProtoReader packed);
+                    Assert.AreEqual(!accepted, packed.Malformed);
+                    break;
+                default:
+                    actual = reader.TrySkipField(1, WProtoWireType.LengthDelimited);
+                    break;
+            }
+
+            Assert.AreEqual(accepted, actual);
+            Assert.AreEqual(!accepted, reader.Malformed);
+            Assert.AreEqual(accepted ? payload.Length : 1, reader.Position);
+            if (!accepted)
+            {
+                Assert.IsFalse(reader.TryReadRemaining(out ReadOnlySpan<byte> remaining));
+                Assert.IsTrue(remaining.IsEmpty);
+                Assert.AreEqual(1, reader.Position);
+            }
+        }
+
+        [TestCase(-1)]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        public void DuplicateAndUnknownTagsSpendTheSameFieldBudget(int configured)
+        {
+            byte[] payload = { 8, 1, 8, 2, 16, 3 };
+            int limit = configured < 0 ? 0 : configured;
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumFieldCount: configured)
+            );
+            int count = 0;
+            while (reader.TryReadTag(out int tag, out int wire))
+            {
+                Assert.IsTrue(reader.TrySkipField(tag, wire));
+                count++;
+            }
+
+            Assert.AreEqual(limit, count);
+            Assert.AreEqual(limit * 2, reader.Position);
+            Assert.IsTrue(reader.Malformed);
+        }
+
+        [TestCase(1)]
+        [TestCase(64)]
+        [TestCase(1024)]
+        public void DuplicateStormStopsAtTheConfiguredWorkBound(int limit)
+        {
+            byte[] payload = new byte[20000];
+            for (int index = 0; index < payload.Length; index += 2)
+            {
+                payload[index] = 8;
+                payload[index + 1] = 1;
+            }
+
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumFieldCount: limit)
+            );
+            int reads = 0;
+            while (reader.TryReadTag(out int tag, out int wire))
+            {
+                Assert.IsTrue(reader.TrySkipField(tag, wire));
+                reads++;
+            }
+
+            Assert.AreEqual(limit, reads);
+            Assert.AreEqual(limit * 2, reader.Position);
+            Assert.IsTrue(reader.Malformed);
+        }
+
+        [Test]
+        public void ZeroLengthFieldsAreAcceptedAtTheZeroLengthLimit()
+        {
+            WProtoReader reader = new WProtoReader(
+                new byte[] { 0 },
+                new WProtoReadLimits(maximumLengthDelimitedBytes: 0)
+            );
+            Assert.IsTrue(reader.TryReadString(out string value));
+            Assert.AreEqual(string.Empty, value);
+            Assert.IsFalse(reader.Malformed);
+            Assert.IsTrue(reader.End);
+        }
+
+        [Test]
+        public void NullLimitsPreserveDefaultReaderBehavior()
+        {
+            WProtoReader reader = new WProtoReader(new byte[] { 8, 1 }, (WProtoReadLimits)null);
+            Assert.IsTrue(reader.TryReadTag(out int tag, out int wire));
+            Assert.IsTrue(reader.TrySkipField(tag, wire));
+            Assert.IsFalse(reader.Malformed);
+            Assert.IsTrue(reader.End);
+        }
+
+        [Test]
+        public void FieldBudgetAtExactEndIsNotMalformed()
+        {
+            byte[] payload = { 8, 1 };
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumFieldCount: 1)
+            );
+            Assert.IsTrue(reader.TryReadTag(out int tag, out int wire));
+            Assert.IsTrue(reader.TrySkipField(tag, wire));
+            Assert.IsFalse(reader.TryReadTag(out _, out _));
+            Assert.IsFalse(reader.Malformed);
+        }
+
+        [TestCase(2, false)]
+        [TestCase(3, true)]
+        public void SkippedGroupsIncludeTheirTagsAndTerminators(int limit, bool accepted)
+        {
+            byte[] payload = { 11, 16, 1, 12 };
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumFieldCount: limit)
+            );
+            Assert.IsTrue(reader.TryReadTag(out int tag, out int wire));
+            Assert.AreEqual(accepted, reader.TrySkipField(tag, wire));
+            Assert.AreEqual(!accepted, reader.Malformed);
+        }
+
+        [TestCase(0, false)]
+        [TestCase(1, true)]
+        public void GroupDepthUsesTheConfiguredLimit(int depth, bool accepted)
+        {
+            byte[] payload = { 11, 12 };
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumNestingDepth: depth)
+            );
+            Assert.IsTrue(reader.TryReadTag(out int tag, out int wire));
+            Assert.AreEqual(accepted, reader.TrySkipField(tag, wire));
+            Assert.AreEqual(!accepted, reader.Malformed);
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(4)]
+        public void DetachedAndNestedReadersPreserveDepthLimits(int depth)
+        {
+            WProtoReader reader = new WProtoReader(
+                default,
+                new WProtoReadLimits(maximumNestingDepth: depth)
+            );
+            AssertDepthLimit(ref reader, depth);
+        }
+
+        private static void AssertDepthLimit(ref WProtoReader reader, int depth)
+        {
+            if (reader.Depth < depth)
+            {
+                WProtoReader child = new WProtoReader(default, in reader);
+                Assert.IsFalse(child.Malformed);
+                AssertDepthLimit(ref child, depth);
+                return;
+            }
+
+            Assert.AreEqual(depth, reader.Depth);
+            WProtoReader refused = new WProtoReader(default, in reader);
+            Assert.IsTrue(refused.Malformed);
+            Assert.IsFalse(reader.TryReadMessage(out WProtoReader nested));
+            Assert.IsTrue(reader.Malformed);
+            Assert.IsTrue(nested.Malformed);
+        }
+
+        [Test]
+        public void NestedReadersHaveIndependentFieldCountsWithInheritedLimits()
+        {
+            byte[] payload = { 10, 4, 8, 1, 8, 2 };
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumFieldCount: 1)
+            );
+            Assert.IsTrue(reader.TryReadTag(out _, out _));
+            Assert.IsTrue(reader.TryReadMessage(out WProtoReader nested));
+            Assert.IsTrue(nested.TryReadTag(out _, out _));
+            Assert.IsTrue(nested.TryReadInt32(out _));
+            Assert.IsFalse(nested.TryReadTag(out _, out _));
+            Assert.IsTrue(nested.Malformed);
+            Assert.AreEqual(2, nested.Position);
+        }
+
+        [Test]
+        public void PackedRunsDoNotSpendDepthOrTreatElementsAsTags()
+        {
+            byte[] payload = { 10, 2, 1, 2 };
+            WProtoReader reader = new WProtoReader(
+                payload,
+                new WProtoReadLimits(maximumFieldCount: 1, maximumNestingDepth: 0)
+            );
+            Assert.IsTrue(reader.TryReadTag(out _, out _));
+            Assert.IsTrue(reader.TryReadPackedRun(out WProtoReader packed));
+            Assert.AreEqual(0, packed.Depth);
+            Assert.AreEqual(2, packed.CountPackedElements(WProtoWireType.Varint));
+            Assert.IsTrue(packed.TryReadInt32(out _));
+            Assert.IsTrue(packed.TryReadInt32(out _));
+            Assert.IsTrue(packed.End);
+            Assert.IsFalse(packed.Malformed);
+        }
+
+        [Test]
+        public void DetachedOversizedPayloadNeverReachesTheFormatter()
+        {
+            WProtoReader reader = new WProtoReader(
+                default,
+                new WProtoReadLimits(maximumMessageBytes: 1)
+            );
+            CountingFormatter formatter = new CountingFormatter();
+            byte[] payload = { 8, 1 };
+            Assert.IsFalse(reader.TryReadMessage(payload, formatter, out int value));
+            Assert.AreEqual(0, value);
+            Assert.AreEqual(0, formatter.Reads);
+            Assert.IsTrue(reader.Malformed);
+        }
+
+        [Test]
+        public void FormatterCannotReplaceTheRootReaderToDiscardLimits()
+        {
+            IWProtoFormatter<LimitMarker> original = WProtoFormatterProvider.TryGet(
+                out IWProtoFormatter<LimitMarker> registered
+            )
+                ? registered
+                : null;
+            try
+            {
+                WProtoFormatterProvider.Register<LimitMarker>(new ResettingFormatter());
+                Assert.Throws<InvalidOperationException>(() =>
+                    WProtoFacade.TryDeserialize(
+                        ReadOnlySpan<byte>.Empty,
+                        new WProtoReadLimits(maximumFieldCount: 1),
+                        out LimitMarker _
+                    )
+                );
+            }
+            finally
+            {
+                WProtoFormatterProvider.Register(original);
+            }
+        }
+
+        [Test]
+        public void FacadeRejectsAnOversizedRootBeforeCallingTheFormatter()
+        {
+            IWProtoFormatter<LimitMarker> original = WProtoFormatterProvider.TryGet(
+                out IWProtoFormatter<LimitMarker> registered
+            )
+                ? registered
+                : null;
+            try
+            {
+                MarkerFormatter formatter = new MarkerFormatter();
+                WProtoFormatterProvider.Register<LimitMarker>(formatter);
+                Assert.Throws<InvalidOperationException>(() =>
+                    WProtoFacade.TryDeserialize(
+                        new byte[] { 8, 1 },
+                        new WProtoReadLimits(maximumMessageBytes: 1),
+                        out LimitMarker _
+                    )
+                );
+                Assert.AreEqual(0, formatter.Reads);
+            }
+            finally
+            {
+                WProtoFormatterProvider.Register(original);
+            }
+        }
+
+        [TestCase(0, false)]
+        [TestCase(1, true)]
+        public void FacadePropagatesFieldLimitsAndKeepsItsRoutingContract(int limit, bool accepted)
+        {
+            IWProtoFormatter<LimitMarker> original = WProtoFormatterProvider.TryGet(
+                out IWProtoFormatter<LimitMarker> registered
+            )
+                ? registered
+                : null;
+            try
+            {
+                WProtoFormatterProvider.Register<LimitMarker>(new MarkerFormatter());
+                byte[] payload = { 8, 1 };
+                WProtoReadLimits limits = new WProtoReadLimits(maximumFieldCount: limit);
+                if (accepted)
+                {
+                    Assert.IsTrue(WProtoFacade.TryDeserialize(payload, limits, out LimitMarker _));
+                    Assert.IsTrue(
+                        WProtoFacade.TryDeserializeAs(
+                            payload,
+                            typeof(LimitMarker),
+                            limits,
+                            out LimitMarker _
+                        )
+                    );
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() =>
+                        WProtoFacade.TryDeserialize(payload, limits, out LimitMarker _)
+                    );
+                    Assert.Throws<InvalidOperationException>(() =>
+                        WProtoFacade.TryDeserializeAs(
+                            payload,
+                            typeof(LimitMarker),
+                            limits,
+                            out LimitMarker _
+                        )
+                    );
+                }
+
+                WProtoFormatterProvider.Register<LimitMarker>(null);
+                Assert.IsFalse(WProtoFacade.TryDeserialize(payload, limits, out LimitMarker _));
+            }
+            finally
+            {
+                WProtoFormatterProvider.Register(original);
+            }
+        }
+
+        [TestCase(-1, 0)]
+        [TestCase(0, 0)]
+        [TestCase(64, 64)]
+        [TestCase(int.MaxValue, 64)]
+        public void CallerCannotRaiseTheStackSafetyCeiling(int requested, int expected)
+        {
+            Assert.AreEqual(
+                expected,
+                new WProtoReadLimits(maximumNestingDepth: requested).MaximumNestingDepth
+            );
+        }
+
+        private sealed class CountingFormatter : IWProtoFormatter<int>
+        {
+            internal int Reads;
+
+            public int Measure(in int value) => 0;
+
+            public bool Write(ref WProtoWriter writer, in int value) => true;
+
+            public bool TryRead(ref WProtoReader reader, out int value)
+            {
+                Reads++;
+                value = 1;
+                return true;
+            }
+        }
+
+        private sealed class MarkerFormatter : IWProtoFormatter<LimitMarker>
+        {
+            internal int Reads;
+
+            public int Measure(in LimitMarker value) => 0;
+
+            public bool Write(ref WProtoWriter writer, in LimitMarker value) => true;
+
+            public bool TryRead(ref WProtoReader reader, out LimitMarker value)
+            {
+                Reads++;
+                value = default;
+                while (reader.TryReadTag(out int tag, out int wire))
+                {
+                    if (!reader.TrySkipField(tag, wire))
+                    {
+                        return false;
+                    }
+                }
+
+                return !reader.Malformed;
+            }
+        }
+
+        private struct LimitMarker { }
+
+        private sealed class ResettingFormatter : IWProtoFormatter<LimitMarker>
+        {
+            public int Measure(in LimitMarker value) => 0;
+
+            public bool Write(ref WProtoWriter writer, in LimitMarker value) => true;
+
+            public bool TryRead(ref WProtoReader reader, out LimitMarker value)
+            {
+                reader = default;
+                value = default;
+                return true;
+            }
+        }
+    }
+}

--- a/Tests/Runtime/Serialization/WProtoReadLimitsTests.cs
+++ b/Tests/Runtime/Serialization/WProtoReadLimitsTests.cs
@@ -13,6 +13,16 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
     [Category("Serialization")]
     public sealed class WProtoReadLimitsTests
     {
+        [Test]
+        public void ParameterlessConstructionSupportsGenericFactories()
+        {
+            WProtoReadLimits limits = CreateDefault<WProtoReadLimits>();
+            Assert.AreEqual(int.MaxValue, limits.MaximumMessageBytes);
+            Assert.AreEqual(int.MaxValue, limits.MaximumLengthDelimitedBytes);
+            Assert.AreEqual(int.MaxValue, limits.MaximumFieldCount);
+            Assert.AreEqual(WProtoReader.MaxNestingDepth, limits.MaximumNestingDepth);
+        }
+
         [TestCase(-1, false)]
         [TestCase(0, false)]
         [TestCase(1, false)]
@@ -402,6 +412,12 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                 expected,
                 new WProtoReadLimits(maximumNestingDepth: requested).MaximumNestingDepth
             );
+        }
+
+        private static T CreateDefault<T>()
+            where T : class, new()
+        {
+            return new T();
         }
 
         private sealed class CountingFormatter : IWProtoFormatter<int>

--- a/Tests/Runtime/Serialization/WProtoReadLimitsTests.cs.meta
+++ b/Tests/Runtime/Serialization/WProtoReadLimitsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51e902deaef4e9ec79a7b19129da89a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/features/editor-tools/editor-tools-guide.md
+++ b/docs/features/editor-tools/editor-tools-guide.md
@@ -394,6 +394,8 @@ Every texture in a fresh project imports at `Max Size: 2048`, whatever its real 
 icon wastes an import slot; a 4096-wide sky is silently halved. This reads each source file's actual
 dimensions and sets `Max Size` to the power of two that fits.
 
+Closing the window releases its serialized editor state; reopening binds fresh state.
+
 1. Add `Assets/Sprites` to the source list (the window pre-fills it if that folder exists).
 2. Choose a **Fit Mode**:
 
@@ -657,6 +659,9 @@ Putting a footstep sound on frame 4 of a run cycle in Unity's Animation window m
 right time value and typing a method name from memory. This shows the sprite at each event, lists the
 methods that are actually callable, and edits the parameter with the right field type.
 
+Changing clips or closing the window releases copied sprite previews. Unity's shared previews stay
+owned by Unity, and a failed preview copy releases its temporary texture.
+
 First, mark the methods you want to fire:
 
 <!-- doc-sample: compiles -->
@@ -727,6 +732,9 @@ By default an `[AnimationEvent]` method is offered on its declaring class only. 
 A `.spriteatlas` asset holds a hand-maintained list of sprites, so every new sprite an artist adds is
 one someone has to remember to drag in. This drives the atlas from a rule instead — a regex, an asset
 label, or both — and rescans on demand.
+
+Project changes rebuild the serialized editor state and drop removed configurations from the
+foldout cache while preserving surviving scan results. Closing the window releases its cached state.
 
 1. Click **Create New Config in 'Assets/Data'**. That makes a `ScriptableSpriteAtlas` asset (you can
    also use `Assets > Create > Wallstop Studios > Unity Helpers > Scriptable Sprite Atlas Config`).

--- a/docs/features/relational-components/relational-components.md
+++ b/docs/features/relational-components/relational-components.md
@@ -322,7 +322,13 @@ Unbounded collections without filters or depth limits use a cached Unity query a
   - Case-sensitive substring match on the GameObject name
 
 - `AllowInterfaces` (default: true)
-  - If `true`, can assign by interface or base type; set `false` to restrict to concrete types
+  - If `true`, can assign by interface or base type. With `false`, the candidate's runtime type must
+    exactly match the field's element type, even when that concrete type is not sealed. Derived
+    components, interface fields, and abstract base fields do not match. This applies equally to
+    single values, arrays, lists, and sets in every relation.
+  - When upgrading, fields using `AllowInterfaces = false` with a concrete type that is not sealed
+    now bind exact matches instead of remaining empty. A field declared as `Component` no longer
+    accepts derived components under this option; keep the default `true` for polymorphic binding.
 
 ### Choosing the Right Collection Type
 

--- a/docs/features/serialization/serialization.md
+++ b/docs/features/serialization/serialization.md
@@ -2416,6 +2416,41 @@ groups together. A formatter reads a sub-message by calling another formatter, s
 stack depth: a few kilobytes can describe two thousand levels, and a stack overflow cannot be
 caught. `TryReadMessage` refuses past the bound and reports it as malformed.
 
+For smaller protocol envelopes, construct immutable `WProtoReadLimits` once and reuse them:
+
+```csharp
+WProtoReadLimits limits = new WProtoReadLimits(
+    maximumMessageBytes: 64 * 1024,
+    maximumLengthDelimitedBytes: 16 * 1024,
+    maximumFieldCount: 1024,
+    maximumNestingDepth: 16
+);
+WProtoReader reader = new WProtoReader(bytes, limits);
+```
+
+The byte limit rejects an oversized reader region immediately, before a facade invokes its formatter.
+The length limit applies before slicing, copying, or decoding strings, bytes, packed fields, nested
+messages, and unknown length-delimited fields. The tag limit counts duplicate and unknown fields,
+including tags inside skipped groups and their terminators; it refuses the next tag without consuming
+it. A clean end exactly at the limit still succeeds. Limits propagate through nested, detached,
+merged, and packed readers. Each reader region has its own tag count, while skipped groups share
+that region's count. Packed elements have no tags, so the tag limit does not count them.
+
+`WProtoFacade.TryDeserialize(bytes, limits, out T value)` and its `TryDeserializeAs` overload also
+accept these limits. The facade retains its routing contract: `false` means the type is unhandled;
+a registered formatter refusing malformed or over-budget input raises `InvalidOperationException`
+and never retries the payload with protobuf-net. Reader methods instead return `false`, latch
+`Malformed`, and clear their output. A failed length read may consume its prefix, but not its payload;
+a failed nested or packed read returns a malformed child reader.
+
+Defaults preserve existing behavior: no additional wire-size or tag-count cap and a maximum depth
+of 64. Negative limits become zero; zero allows empty regions or fields but no tags or descent,
+respectively. Requested depth above 64 remains capped at 64. Limits are immutable and reusable across
+threads; constructing readers does not allocate a mutable budget object. These are **per-region wire
+limits**, not a cumulative decoded-object, collection-element, or retained-memory budget. Custom
+formatters remain responsible for their own allocations, and these overloads do not configure JSON
+or the legacy protobuf-net fallback.
+
 `TryReadMessage(formatter, ...)` accepts a hand-written formatter only when it returns success,
 leaves its nested reader well formed, and consumes the complete nested payload. A formatter cannot
 hide a malformed read or silently ignore a suffix. The root facade enforces the same complete-read

--- a/docs/features/serialization/serialization.md
+++ b/docs/features/serialization/serialization.md
@@ -2416,7 +2416,9 @@ groups together. A formatter reads a sub-message by calling another formatter, s
 stack depth: a few kilobytes can describe two thousand levels, and a stack overflow cannot be
 caught. `TryReadMessage` refuses past the bound and reports it as malformed.
 
-For smaller protocol envelopes, construct immutable `WProtoReadLimits` once and reuse them:
+Construct immutable `WProtoReadLimits` once and reuse them. The public parameterless constructor
+creates the default profile and supports generic `new()` factories. Use named constructor arguments
+to override individual limits for smaller protocol envelopes:
 
 ```csharp
 WProtoReadLimits limits = new WProtoReadLimits(

--- a/docs/images/unity-helpers-banner.svg
+++ b/docs/images/unity-helpers-banner.svg
@@ -132,11 +132,11 @@
           fill="none" stroke="#f39c12" stroke-width="1.4" opacity="0.85"/>
     <text x="75" y="17" text-anchor="middle" fill="#ffd9b5">🎮 Unity 2021.3+</text>
 
-    <!-- 13,000+ tests -->
+    <!-- 14,000+ tests -->
     <rect x="0" y="43" width="150" height="26" rx="13" ry="13" fill="#1a1a2e" opacity="0.88"/>
     <rect x="0" y="43" width="150" height="26" rx="13" ry="13"
           fill="none" stroke="#e94560" stroke-width="1.4" opacity="0.85"/>
-    <text x="75" y="60" text-anchor="middle" fill="#ffd9b5">✅️ 13,000+ tests</text>
+    <text x="75" y="60" text-anchor="middle" fill="#ffd9b5">✅️ 14,000+ tests</text>
 
     <!-- Performant -->
     <rect x="0" y="86" width="150" height="26" rx="13" ry="13" fill="#1a1a2e" opacity="0.88"/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -234,9 +234,9 @@ public class CharacterStats : MonoBehaviour
 
 <div class="feature-card" markdown>
 
-### 13,000+ Tests
+### 14,000+ Tests
 
-13,000+ automated tests.
+14,000+ automated tests.
 
 </div>
 

--- a/docs/overview/getting-started.md
+++ b/docs/overview/getting-started.md
@@ -49,7 +49,7 @@ Unity Helpers is a toolkit used in commercial games that reduces common boilerpl
 
 ### 3. ✅ Testing & Compatibility
 
-- ✅ **13,000+ automated tests** - Edge cases are handled through test coverage
+- ✅ **14,000+ automated tests** - Edge cases are handled through test coverage
 - ✅ **Shipped in commercial games** - Used at scale in production
 - ✅ **IL2CPP/WebGL compatible** - Works with aggressive compilers
 - ✅ **Schema evolution** - Player saves maintain compatibility across updates
@@ -321,7 +321,7 @@ Based on your needs:
 Yes! Unity Helpers is:
 
 - ✅ Used in shipped commercial games
-- ✅ 13,000+ automated test cases
+- ✅ 14,000+ automated test cases
 - ✅ Compatible with Unity 2022, 2023, and Unity 6
 - ✅ Zero external dependencies: protobuf-net is bundled
 - ✅ **Fully WebGL/IL2CPP compatible** with optimized SINGLE_THREADED hot paths

--- a/docs/performance/random-performance.md
+++ b/docs/performance/random-performance.md
@@ -179,8 +179,26 @@ The vectors come from main commit `14adde00a4e372a387dd2a3a3a845b47b7078cc6` and
 `scripts/random-quality/raw-stream-vectors.json`. Preserve them when changing bounded sampling;
 an intentional raw-stream change requires an explicit compatibility decision.
 
-This host gate covers the .NET implementation. UnityRandom, NativePcgRandom, native backends,
-and serialized continuation require their own Unity checks.
+`RandomRawStreamCompatibilityTests` runs all 80 one-MiB hashes inside Unity, using direct
+constructors so the cases also reach IL2CPP and WebGL test players. The host gate checks exact
+parity between the Unity cases and the frozen JSON inventory. A host pass does not prove a player
+pass: retain the executed fixture results for each Unity version and backend in the campaign.
+
+The two generators outside that host inventory have separate Unity fixtures:
+
+| Generator             | Raw compatibility check                                                        | Continuation check                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| 20 managed generators | 80 frozen hashes, two seeds and both widths                                    | Snapshot, copy, JSON and protobuf fixtures; generated protobuf runs on IL2CPP                           |
+| NativePcgRandom       | Existing integer-seed golden words at both widths                              | Value copies preserve partially consumed bit reservoirs; no RandomState or protobuf API                 |
+| UnityRandom           | Both widths match the current engine's integer draws and final engine position | Mixed snapshot, copy, JSON and generated protobuf continuation with cached Gaussian, bit and byte state |
+
+UnityRandom's adapter check intentionally follows the running engine. It does not promise identical
+Unity engine streams or snapshot payloads across engine versions. JSON and direct protobuf-net
+oracle cases that require unsupported reflection remain separately marked on IL2CPP. Raw hashes
+and continuation checks establish compatibility, not statistical quality, throughput or allocation
+performance; the paired player campaign and WebGL execution remain separate acceptance items.
+WDoomRandom intentionally skips the inherited statistical fixture; its snapshot, copy and protobuf
+paths have dedicated coverage, but its JSON continuation still needs an explicit fixture.
 
 ## Refreshing these numbers
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -62,7 +62,7 @@ Unity Helpers provides tested utilities for common Unity patterns. Benchmarks sh
 - 🎮 **Designer-friendly** effects system (buffs/debuffs as ScriptableObjects)
 - 🌳 **O(log n)** spatial queries instead of O(n) loops
 - 🛠️ **20+ editor tools** that automate sprite/animation workflows
-- ✅ **13,000+ tests**
+- ✅ **14,000+ tests**
 
 ---
 
@@ -380,7 +380,7 @@ Common Unity development patterns like GetComponent calls, spatial queries, and 
 **Built for Real Projects:**
 
 - ✅ **Tested** in shipped commercial games
-- ✅ **13,000+ automated tests** catch edge cases before you hit them
+- ✅ **14,000+ automated tests** catch edge cases before you hit them
 - ✅ **Zero external dependencies**: protobuf-net is bundled for binary serialization
 - ✅ **IL2CPP/WebGL ready** with optimized SINGLE_THREADED paths
 - ✅ **MIT Licensed** - use freely in commercial projects

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 >
 > - Professional inspector tooling, spatial data structures, PRNGs, serialization utilities
 > - Effects systems, relational components, and 20+ editor tools
-> - 13,000+ tests, IL2CPP/WebGL compatible, shipped in commercial games
+> - 14,000+ tests, IL2CPP/WebGL compatible, shipped in commercial games
 
 ## Key Information
 

--- a/scripts/agent-preflight.ps1
+++ b/scripts/agent-preflight.ps1
@@ -415,10 +415,9 @@ function Add-PathsToGitIndexWithRetry {
         return $false
     }
 
-    $indexLockPath = Join-Path -Path (Join-Path -Path $RepoRoot -ChildPath '.git') -ChildPath 'index.lock'
-
     Push-Location $RepoRoot
     try {
+        $indexLockPath = (Get-GitRepositoryInfo).IndexLockPath
         $exitCode = Invoke-GitAddWithRetry `
             -Items $uniquePaths `
             -IndexLockPath $indexLockPath `

--- a/scripts/git-staging-helpers.ps1
+++ b/scripts/git-staging-helpers.ps1
@@ -113,9 +113,14 @@ function Get-GitRepositoryInfo {
         $repoRoot = Split-Path -Parent $resolvedGitDir
     }
 
+    $indexPath = & git rev-parse --git-path index
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($indexPath)) {
+        throw "git rev-parse --git-path index failed; cannot determine the effective index."
+    }
+
     return [pscustomobject]@{
         Directory      = $resolvedGitDir
-        IndexLockPath  = (Join-Path -Path $resolvedGitDir -ChildPath 'index.lock')
+        IndexLockPath  = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$indexPath.lock")
         RepositoryRoot = $repoRoot.Trim()
     }
 }

--- a/scripts/git-staging-helpers.sh
+++ b/scripts/git-staging-helpers.sh
@@ -44,7 +44,6 @@ _GIT_FLOCK_HELD=0
 
 # Cache for git directory path (computed once per script run)
 _GIT_DIR=""
-_INDEX_LOCK_PATH=""
 
 # Log a message if verbose mode is enabled
 # Args:
@@ -80,14 +79,11 @@ get_git_dir() {
     echo "$_GIT_DIR"
 }
 
-# Get the path to .git/index.lock (cached)
+# Partial commits give hooks a separate index while Git holds the main index lock.
 get_index_lock_path() {
-    if [[ -z "$_INDEX_LOCK_PATH" ]]; then
-        local git_dir
-        git_dir=$(get_git_dir) || return 1
-        _INDEX_LOCK_PATH="$git_dir/index.lock"
-    fi
-    echo "$_INDEX_LOCK_PATH"
+    local index_path
+    index_path=$(git rev-parse --git-path index) || return 1
+    printf '%s.lock\n' "$index_path"
 }
 
 # Check if git is available

--- a/scripts/lint-tests.ps1
+++ b/scripts/lint-tests.ps1
@@ -1726,7 +1726,7 @@ foreach ($file in $filesToScan) {
   $createsUnity = ($assignMatches.Count -gt 0) -or ($text -match '\bnew\s+(GameObject|Texture2D|Material|Mesh|Camera)\s*\(') -or ($soMatches.Count -gt 0)
   if ($createsUnity) {
     # Check for direct or indirect inheritance (CommonTestBase or any base that inherits it)
-    $usesBase = ($text -match ':\s*(CommonTestBase|AttributeTagsTestBase|TagsTestBase|EditorCommonTestBase|SpriteSheetExtractorTestBase|BatchedEditorTestBase|DetectAssetChangeTestBase)')
+    $usesBase = ($text -match ':\s*(CommonTestBase|AttributeTagsTestBase|TagsTestBase|EditorCommonTestBase|SpriteSheetExtractorTestBase|BatchedEditorTestBase|DetectAssetChangeTestBase|RelationalExactBindingTestBase)')
     # Check for file-level UNH-SUPPRESS UNH003 comment
     $hasSuppress = ($text -match 'UNH-SUPPRESS.*UNH003|UNH-SUPPRESS:\s*Complex|UNH-SUPPRESS:\s*This IS the CommonTestBase')
     if (-not $usesBase -and -not $hasSuppress) {

--- a/scripts/tests/test-git-staging-helpers.sh
+++ b/scripts/tests/test-git-staging-helpers.sh
@@ -5,6 +5,15 @@
 
 set -euo pipefail
 
+# cspell:ignore Fxq gpgsign
+
+# A hook caller's repository and index must never redirect these temporary-repository tests.
+local_git_environment="$(git rev-parse --local-env-vars)"
+while IFS= read -r git_environment_name; do
+    unset "$git_environment_name"
+done <<< "$local_git_environment"
+unset local_git_environment git_environment_name
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -123,7 +132,187 @@ else
     fail "helper cleanup preserves stderr" "stderr probe was suppressed"
 fi
 
+export STAGING_HELPERS_ROOT="$REPO_ROOT"
+for helper_shell in bash powershell; do
+    for commit_kind in ordinary partial alternate; do
+        run_test
+        if (
+            set -euo pipefail
+            repo_path="$TMP_DIR/$helper_shell-$commit_kind"
+            create_repo "$repo_path"
+            cd "$repo_path"
+            export GIT_HELPERS_LOCK_FILE="$repo_path/.git-staging.lock"
+            source "$HELPERS_PATH"
+            printf 'before\n' > selected.txt
+            printf 'before\n' > unrelated.txt
+            git_add_with_retry selected.txt unrelated.txt
+            git -c core.hooksPath= -c commit.gpgsign=false commit -qm initial
+            printf 'after\n' > selected.txt
+            printf 'after\n' > unrelated.txt
+            if [[ "$commit_kind" == alternate ]]; then
+                cp .git/index 'alternate index'
+                export GIT_INDEX_FILE='alternate index'
+            fi
+            git_add_with_retry selected.txt unrelated.txt
+            mkdir hooks
+            git config core.hooksPath hooks
+            if [[ "$helper_shell" == bash ]]; then
+                cat > hooks/pre-commit <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+source "$STAGING_HELPERS_ROOT/scripts/git-staging-helpers.sh"
+ensure_no_index_lock 100
+printf 'hook\n' >> selected.txt
+git_add_with_retry selected.txt
+HOOK
+            else
+                cat > hooks/pre-commit <<'HOOK'
+#!/usr/bin/env bash
+exec pwsh -NoProfile -File hooks/check.ps1
+HOOK
+                cat > hooks/check.ps1 <<'HOOK'
+$ErrorActionPreference = 'Stop'
+. "$env:STAGING_HELPERS_ROOT/scripts/git-staging-helpers.ps1"
+if (-not (Invoke-EnsureNoIndexLock -MaxWaitMilliseconds 100)) { exit 1 }
+Add-Content -LiteralPath selected.txt -Value 'hook'
+$info = Get-GitRepositoryInfo
+Invoke-GitAddWithRetry -Items @('selected.txt') -IndexLockPath $info.IndexLockPath
+HOOK
+            fi
+            chmod +x hooks/pre-commit
+            if [[ "$commit_kind" == partial ]]; then
+                git -c commit.gpgsign=false commit -qm partial --only -- selected.txt || exit 1
+                [[ "$(git show HEAD:unrelated.txt)" == before ]] || exit 1
+                [[ "$(git diff --cached --name-only -- unrelated.txt)" == unrelated.txt ]] || exit 1
+                [[ "$(git show :unrelated.txt)" == after ]] || exit 1
+            else
+                git -c commit.gpgsign=false commit -qm complete || exit 1
+                [[ "$(git show HEAD:unrelated.txt)" == after ]] || exit 1
+                [[ -z "$(git diff --cached --name-only)" ]] || exit 1
+            fi
+            [[ "$(git show HEAD:selected.txt)" == $'after\nhook' ]] || exit 1
+        ) > "$TMP_DIR/commit-output" 2>&1; then
+            pass "$helper_shell $commit_kind commit checks and restages the effective index"
+        else
+            fail "$helper_shell $commit_kind commit checks and restages the effective index" "$(cat "$TMP_DIR/commit-output")"
+        fi
+    done
+    for index_kind in ordinary alternate worktree; do
+        run_test
+        if (
+            set -euo pipefail
+            repo_path="$TMP_DIR/$helper_shell-contention-$index_kind"
+            create_repo "$repo_path"
+            cd "$repo_path"
+            git -c core.hooksPath= -c commit.gpgsign=false commit --allow-empty -qm initial || exit 1
+            if [[ "$index_kind" == worktree ]]; then
+                git worktree add -qb linked "$repo_path/linked" || exit 1
+                cd linked
+            elif [[ "$index_kind" == alternate ]]; then
+                export GIT_INDEX_FILE="$repo_path/alternate index"
+            fi
+            EXPECTED_INDEX_LOCK="$(git rev-parse --git-path index).lock"
+            export EXPECTED_INDEX_LOCK
+            printf 'external writer\n' > "$EXPECTED_INDEX_LOCK"
+            if [[ "$helper_shell" == bash ]]; then
+                source "$HELPERS_PATH"
+                [[ "$(get_index_lock_path)" == "$EXPECTED_INDEX_LOCK" ]] || exit 1
+                if ensure_no_index_lock 100; then exit 1; fi
+            else
+                EXPECTED_INDEX_LOCK="$(realpath "$EXPECTED_INDEX_LOCK")"
+                pwsh -NoProfile -Command '
+                    $ErrorActionPreference = "Stop"
+                    . "$env:STAGING_HELPERS_ROOT/scripts/git-staging-helpers.ps1"
+                    if ((Get-GitRepositoryInfo).IndexLockPath -ne $env:EXPECTED_INDEX_LOCK) { exit 1 }
+                    if (Invoke-EnsureNoIndexLock -MaxWaitMilliseconds 100) { exit 1 }
+                ' || exit 1
+            fi
+            [[ "$(cat "$EXPECTED_INDEX_LOCK")" == 'external writer' ]] || exit 1
+            rm "$EXPECTED_INDEX_LOCK"
+            if [[ "$helper_shell" == bash ]]; then
+                ensure_no_index_lock 100 || exit 1
+            else
+                pwsh -NoProfile -Command '
+                    . "$env:STAGING_HELPERS_ROOT/scripts/git-staging-helpers.ps1"
+                    if (-not (Invoke-EnsureNoIndexLock -MaxWaitMilliseconds 100)) { exit 1 }
+                ' || exit 1
+            fi
+        ) > "$TMP_DIR/contention-output" 2>&1; then
+            pass "$helper_shell protects the $index_kind index until its lock is released"
+        else
+            fail "$helper_shell protects the $index_kind index until its lock is released" "$(cat "$TMP_DIR/contention-output")"
+        fi
+    done
+done
+
 echo ""
+for index_kind in ordinary relative; do
+    run_test
+    if (
+        set -euo pipefail
+        repo_path="$TMP_DIR/location-$index_kind"
+        create_repo "$repo_path"
+        mkdir "$repo_path/nested"
+        export INDEX_LOCATION_ROOT="$repo_path"
+        export INDEX_LOCATION_KIND="$index_kind"
+        pwsh -NoProfile -Command '
+            $ErrorActionPreference = "Stop"
+            . "$env:STAGING_HELPERS_ROOT/scripts/git-staging-helpers.ps1"
+            Set-Location (Join-Path $env:INDEX_LOCATION_ROOT "nested")
+            $expected = Join-Path $env:INDEX_LOCATION_ROOT ".git/index.lock"
+            if ($env:INDEX_LOCATION_KIND -eq "relative") {
+                $env:GIT_INDEX_FILE = "alternate index"
+                $expected = Join-Path $env:INDEX_LOCATION_ROOT "alternate index.lock"
+            }
+            $info = Get-GitRepositoryInfo
+            if ($info.IndexLockPath -ne $expected) { throw "Index path was not captured absolutely" }
+            [System.IO.File]::WriteAllText($expected, "external writer")
+            Set-Location $env:INDEX_LOCATION_ROOT
+            if (Wait-ForGitIndexLock -IndexLockPath $info.IndexLockPath -MaxWaitMilliseconds 0) {
+                throw "Changing location hid the captured index lock"
+            }
+            Remove-Item -LiteralPath $expected
+            if (-not (Wait-ForGitIndexLock -IndexLockPath $info.IndexLockPath -MaxWaitMilliseconds 0)) {
+                throw "Released index is still reported locked"
+            }
+        '
+    ) > "$TMP_DIR/location-output" 2>&1; then
+        pass "PowerShell $index_kind index remains valid after changing location"
+    else
+        fail "PowerShell $index_kind index remains valid after changing location" "$(cat "$TMP_DIR/location-output")"
+    fi
+done
+
+if [[ "${GIT_HELPERS_ISOLATION_PROBE:-0}" != 1 ]]; then
+    for suite in test-git-staging-helpers.sh test-precommit-integration.sh; do
+        run_test
+        if (
+            set -euo pipefail
+            caller="$TMP_DIR/caller-$suite"
+            create_repo "$caller"
+            cd "$caller"
+            source "$HELPERS_PATH"
+            printf 'caller index sentinel\n' > sentinel.txt
+            git_add_with_retry sentinel.txt
+            cp .git/index index-before
+            cp .git/config config-before
+            export GIT_DIR="$caller/.git"
+            export GIT_COMMON_DIR="$caller/.git"
+            export GIT_WORK_TREE="$caller"
+            export GIT_INDEX_FILE="$caller/.git/index"
+            export GIT_HELPERS_ISOLATION_PROBE=1
+            bash "$SCRIPT_DIR/$suite" || exit 1
+            cmp index-before .git/index || exit 1
+            cmp config-before .git/config || exit 1
+            [[ "$(cat sentinel.txt)" == 'caller index sentinel' ]] || exit 1
+        ) > "$TMP_DIR/isolation-output" 2>&1; then
+            pass "$suite preserves the caller index and config under inherited Git environment"
+        else
+            fail "$suite preserves the caller index and config under inherited Git environment" "$(cat "$TMP_DIR/isolation-output")"
+        fi
+    done
+fi
+
 echo "=== Test Summary ==="
 echo "Tests run:    $tests_run"
 echo -e "Tests passed: ${GREEN}$tests_passed${NC}"

--- a/scripts/tests/test-precommit-integration.sh
+++ b/scripts/tests/test-precommit-integration.sh
@@ -30,6 +30,13 @@
 
 set -euo pipefail
 
+# A hook caller's repository and index must never redirect these temporary-repository tests.
+local_git_environment="$(git rev-parse --local-env-vars)"
+while IFS= read -r git_environment_name; do
+    unset "$git_environment_name"
+done <<< "$local_git_environment"
+unset local_git_environment git_environment_name
+
 # cspell:ignore ZZQWERTYNOISE gpgsign
 
 RED='\033[0;31m'
@@ -644,6 +651,35 @@ $output
     fi
 }
 
+test_precommit_partial_commit() {
+    local sandbox="$TEMPDIR/precommit-partial-commit"
+    local name="real pre-commit hook accepts partial commits and retains unrelated staging"
+    mkdir -p "$sandbox/.githooks" "$sandbox/scripts"
+    cp "$REPO_ROOT/.githooks/pre-commit" "$REPO_ROOT/.githooks/pre-commit.ps1" "$sandbox/.githooks/"
+    cp "$REPO_ROOT/scripts/git-staging-helpers.ps1" "$REPO_ROOT/scripts/normalize-eol.ps1" "$sandbox/scripts/"
+    git -C "$sandbox" init -q
+    git -C "$sandbox" config user.email test@example.com
+    git -C "$sandbox" config user.name "Test User"
+    git -C "$sandbox" config core.hooksPath .githooks
+    chmod +x "$sandbox/.githooks/pre-commit"
+    printf 'before\n' > "$sandbox/selected.txt"
+    printf 'before\n' > "$sandbox/unrelated.txt"
+    git -C "$sandbox" add selected.txt unrelated.txt
+    git -C "$sandbox" -c commit.gpgsign=false commit -qm initial
+    printf 'after\n' > "$sandbox/selected.txt"
+    printf 'after\n' > "$sandbox/unrelated.txt"
+    git -C "$sandbox" add selected.txt unrelated.txt
+    local output
+    if output=$(git -C "$sandbox" -c commit.gpgsign=false commit -qm partial --only -- selected.txt 2>&1) &&
+        [[ "$(git -C "$sandbox" show HEAD:selected.txt)" == after ]] &&
+        [[ "$(git -C "$sandbox" show HEAD:unrelated.txt)" == before ]] &&
+        [[ "$(git -C "$sandbox" diff --cached --name-only)" == unrelated.txt ]]; then
+        pass "$name"
+    else
+        fail "$name" "$output"
+    fi
+}
+
 test_precommit_meta_scope() {
     local relative sandbox output exit_code expected name
     for relative in 'Samples~/Example/data.txt' 'Samples~/Example/tools~/driver.c' 'scripts/tools~/native/driver.c' 'scripts/tools~copy/driver.c' 'Runtime/Ordinary/data.txt'; do
@@ -711,6 +747,7 @@ test_precommit_fast_path_removes_ignored_artifacts
 test_premergecommit_delegates_to_precommit
 test_precommit_refuses_partial_final_newline_before_write
 test_precommit_checks_staged_csharp_blob
+test_precommit_partial_commit
 test_precommit_meta_scope
 
 echo ""

--- a/scripts/tests/test-random-quality-stream.mjs
+++ b/scripts/tests/test-random-quality-stream.mjs
@@ -46,7 +46,7 @@ const built = spawnSync("dotnet", ["build", project, "-c", "Release", "--nologo"
   encoding: null,
   maxBuffer: 4 * 1024 * 1024
 });
-assert.equal(built.status, 0, built.stderr.toString());
+assert.equal(built.status, 0, Buffer.concat([built.stdout, built.stderr]).toString());
 const host = path.join(
   repoRoot,
   "Generator~",
@@ -114,6 +114,43 @@ const expectedVectors = names.flatMap((generator) =>
     vectorSeeds.map((vectorSeed) => vectorKey({ generator, width, seed: vectorSeed }))
   )
 );
+const unityVectorSource = fs.readFileSync(
+  path.join(repoRoot, "Tests/Runtime/Random/RandomRawStreamCompatibilityTests.cs"),
+  "utf8"
+);
+const unityVectors = [
+  ...unityVectorSource.matchAll(
+    /\[TestCase\(\s*nameof\((\w+)\),\s*(32|64),\s*"([^"]+)",\s*"([0-9a-f]{64})"\s*\)\]/g
+  )
+].map((match) => ({
+  generator: match[1],
+  width: Number(match[2]),
+  seed: match[3],
+  sha256: match[4]
+}));
+function assertUnityVectors(candidateVectors) {
+  assert.deepEqual(
+    candidateVectors,
+    vectors.vectors.map(({ generator, width, seed: vectorSeed, sha256 }) => ({
+      generator,
+      width,
+      seed: vectorSeed,
+      sha256
+    })),
+    "Unity runtime tests must execute every frozen raw-stream hash with its original width and seed"
+  );
+}
+assertUnityVectors(unityVectors);
+for (const candidateVectors of [
+  unityVectors.slice(1),
+  [...unityVectors, unityVectors[0]],
+  [{ ...unityVectors[0], width: 64 }, ...unityVectors.slice(1)],
+  [{ ...unityVectors[0], sha256: "0".repeat(64) }, ...unityVectors.slice(1)]
+]) {
+  assert.throws(() => assertUnityVectors(candidateVectors), /Unity runtime tests must execute/);
+}
+assert.match(unityVectorSource, /StreamBytes\s*=\s*1024\s*\*\s*1024\s*;/);
+assert.doesNotMatch(unityVectorSource, /SkipUnderIL2CPP|Assert\.Ignore|\[Ignore|#if/);
 assert.deepEqual(
   vectors.vectors.map(vectorKey).sort(),
   expectedVectors.sort(),


### PR DESCRIPTION
**Why:** Exact component bindings failed, editor resources leaked, and partial commits stalled.

**What:**

- Respect exact component types across relational bindings.
- Release editor resources during refresh, replacement, and close.
- Add configurable protobuf wire limits.
- Pin Unity RNG streams to frozen baselines.
- Handle partial-commit indexes in Git staging helpers.

Fixes #730
Fixes #733
Fixes #734

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches widely used relational attributes (binding semantics change under `AllowInterfaces = false`), deserialization limits on untrusted input, and many editor code paths; behavior is heavily tested but upgrades may need field audits.
> 
> **Overview**
> **Exact relational binding** when `AllowInterfaces` is false now requires the component’s **runtime type** to match the field type, including non-sealed concrete types (derived components and polymorphic `Component`/`MonoBehaviour` fields no longer match). Shared EditMode/PlayMode oracles document the behavior.
> 
> **Editor lifecycle fixes** dispose owned `SerializedObject`/`SerializedProperty` and pending collection-drawer wrappers on failure, refresh, and close; atlas, fit-texture, and animation-event windows release cached serialized state and **only destroy copied sprite preview textures**, not Unity-owned previews.
> 
> **WallstopProto** adds immutable **`WProtoReadLimits`** (message size, length-delimited fields, tag count, nesting) with a public parameterless constructor for `new()` factories, wires them through **`WProtoReader`** and **`WProtoFacade.TryDeserialize`**, and documents hostile-payload handling.
> 
> **RNG regression**: frozen SHA-256 baselines for raw streams across generators, plus **`NativePcgRandom`** struct-copy and **`UnityRandom`** adapter stream checks.
> 
> Supporting updates: Git staging helpers resolve the **effective index lock** for `GIT_INDEX_FILE`/partial commits; changelog/docs/skills and test-count messaging move to **14,000+** tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81bd71fe1fd74c9330c4343e6ffc84a45bdbedb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->