### PR TITLE
Preserve restored collection state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `WyRandom.Copy()` losing pending Gaussian, bool, and byte values, so a copied generator continues the same mixed draw sequence ([#638](https://github.com/Ambiguous-Interactive/unity-helpers/issues/638)).
+- Fix malformed `SparseSet` binary saves silently losing invalid element IDs or enlarging their universe for duplicates. Both binary readers now refuse invalid elements before restoring the set ([#647](https://github.com/Ambiguous-Interactive/unity-helpers/issues/647)).
+- Fix explicit-type protobuf collection reads bypassing wrappers, preserving stored elements and capacity rules ([#647](https://github.com/Ambiguous-Interactive/unity-helpers/issues/647)).
 - Fix infinite-bound random draws returning NaN or excluded endpoints, and stop exhausted sources from multiplying retry budgets ([#638](https://github.com/Ambiguous-Interactive/unity-helpers/issues/638)).
 - Fix exact relational component matching when `AllowInterfaces` is disabled, including concrete types that are not sealed ([#733](https://github.com/Ambiguous-Interactive/unity-helpers/issues/733)).
 - Fix editor windows and collection drawers retaining owned serialized state and copied previews after refresh, close or failed initialization; shared Unity previews remain available ([#734](https://github.com/Ambiguous-Interactive/unity-helpers/issues/734)).

--- a/Runtime/Core/Random/WyRandom.cs
+++ b/Runtime/Core/Random/WyRandom.cs
@@ -183,9 +183,12 @@ namespace WallstopStudios.UnityHelpers.Core.Random
             return (hi, lo);
         }
 
+        /// <summary>
+        /// Copies the complete generator state, including pending draws.
+        /// </summary>
         public override IRandom Copy()
         {
-            return new WyRandom(_state);
+            return new WyRandom(InternalState);
         }
     }
 }

--- a/Runtime/Core/Serialization/ProtobufUnitySurrogates.cs
+++ b/Runtime/Core/Serialization/ProtobufUnitySurrogates.cs
@@ -624,7 +624,6 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
         internal bool TryRestore(out SparseSet value)
         {
-            value = default;
             int[] elements = Elements ?? Array.Empty<int>();
             bool inferCapacity = Capacity <= 0;
             int capacity = inferCapacity ? 1 : Capacity;
@@ -632,6 +631,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             {
                 if (element < 0 || int.MaxValue <= element)
                 {
+                    value = default;
                     return false;
                 }
 
@@ -645,12 +645,14 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                 }
                 else if (capacity <= element)
                 {
+                    value = default;
                     return false;
                 }
             }
 
             if (!SerializationCapacityLimits.TryAccept(capacity, elements.Length, out _))
             {
+                value = default;
                 return false;
             }
 

--- a/Runtime/Core/Serialization/ProtobufUnitySurrogates.cs
+++ b/Runtime/Core/Serialization/ProtobufUnitySurrogates.cs
@@ -621,6 +621,47 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
         [ProtoMember(2)]
         [WProtoMember(2)]
         public int Capacity;
+
+        internal bool TryRestore(out SparseSet value)
+        {
+            value = default;
+            int[] elements = Elements ?? Array.Empty<int>();
+            bool inferCapacity = Capacity <= 0;
+            int capacity = inferCapacity ? 1 : Capacity;
+            foreach (int element in elements)
+            {
+                if (element < 0 || int.MaxValue <= element)
+                {
+                    return false;
+                }
+
+                if (inferCapacity)
+                {
+                    int requiredCapacity = element + 1;
+                    if (capacity < requiredCapacity)
+                    {
+                        capacity = requiredCapacity;
+                    }
+                }
+                else if (capacity <= element)
+                {
+                    return false;
+                }
+            }
+
+            if (!SerializationCapacityLimits.TryAccept(capacity, elements.Length, out _))
+            {
+                return false;
+            }
+
+            SparseSet restored = new SparseSet(capacity);
+            foreach (int element in elements)
+            {
+                restored.TryAdd(element);
+            }
+            value = restored;
+            return true;
+        }
     }
 
     internal static class ProtobufUnityModel

--- a/Runtime/Core/Serialization/Serializer.cs
+++ b/Runtime/Core/Serialization/Serializer.cs
@@ -660,7 +660,11 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
         /// </summary>
         internal static T DeserializeCollectionFromWrapper<T>(byte[] data)
         {
-            Type type = typeof(T);
+            return (T)DeserializeCollectionFromWrapper(data, typeof(T));
+        }
+
+        private static object DeserializeCollectionFromWrapper(byte[] data, Type type)
+        {
             Type genericDef = type.GetGenericTypeDefinition();
             bool isSet =
                 genericDef == typeof(SerializableHashSet<>)
@@ -741,7 +745,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
             onAfterDeserialize?.Invoke(result);
 
-            return (T)result;
+            return result;
         }
 
         /// <summary>
@@ -825,12 +829,16 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
         internal static T DeserializeSpecialCollection<T>(byte[] data)
         {
-            Type type = typeof(T);
+            return (T)DeserializeSpecialCollection(data, typeof(T));
+        }
+
+        private static object DeserializeSpecialCollection(byte[] data, Type type)
+        {
             Func<byte[], object> deserializer = SpecialCollectionDeserializers.GetOrAdd(
                 type,
                 SpecialCollectionDeserializerFactory
             );
-            return (T)deserializer(data);
+            return deserializer(data);
         }
 
         private static Func<object, byte[]> BuildSpecialCollectionSerializer(Type type)
@@ -968,34 +976,11 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             SparseSetProtoWrapper wrapper = (SparseSetProtoWrapper)
                 ProtoBuf.Serializer.NonGeneric.Deserialize(typeof(SparseSetProtoWrapper), ms);
 
-            int capacity = wrapper.Capacity;
-            int itemCount = wrapper.Elements?.Length ?? 0;
-            if (capacity <= 0)
-            {
-                // A missing universe must still contain the largest stored element.
-                capacity = 1;
-                for (int i = 0; i < itemCount; i++)
-                {
-                    int candidate = wrapper.Elements[i] + 1;
-                    if (capacity < candidate)
-                    {
-                        capacity = candidate;
-                    }
-                }
-            }
-
-            // Universe size changes which elements are accepted, so refuse excessive sizes instead of clamping.
-            if (!SerializationCapacityLimits.TryAccept(capacity, itemCount, out capacity))
+            if (!wrapper.TryRestore(out SparseSet result))
             {
                 throw new InvalidOperationException(
-                    SerializationCapacityLimits.Refusal(nameof(SparseSet), wrapper.Capacity)
+                    "SparseSet payload contains invalid elements or an unsupported capacity."
                 );
-            }
-
-            SparseSet result = new(capacity);
-            for (int i = 0; i < itemCount; i++)
-            {
-                result.TryAdd(wrapper.Elements[i]);
             }
             return result;
         }
@@ -1818,6 +1803,14 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
         /// <returns>The decoded instance cast to <typeparamref name="T"/>.</returns>
         public static T ProtoDeserialize<T>(byte[] data, Type type)
         {
+            if (
+                type == typeof(T)
+                && (IsSerializableCollectionType(type) || IsSpecialCollectionType(type))
+            )
+            {
+                return ProtoDeserialize<T>(data);
+            }
+
 #if WALLSTOP_PROTO
             // Accept a requested runtime type only when the registered formatter declares that contract or subtype.
             if (
@@ -1849,6 +1842,20 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
             try
             {
+                if (type == typeof(SparseSet))
+                {
+                    return (T)(object)ProtoDeserialize<SparseSet>(data);
+                }
+
+                if (IsSerializableCollectionType(type))
+                {
+                    return (T)DeserializeCollectionFromWrapper(data, type);
+                }
+                if (IsSpecialCollectionType(type))
+                {
+                    return (T)DeserializeSpecialCollection(data, type);
+                }
+
                 if (ProtoDeserializeTypeFromROMFast != null)
                 {
                     ReadOnlyMemory<byte> rom = new(data);

--- a/Runtime/Core/Serialization/WProtoCollectionMarshals.cs
+++ b/Runtime/Core/Serialization/WProtoCollectionMarshals.cs
@@ -447,7 +447,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
         /// <inheritdoc />
         /// <remarks>
         /// A <see cref="SparseSet"/> needs a positive universe size, so a payload carrying none
-        /// falls back to the smallest one that can hold the largest stored element.
+        /// falls back to the smallest one that can hold the largest stored element. Negative or
+        /// unrepresentable elements, elements outside a stated positive universe, and capacities
+        /// beyond the restoration limit are refused. Duplicates retain their first occurrence.
         /// </remarks>
         public bool TryRead(ref WProtoReader reader, out SparseSet value)
         {
@@ -462,36 +464,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                 return false;
             }
 
-            int itemCount = wrapper.Elements?.Length ?? 0;
-            int capacity = wrapper.Capacity;
-            if (capacity <= 0)
-            {
-                capacity = 1;
-                for (int index = 0; index < itemCount; index++)
-                {
-                    int candidate = wrapper.Elements[index] + 1;
-                    if (capacity < candidate)
-                    {
-                        capacity = candidate;
-                    }
-                }
-            }
-
-            // Capacity defines the sparse set universe; clamping would change which elements it accepts.
-            if (!SerializationCapacityLimits.TryAccept(capacity, itemCount, out capacity))
-            {
-                value = default;
-                return false;
-            }
-
-            SparseSet restored = new SparseSet(capacity);
-            for (int index = 0; index < itemCount; index++)
-            {
-                restored.TryAdd(wrapper.Elements[index]);
-            }
-
-            value = restored;
-            return true;
+            return wrapper.TryRestore(out value);
         }
 
         private static SparseSetProtoWrapper Wrap(SparseSet value)

--- a/Tests/Runtime/Random/NativePcgRandomTests.cs
+++ b/Tests/Runtime/Random/NativePcgRandomTests.cs
@@ -83,8 +83,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             for (int i = 0; i < DistributionSamples; i++)
             {
                 float value = random.NextFloat();
-                Assert.GreaterOrEqual(value, 0f, "NextFloat returned a negative value.");
-                Assert.Less(value, 1f, "NextFloat returned 1 or greater.");
+                if (!(0f <= value && value < 1f))
+                {
+                    Assert.GreaterOrEqual(value, 0f, "NextFloat returned a negative value.");
+                    Assert.Less(value, 1f, "NextFloat returned 1 or greater.");
+                }
                 if (maximum < value)
                 {
                     maximum = value;
@@ -120,8 +123,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             for (int i = 0; i < DistributionSamples; i++)
             {
                 double value = random.NextDouble();
-                Assert.GreaterOrEqual(value, 0.0, "NextDouble returned a negative value.");
-                Assert.Less(value, 1.0, "NextDouble returned 1 or greater.");
+                if (!(0.0 <= value && value < 1.0))
+                {
+                    Assert.GreaterOrEqual(value, 0.0, "NextDouble returned a negative value.");
+                    Assert.Less(value, 1.0, "NextDouble returned 1 or greater.");
+                }
                 if (maximum < value)
                 {
                     maximum = value;
@@ -138,7 +144,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             NativePcgRandom random = new(777);
             for (int i = 0; i < DistributionSamples; i++)
             {
-                Assert.GreaterOrEqual(random.NextLong(), 0L, "NextLong returned a negative value.");
+                long value = random.NextLong();
+                if (value < 0L)
+                {
+                    Assert.GreaterOrEqual(value, 0L, "NextLong returned a negative value.");
+                }
             }
         }
 
@@ -218,7 +228,14 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             for (int i = 0; i < samples; i++)
             {
                 uint value = random.NextUint(exclusiveMax);
-                Assert.Less(value, exclusiveMax, "NextUint(max) returned a value at or above max.");
+                if (!(value < exclusiveMax))
+                {
+                    Assert.Less(
+                        value,
+                        exclusiveMax,
+                        "NextUint(max) returned a value at or above max."
+                    );
+                }
                 counts[value]++;
             }
 

--- a/Tests/Runtime/Random/RandomProtoSerializationTests.cs
+++ b/Tests/Runtime/Random/RandomProtoSerializationTests.cs
@@ -597,6 +597,17 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             yield return Named("Restored", "BlastCircuitRandom", new BlastCircuitRandom(seed));
             yield return Named("Restored", "WaveSplatRandom", new WaveSplatRandom(0xC0FFEEUL));
             yield return Named("Restored", "WDoomRandom", new WDoomRandom(seedIndex: 7));
+            yield return Named("Restored", nameof(Sfc64Random), new Sfc64Random(seed));
+            yield return Named(
+                "Restored",
+                nameof(Xoshiro128StarStar),
+                new Xoshiro128StarStar(seed)
+            );
+            yield return Named(
+                "Restored",
+                nameof(Xoshiro256StarStar),
+                new Xoshiro256StarStar(seed)
+            );
         }
 
         /// <summary>
@@ -649,6 +660,142 @@ namespace WallstopStudios.UnityHelpers.Tests.Runtime.Random
             ProtoBuf.Serializer.Serialize(written, (AbstractRandom)random);
             using MemoryStream read = new(written.ToArray());
             return ProtoBuf.Serializer.Deserialize<AbstractRandom>(read);
+        }
+
+        private static IEnumerable<TestCaseData> EveryMixedContinuation()
+        {
+            foreach (bool primeCaches in new[] { false, true })
+            {
+                foreach (TestCaseData generator in EveryGenerator())
+                {
+                    yield return new TestCaseData(generator.Arguments[0], primeCaches).SetName(
+                        nameof(MixedContinuationSurvivesEveryRestorePath)
+                            + "-"
+                            + generator.TestName
+                            + "-"
+                            + primeCaches
+                    );
+                }
+            }
+        }
+
+        [TestCaseSource(nameof(EveryMixedContinuation))]
+        public void MixedContinuationSurvivesEveryRestorePath(IRandom random, bool primeCaches)
+        {
+            if (primeCaches)
+            {
+                PrimeCommonReservoirs(random);
+            }
+
+            RandomState saved = random.InternalState;
+            Assert.AreEqual(primeCaches, saved.Gaussian.HasValue);
+            Assert.AreEqual(primeCaches && random is not SystemRandom ? 31 : 0, saved.BitCount);
+            Assert.AreEqual(primeCaches ? 3 : 0, saved.ByteCount);
+            IRandom[] restored =
+            {
+                random.Copy(),
+                RestoreFromState(random, saved),
+                RoundTrip(random),
+            };
+            foreach (IRandom restoredRandom in restored)
+            {
+                Assert.AreEqual(saved, restoredRandom.InternalState);
+            }
+
+            AssertMixedContinuation(random, restored);
+        }
+
+        [Test]
+        public void MixedContinuationDetectsADiscardedByteReservoir()
+        {
+            PcgRandom random = new(12345);
+            PrimeCommonReservoirs(random);
+            RandomState saved = random.InternalState;
+            RandomState missingBytes = new(
+                state1: saved.State1,
+                state2: saved.State2,
+                gaussian: saved.Gaussian,
+                payload: saved.PayloadBytes,
+                bitBuffer: saved.BitBuffer,
+                bitCount: saved.BitCount
+            );
+            IRandom[] damaged = { new PcgRandom(missingBytes) };
+
+            Assert.Throws<AssertionException>(() => AssertMixedContinuation(random, damaged));
+        }
+
+        private static void PrimeCommonReservoirs(IRandom random)
+        {
+            random.NextBool();
+            random.NextByte();
+            random.NextGaussian();
+        }
+
+        private static IRandom RestoreFromState(IRandom random, RandomState saved)
+        {
+            return random switch
+            {
+                DotNetRandom _ => new DotNetRandom(saved),
+                PcgRandom _ => new PcgRandom(saved),
+                XorShiftRandom _ => new XorShiftRandom(saved),
+                WyRandom _ => new WyRandom(saved),
+                XoroShiroRandom _ => new XoroShiroRandom(saved),
+                SystemRandom _ => new SystemRandom(saved),
+                LinearCongruentialGenerator _ => new LinearCongruentialGenerator(saved),
+                SquirrelRandom _ => new SquirrelRandom(saved),
+                RomuDuo _ => new RomuDuo(saved),
+                SplitMix64 _ => new SplitMix64(saved),
+                IllusionFlow _ => new IllusionFlow(saved),
+                FlurryBurstRandom _ => new FlurryBurstRandom(saved),
+                PhotonSpinRandom _ => new PhotonSpinRandom(saved),
+                StormDropRandom _ => new StormDropRandom(saved),
+                BlastCircuitRandom _ => new BlastCircuitRandom(saved),
+                WaveSplatRandom _ => new WaveSplatRandom(saved),
+                WDoomRandom _ => new WDoomRandom(saved),
+                Xoshiro128StarStar _ => new Xoshiro128StarStar(saved),
+                Xoshiro256StarStar _ => new Xoshiro256StarStar(saved),
+                Sfc64Random _ => new Sfc64Random(saved),
+                _ => throw new ArgumentException(
+                    "The generator needs a direct state constructor.",
+                    nameof(random)
+                ),
+            };
+        }
+
+        private static void AssertMixedContinuation(IRandom random, IRandom[] restored)
+        {
+            for (int round = 0; round < 64; ++round)
+            {
+                bool expectedBool = random.NextBool();
+                byte expectedByte = random.NextByte();
+                long expectedGaussian = BitConverter.DoubleToInt64Bits(random.NextGaussian());
+                uint expectedUint = random.NextUint();
+                ulong expectedUlong = random.NextUlong();
+                RandomState expectedState = random.InternalState;
+                foreach (IRandom restoredRandom in restored)
+                {
+                    bool actualBool = restoredRandom.NextBool();
+                    byte actualByte = restoredRandom.NextByte();
+                    long actualGaussian = BitConverter.DoubleToInt64Bits(
+                        restoredRandom.NextGaussian()
+                    );
+                    uint actualUint = restoredRandom.NextUint();
+                    ulong actualUlong = restoredRandom.NextUlong();
+                    if (
+                        expectedBool != actualBool
+                        || expectedByte != actualByte
+                        || expectedGaussian != actualGaussian
+                        || expectedUint != actualUint
+                        || expectedUlong != actualUlong
+                        || !expectedState.Equals(restoredRandom.InternalState)
+                    )
+                    {
+                        Assert.Fail(
+                            $"Restore {Array.IndexOf(restored, restoredRandom)} diverged at mixed round {round}."
+                        );
+                    }
+                }
+            }
         }
 
         private static IEnumerable<TestCaseData> EveryGeneratorRepairedAfterDeserialization()

--- a/Tests/Runtime/Serialization/SerializationCapacityLimitTests.cs
+++ b/Tests/Runtime/Serialization/SerializationCapacityLimitTests.cs
@@ -4,9 +4,12 @@
 namespace WallstopStudios.UnityHelpers.Tests.Serialization
 {
     using System;
+    using System.Collections.Generic;
     using NUnit.Framework;
     using WallstopStudios.UnityHelpers.Core.DataStructure;
     using WallstopStudios.UnityHelpers.Core.Serialization;
+    using WallstopStudios.UnityHelpers.Core.Serialization.WallstopProto;
+    using WallstopStudios.UnityHelpers.Tests.Core;
 
     /// <summary>
     /// Pins what a deserializer will allocate for a capacity a payload only claims.
@@ -59,6 +62,20 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                 "A payload that delivered no elements must not size a buffer beyond the limit."
             );
 
+            Deque<int> typed = Serializer.ProtoDeserialize<Deque<int>>(
+                HostileCapacityClaim,
+                typeof(Deque<int>)
+            );
+            Assert.AreEqual(restored.Capacity, typed.Capacity);
+            Assert.IsTrue(
+                Serializer.TryProtoDeserialize(
+                    HostileCapacityClaim,
+                    typeof(Deque<int>),
+                    out Deque<int> attempted
+                )
+            );
+            Assert.AreEqual(restored.Capacity, attempted.Capacity);
+
             // Clamping is not truncation: the deque still works, and grows past the clamp on demand.
             for (int index = 0; index < 32; index++)
             {
@@ -79,6 +96,149 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             );
         }
 
+        [TestCaseSource(nameof(SparseSetPayloadCases))]
+        public void SparseSetPayloadRestorationPreservesElementsOrRefusesTheWholePayload(
+            int capacity,
+            int[] elements,
+            int expectedCapacity,
+            int[] expectedElements
+        )
+        {
+            SerializationCapacityLimits.MaximumRestoredCapacity = 8;
+            byte[] payload = EncodeSparseSetPayload(capacity, elements);
+            WProtoReader reader = new WProtoReader(payload);
+            bool accepted = new SparseSetMarshalFormatter().TryRead(
+                ref reader,
+                out SparseSet value
+            );
+            Assert.AreEqual(expectedElements != null, accepted);
+            if (expectedElements == null)
+            {
+                Assert.IsTrue(value == null);
+                Assert.IsFalse(Serializer.TryProtoDeserialize(payload, out SparseSet refused));
+                Assert.IsTrue(refused == null);
+                Assert.Throws<SerializationCorruptDataException>(() =>
+                    Serializer.ProtoDeserialize<SparseSet>(payload)
+                );
+                Assert.IsFalse(
+                    Serializer.TryProtoDeserialize(payload, typeof(SparseSet), out SparseSet typed)
+                );
+                Assert.IsTrue(typed == null);
+                Assert.IsFalse(
+                    Serializer.TryProtoDeserialize(payload, typeof(SparseSet), out object boxed)
+                );
+                Assert.IsTrue(boxed == null);
+                Assert.Throws<SerializationCorruptDataException>(() =>
+                    Serializer.ProtoDeserialize<SparseSet>(payload, typeof(SparseSet))
+                );
+                Assert.Throws<SerializationCorruptDataException>(() =>
+                    Serializer.ProtoDeserialize<object>(payload, typeof(SparseSet))
+                );
+                return;
+            }
+
+            Assert.AreEqual(payload.Length, reader.Position);
+            AssertSparseSetContents(value, expectedCapacity, expectedElements);
+            AssertSparseSetContents(
+                Serializer.ProtoDeserialize<SparseSet>(payload),
+                expectedCapacity,
+                expectedElements
+            );
+            AssertSparseSetContents(
+                Serializer.ProtoDeserialize<SparseSet>(payload, typeof(SparseSet)),
+                expectedCapacity,
+                expectedElements
+            );
+            Assert.IsTrue(
+                Serializer.TryProtoDeserialize(payload, typeof(SparseSet), out SparseSet typedValue)
+            );
+            AssertSparseSetContents(typedValue, expectedCapacity, expectedElements);
+            AssertSparseSetContents(
+                (SparseSet)Serializer.ProtoDeserialize<object>(payload, typeof(SparseSet)),
+                expectedCapacity,
+                expectedElements
+            );
+            Assert.IsTrue(
+                Serializer.TryProtoDeserialize(payload, typeof(SparseSet), out object boxedValue)
+            );
+            AssertSparseSetContents((SparseSet)boxedValue, expectedCapacity, expectedElements);
+        }
+
+        [TestCaseSource(nameof(SparseSetPayloadCases))]
+        [SkipUnderIL2CPP]
+        public void LegacySparseSetPayloadRestorationUsesTheSameValidation(
+            int capacity,
+            int[] elements,
+            int expectedCapacity,
+            int[] expectedElements
+        )
+        {
+            SerializationCapacityLimits.MaximumRestoredCapacity = 8;
+            byte[] payload = EncodeSparseSetPayload(capacity, elements);
+            if (expectedElements == null)
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                    Serializer.DeserializeSparseSetWrapper(payload)
+                );
+                return;
+            }
+
+            AssertSparseSetContents(
+                Serializer.DeserializeSparseSetWrapper(payload),
+                expectedCapacity,
+                expectedElements
+            );
+        }
+
+        private static IEnumerable<TestCaseData> SparseSetPayloadCases()
+        {
+            yield return new TestCaseData(0, null, 1, Array.Empty<int>());
+            yield return new TestCaseData(0, Array.Empty<int>(), 1, Array.Empty<int>());
+            yield return new TestCaseData(-1, new[] { 3, 1, 3, 7 }, 8, new[] { 3, 1, 7 });
+            yield return new TestCaseData(8, new[] { 3, 1, 3, 7 }, 8, new[] { 3, 1, 7 });
+            yield return new TestCaseData(1, new[] { 0, 0, 0 }, 1, new[] { 0 });
+            yield return new TestCaseData(0, new[] { int.MaxValue }, 0, null);
+            yield return new TestCaseData(0, new[] { int.MaxValue - 1 }, 0, null);
+            yield return new TestCaseData(0, new[] { int.MinValue }, 0, null);
+            yield return new TestCaseData(0, new[] { 0, -1 }, 0, null);
+            yield return new TestCaseData(4, new[] { 1, 4, 2 }, 0, null);
+            yield return new TestCaseData(4, new[] { 1, -1, 2 }, 0, null);
+            yield return new TestCaseData(4, new[] { 1, int.MaxValue, 2 }, 0, null);
+            yield return new TestCaseData(0, new[] { 8 }, 0, null);
+            yield return new TestCaseData(9, Array.Empty<int>(), 0, null);
+        }
+
+        private static byte[] EncodeSparseSetPayload(int capacity, int[] elements)
+        {
+            SparseSetProtoWrapper wrapper = new SparseSetProtoWrapper
+            {
+                Capacity = capacity,
+                Elements = elements,
+            };
+            SparseSetProtoWrapper.WProtoFormatter formatter = SparseSetProtoWrapper
+                .WProtoFormatter
+                .Instance;
+            byte[] payload = new byte[formatter.Measure(wrapper)];
+            WProtoWriter writer = new WProtoWriter(payload);
+            Assert.IsTrue(formatter.Write(ref writer, wrapper));
+            return payload;
+        }
+
+        private static void AssertSparseSetContents(
+            SparseSet restored,
+            int expectedCapacity,
+            int[] expectedElements
+        )
+        {
+            Assert.IsTrue(restored != null);
+            Assert.AreEqual(expectedCapacity, restored.Capacity);
+            CollectionAssert.AreEqual(expectedElements, restored.ToArray());
+            foreach (int element in expectedElements)
+            {
+                Assert.IsTrue(restored.Contains(element));
+            }
+        }
+
         /// <remarks>
         /// A <c>CyclicBuffer</c>'s stated capacity costs nothing to honor, which is why the three
         /// restore paths do not bound it the way they bound a deque's or a sparse set's.
@@ -94,6 +254,19 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
 
             Assert.IsTrue(restored != null);
             Assert.AreEqual(0, restored.Count);
+            CyclicBuffer<int> typed = Serializer.ProtoDeserialize<CyclicBuffer<int>>(
+                HostileCapacityClaim,
+                typeof(CyclicBuffer<int>)
+            );
+            Assert.AreEqual(restored.Capacity, typed.Capacity);
+            Assert.IsTrue(
+                Serializer.TryProtoDeserialize(
+                    HostileCapacityClaim,
+                    typeof(CyclicBuffer<int>),
+                    out CyclicBuffer<int> attempted
+                )
+            );
+            Assert.AreEqual(restored.Capacity, attempted.Capacity);
             restored.Add(3);
             Assert.AreEqual(1, restored.Count);
         }

--- a/Tests/Runtime/Serialization/WProtoCollectionMarshalTests.cs
+++ b/Tests/Runtime/Serialization/WProtoCollectionMarshalTests.cs
@@ -82,19 +82,26 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         [WallstopStudios.UnityHelpers.Tests.Core.SkipUnderIL2CPP]
         public void TheShippedWrapperPathReadsWhatTheMarshalWrites()
         {
-            foreach (Sample sample in Samples())
+            foreach (bool empty in new[] { false, true })
             {
-                sample.AssertShippedReadsOurs();
+                foreach (Sample sample in Samples(empty))
+                {
+                    sample.AssertShippedReadsOurs();
+                }
             }
+            AssertRuntimeSelectedCapacityPolicies();
         }
 
         [Test]
         [WallstopStudios.UnityHelpers.Tests.Core.SkipUnderIL2CPP]
         public void TheMarshalReadsWhatTheShippedWrapperPathWrote()
         {
-            foreach (Sample sample in Samples())
+            foreach (bool empty in new[] { false, true })
             {
-                sample.AssertOursReadsShipped();
+                foreach (Sample sample in Samples(empty))
+                {
+                    sample.AssertOursReadsShipped();
+                }
             }
         }
 
@@ -118,19 +125,10 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
         [Test]
         public void AnEmptyMarshalledCollectionRoundTrips()
         {
-            AssertRoundTrip(new SerializableHashSet<int>(), set => Assert.AreEqual(0, set.Count));
-            AssertRoundTrip(new SerializableSortedSet<int>(), set => Assert.AreEqual(0, set.Count));
-            AssertRoundTrip(
-                new SerializableDictionary<string, int>(),
-                map => Assert.AreEqual(0, map.Count)
-            );
-            AssertRoundTrip(
-                new SerializableSortedDictionary<string, int>(),
-                map => Assert.AreEqual(0, map.Count)
-            );
-            AssertRoundTrip(new Deque<int>(4), deque => Assert.AreEqual(0, deque.Count));
-            AssertRoundTrip(new CyclicBuffer<int>(4), buffer => Assert.AreEqual(0, buffer.Count));
-            AssertRoundTrip(new SparseSet(8), set => Assert.AreEqual(0, set.Count));
+            foreach (Sample sample in Samples(true))
+            {
+                sample.AssertRoundTrips();
+            }
         }
 
         /// <summary>
@@ -148,6 +146,33 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             Assert.AreEqual(1, restored.Count);
         }
 
+        private static void AssertRuntimeSelectedCapacityPolicies()
+        {
+            int previousLimit = SerializationCapacityLimits.MaximumRestoredCapacity;
+            try
+            {
+                SerializationCapacityLimits.MaximumRestoredCapacity = 8;
+                byte[] payload = { 0x10, 0x09 };
+                Assert.IsFalse(
+                    Serializer.TryProtoDeserialize(payload, typeof(SparseSet), out object refused)
+                );
+                Assert.IsTrue(refused == null);
+                Deque<int> deque =
+                    (Deque<int>)Serializer.ProtoDeserialize<object>(payload, typeof(Deque<int>));
+                Assert.AreEqual(8, deque.Capacity);
+                Assert.AreEqual(0, deque.Count);
+                CyclicBuffer<int> buffer =
+                    (CyclicBuffer<int>)
+                        Serializer.ProtoDeserialize<object>(payload, typeof(CyclicBuffer<int>));
+                Assert.AreEqual(9, buffer.Capacity);
+                Assert.AreEqual(0, buffer.Count);
+            }
+            finally
+            {
+                SerializationCapacityLimits.MaximumRestoredCapacity = previousLimit;
+            }
+        }
+
         private static void AssertRoundTrip<T>(T value, Action<T> verify)
         {
             Assert.IsTrue(
@@ -160,27 +185,44 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             );
             Assert.IsTrue(restored != null);
             verify(restored);
+            verify(Serializer.ProtoDeserialize<T>(bytes, typeof(T)));
+            Assert.IsTrue(Serializer.TryProtoDeserialize(bytes, typeof(T), out T typed));
+            verify(typed);
         }
 
-        private static IEnumerable<Sample> Samples()
+        private static IEnumerable<Sample> Samples(bool empty = false)
         {
-            SerializableHashSet<int> hashSet = new SerializableHashSet<int> { 1, 300, -7 };
+            SerializableHashSet<int> hashSet = new SerializableHashSet<int>();
+            if (!empty)
+            {
+                hashSet.Add(1);
+                hashSet.Add(300);
+                hashSet.Add(-7);
+            }
             yield return Sample.Wrapped(
                 hashSet,
                 restored => CollectionAssert.AreEquivalent(hashSet.ToList(), restored.ToList())
             );
 
-            SerializableSortedSet<int> sortedSet = new SerializableSortedSet<int> { 5, 1, 9 };
+            SerializableSortedSet<int> sortedSet = new SerializableSortedSet<int>();
+            if (!empty)
+            {
+                sortedSet.Add(5);
+                sortedSet.Add(1);
+                sortedSet.Add(9);
+            }
             yield return Sample.Wrapped(
                 sortedSet,
                 restored => CollectionAssert.AreEqual(sortedSet.ToList(), restored.ToList())
             );
 
-            SerializableDictionary<string, int> dictionary = new SerializableDictionary<string, int>
+            SerializableDictionary<string, int> dictionary =
+                new SerializableDictionary<string, int>();
+            if (!empty)
             {
-                { "a", 1 },
-                { "b", 300 },
-            };
+                dictionary.Add("a", 1);
+                dictionary.Add("b", 300);
+            }
             yield return Sample.Wrapped(
                 dictionary,
                 restored =>
@@ -194,7 +236,12 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             );
 
             SerializableSortedDictionary<string, int> sortedDictionary =
-                new SerializableSortedDictionary<string, int> { { "b", 2 }, { "a", 1 } };
+                new SerializableSortedDictionary<string, int>();
+            if (!empty)
+            {
+                sortedDictionary.Add("b", 2);
+                sortedDictionary.Add("a", 1);
+            }
             yield return Sample.Wrapped(
                 sortedDictionary,
                 restored =>
@@ -204,13 +251,21 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                         sortedDictionary.Keys.ToList(),
                         restored.Keys.ToList()
                     );
+                    foreach (KeyValuePair<string, int> pair in sortedDictionary)
+                    {
+                        Assert.IsTrue(restored.TryGetValue(pair.Key, out int actual));
+                        Assert.AreEqual(pair.Value, actual);
+                    }
                 }
             );
 
             Deque<int> deque = new Deque<int>(16);
-            deque.PushBack(1);
-            deque.PushBack(2);
-            deque.PushFront(0);
+            if (!empty)
+            {
+                deque.PushBack(1);
+                deque.PushBack(2);
+                deque.PushFront(0);
+            }
             yield return Sample.Special(
                 deque,
                 restored =>
@@ -221,10 +276,13 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             );
 
             CyclicBuffer<int> buffer = new CyclicBuffer<int>(3);
-            buffer.Add(1);
-            buffer.Add(2);
-            buffer.Add(3);
-            buffer.Add(4);
+            if (!empty)
+            {
+                buffer.Add(1);
+                buffer.Add(2);
+                buffer.Add(3);
+                buffer.Add(4);
+            }
             yield return Sample.Special(
                 buffer,
                 restored =>
@@ -239,8 +297,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
             );
 
             SparseSet sparse = new SparseSet(64);
-            sparse.TryAdd(3);
-            sparse.TryAdd(40);
+            if (!empty)
+            {
+                sparse.TryAdd(3);
+                sparse.TryAdd(40);
+            }
             yield return Sample.Special(
                 sparse,
                 restored =>
@@ -307,6 +368,9 @@ namespace WallstopStudios.UnityHelpers.Tests.Serialization
                     typeof(T).Name + " is not served at the root."
                 );
                 _verify(_shippedRead(ours));
+                _verify((T)Serializer.ProtoDeserialize<object>(ours, typeof(T)));
+                Assert.IsTrue(Serializer.TryProtoDeserialize(ours, typeof(T), out object boxed));
+                _verify((T)boxed);
             }
 
             internal override void AssertOursReadsShipped()

--- a/docs/features/serialization/serialization.md
+++ b/docs/features/serialization/serialization.md
@@ -1389,10 +1389,23 @@ sequence of separate fields whose length is not knowable until it ends, and stil
 **A capacity is not sized from the payload at all.** The wrappers for `Deque`, `SparseSet` and the
 bit sets carry a capacity, and a capacity, unlike a length prefix, has nothing behind it: six
 bytes claiming `int.MaxValue` used to allocate 8 GB. `SerializationCapacityLimits` bounds it now,
-clamping where the structure grows on demand and refusing where the capacity decides behavior. If
-your saves genuinely hold more than 1,048,576 elements, raise
-`SerializationCapacityLimits.MaximumRestoredCapacity` once at startup; that is a decision your game
-makes about its own data, not one a payload makes.
+clamping where the structure grows on demand and refusing where the capacity decides behavior.
+The ceiling is the larger of `SerializationCapacityLimits.MaximumRestoredCapacity` (1,048,576 by
+default) and the number of elements actually delivered. Raise the configured limit once at startup
+if your saves need a larger capacity than either permits.
+
+`SparseSet` binary restoration validates every stored element before allocating the set. Negative
+IDs, `int.MaxValue`, and IDs outside a stated positive capacity refuse the whole payload instead
+of silently dropping elements. When capacity is omitted or nonpositive, restoration infers the
+smallest universe containing the elements, subject to the capacity budget. Duplicate IDs keep
+their first occurrence without enlarging the universe. Generated and legacy binary paths use
+the same validation; `TryProtoDeserialize` returns false on refusal.
+
+The explicit-type `ProtoDeserialize` overload uses the same wrapper rules for serializable sets
+and dictionaries, `Deque`, `CyclicBuffer`, and `SparseSet`. Keep the collection's concrete type as
+the generic argument for generated IL2CPP reads. Requests returning `object` use the legacy
+runtime-type path for generic collections; `SparseSet` also supports that request through its
+generated reader.
 
 The same three pieces are public, for a formatter you write yourself:
 `WProtoReader.CountPackedElements(wireType)` returns the exact element count of a packed run without

--- a/docs/features/utilities/random-generators.md
+++ b/docs/features/utilities/random-generators.md
@@ -69,6 +69,11 @@ constructor that takes one back. Snapshot mid-stream, store the snapshot in your
 restored generator resumes the exact sequence, verified for all of them by
 `GeneratorSnapshotRestoreTests`.
 
+For the 20 managed generators, `Copy()`, snapshot construction, and protobuf restoration retain
+pending Gaussian samples and partly consumed bool and byte reservoirs. Mixed draws continue with
+the same values and state, whether those caches are empty or primed. `WyRandom.Copy()` now preserves
+these caches too, so copying after a bool, byte, or Gaussian draw no longer changes the continuation.
+
 `UnityRandom` resumes too, and it is worth knowing how. Its position belongs to
 `UnityEngine.Random`'s engine globals rather than to the object, so the snapshot carries that position
 and restoring one **writes `UnityEngine.Random.state` back**. Anything else drawing from


### PR DESCRIPTION
**Why:** Restored collections and copied generators could silently lose state.

**What:**

- Reject invalid SparseSet saves and preserve collection wrapper rules.
- Preserve WyRandom's pending draws when copying.
- Verify mixed continuation across all 20 managed generators.
- Reduce PCG test overhead while retaining every sample and check.

Addresses #647 and #638.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches save/load and explicit-type protobuf deserialization for core collections plus RNG continuity; behavior changes reject previously accepted malformed SparseSet payloads.
> 
> **Overview**
> Fixes **silent state loss** when copying `WyRandom` and when deserializing package collections through explicit runtime types.
> 
> **`WyRandom.Copy()`** now clones **`InternalState`** (including pending Gaussian, bool, and byte reservoirs) instead of only the core PRNG word, so mixed draw sequences continue unchanged after a copy. New **`MixedContinuationSurvivesEveryRestorePath`** coverage extends the same guarantee across copy, snapshot construction, and protobuf restore for all 20 managed generators.
> 
> **`SparseSet`** binary restore logic moves into **`SparseSetProtoWrapper.TryRestore`**, shared by WallstopProto marshals and the legacy wrapper path. Invalid element IDs, IDs outside a stated universe, and over-limit capacities **refuse the whole payload** (no silent drops or universe inflation); omitted capacity is inferred from elements; duplicates keep the first ID.
> 
> **`Serializer.ProtoDeserialize<T>(data, Type type)`** now routes **`SparseSet`**, serializable sets/dictionaries, **`Deque`**, and **`CyclicBuffer`** through the same wrapper/special-collection deserializers when `type` matches `T`, fixing typed/`object` reads that previously skipped wrappers. Docs and changelog describe capacity limits and refusal behavior; PCG distribution tests use conditional asserts to cut overhead without reducing sample counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac6626fba97bd2392effd74343d4ff6ab0ab280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->