### PR TITLE
Publish the merge-policy attestation for ruleset 22983578

### DIFF
--- a/.github/merge-policy-attestation.json
+++ b/.github/merge-policy-attestation.json
@@ -6,9 +6,7 @@
       "rulesetId": 22983578,
       "rulesetName": "Required CI - Success (default branch)",
       "enforcement": "active",
-      "requiredContexts": [
-        "Unity CI Success"
-      ],
+      "requiredContexts": ["Unity CI Success"],
       "bypassActors": []
     }
   ]

--- a/.github/merge-policy-attestation.json
+++ b/.github/merge-policy-attestation.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "repository": "Ambiguous-Interactive/unity-helpers",
+  "rulesets": [
+    {
+      "rulesetId": 22983578,
+      "rulesetName": "Required CI - Success (default branch)",
+      "enforcement": "active",
+      "requiredContexts": [
+        "Unity CI Success"
+      ],
+      "bypassActors": []
+    }
+  ]
+}


### PR DESCRIPTION
**Why:** The central merge-policy audit requires bypass-actor evidence for every ruleset that requires a reviewed context. The reader credential is read-only, so GitHub hides bypass actors from it. The reviewed contract fills that one field from this published attestation.

**What:** `.github/merge-policy-attestation.json` attests ruleset 22983578 `Required CI - Success (default branch)`: active, requires `Unity CI Success`, and grants bypass to no actor.

**Proof:** The audit compares the file against the live ruleset name, enforcement, and required contexts on every run, and fails closed when the file goes stale.

Refs Ambiguous-Interactive/ambiguous-organization-build-lock#255

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CI governance metadata with no runtime or application code changes.
> 
> **Overview**
> Adds **`.github/merge-policy-attestation.json`** so the org merge-policy audit can verify ruleset **22983578** (`Required CI - Success (default branch)`) when the GitHub API does not expose bypass actors to read-only credentials.
> 
> The attestation records **active** enforcement, required check context **`Unity CI Success`**, and an **empty `bypassActors`** list. The audit is expected to compare this file to live ruleset settings on each run and fail if it is out of date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0661642ac49c7682fb2152fccaad3248d96bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->