### PR TITLE
Enforce warning-free Unity package compiles

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -72,7 +72,6 @@ jobs:
       unity-versions: ${{ steps.resolve.outputs.unity-versions }}
       release-unity-version: ${{ steps.release_version.outputs.version }}
       test-modes: ${{ steps.resolve.outputs.test-modes }}
-      matrix-exclude: ${{ steps.resolve.outputs.matrix-exclude }}
       editmode-integration-assemblies: ${{ steps.assemblies.outputs.editmode_integrations }}
       playmode-integration-assemblies: ${{ steps.assemblies.outputs.playmode_integrations }}
       standalone-integration-assemblies: ${{ steps.assemblies.outputs.standalone_integrations }}
@@ -308,12 +307,7 @@ jobs:
       # trade-off accepted here is politeness -- a sibling repo's Unity job can now
       # queue behind more of ours at once.
       matrix:
-        unity-version:
-          - 2021.3.45f1
-          - 2022.3.45f1
-          - 6000.5.2f1
-          - 6000.6.0f1
-        exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}
+        unity-version: ${{ fromJSON(needs.matrix-config.outputs.unity-versions) }}
     steps:
       - name: Require current PR head before setup
         timeout-minutes: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix package compiler and analyzer warnings across supported Unity versions, including the 2021.3 serialization attribute conflict and Unity 6 obsolete build-target calls ([#766](https://github.com/Ambiguous-Interactive/unity-helpers/issues/766), [#770](https://github.com/Ambiguous-Interactive/unity-helpers/issues/770)).
 - Fix the seven UI Toolkit progress controls failing to compile on Unity 6000.6. Their UXML tags and attributes remain available on Unity 2021.3 and newer ([#759](https://github.com/Ambiguous-Interactive/unity-helpers/issues/759)).
 - Fix pooled serialization writes accepting negative or oversized advances and overflowing capacity calculations ([#760](https://github.com/Ambiguous-Interactive/unity-helpers/issues/760)).
 - Fix caught exceptions losing their type, inner exceptions, and stack trace in diagnostic logs ([#762](https://github.com/Ambiguous-Interactive/unity-helpers/issues/762)).

--- a/Editor/CustomEditors/MatchColliderToSpriteEditor.cs
+++ b/Editor/CustomEditors/MatchColliderToSpriteEditor.cs
@@ -20,7 +20,7 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomEditors
             if (matchColliderToSprite == null)
             {
                 this.LogError(
-                    $"Target was of type {target?.GetType()}, expected {nameof(MatchColliderToSprite)}."
+                    $"Target was of type {(target != null ? target.GetType() : null)}, expected {nameof(MatchColliderToSprite)}."
                 );
                 return;
             }
@@ -87,9 +87,13 @@ namespace WallstopStudios.UnityHelpers.Editor.CustomEditors
                 nameof(MatchColliderToSprite.polygonCollider)
             );
             PolygonCollider2D collider = colliderProperty.objectReferenceValue as PolygonCollider2D;
-            if (collider == null && target is MatchColliderToSprite matcher)
+            if (
+                collider == null
+                && target is MatchColliderToSprite matcher
+                && matcher.TryGetComponent(out PolygonCollider2D resolvedCollider)
+            )
             {
-                matcher.TryGetComponent(out collider);
+                collider = resolvedCollider;
             }
             return collider;
         }

--- a/Editor/Sprites/SpriteSheetAnimationCreator.cs
+++ b/Editor/Sprites/SpriteSheetAnimationCreator.cs
@@ -1554,15 +1554,34 @@ namespace WallstopStudios.UnityHelpers.Editor.Sprites
             public AnimationCurve FrameRateCurve = AnimationCurve.Constant(0, 1, 12f);
             public List<Sprite> SpritesToAnimate = new();
 
+            [NonSerialized]
             public TextField nameField;
+
+            [NonSerialized]
             public IntegerField startIndexField;
+
+            [NonSerialized]
             public IntegerField endIndexField;
+
+            [NonSerialized]
             public FloatField defaultFrameRateField;
+
+            [NonSerialized]
             public CurveField frameRateCurveField;
+
+            [NonSerialized]
             public Label spriteCountLabel;
+
+            [NonSerialized]
             public Button previewButton;
+
+            [NonSerialized]
             public Button removeButton;
+
+            [NonSerialized]
             public Toggle loopingField;
+
+            [NonSerialized]
             public FloatField cycleOffsetField;
         }
 

--- a/Editor/Tools/ProtoSchemaExporterWindow.cs
+++ b/Editor/Tools/ProtoSchemaExporterWindow.cs
@@ -340,7 +340,14 @@ namespace WallstopStudios.UnityHelpers.Editor.Tools
                     .ThenBy(ContractDisplayName, StringComparer.Ordinal)
             );
             _assemblyNames.AddRange(assemblyNames.OrderBy(name => name, StringComparer.Ordinal));
-            foreach (System.Reflection.Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+#if UNITY_6000_6_OR_NEWER
+            IReadOnlyList<System.Reflection.Assembly> loadedAssemblies =
+                UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
+#else
+            IReadOnlyList<System.Reflection.Assembly> loadedAssemblies =
+                AppDomain.CurrentDomain.GetAssemblies();
+#endif
+            foreach (System.Reflection.Assembly assembly in loadedAssemblies)
             {
                 foreach (
                     WProtoSurrogateAttribute surrogate in assembly.GetCustomAttributes<WProtoSurrogateAttribute>()

--- a/Editor/Tools/WProtoSubtypeTagAssigner.cs
+++ b/Editor/Tools/WProtoSubtypeTagAssigner.cs
@@ -444,7 +444,13 @@ namespace WallstopStudios.UnityHelpers.Editor.Tools
             }
 
             // Visit assemblies with orphan-only manifests so unused numbers remain retired.
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+#if UNITY_6000_6_OR_NEWER
+            IReadOnlyList<Assembly> loadedAssemblies =
+                UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
+#else
+            IReadOnlyList<Assembly> loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+#endif
+            foreach (Assembly assembly in loadedAssemblies)
             {
                 if (assembly.IsDynamic || byAssembly.ContainsKey(assembly))
                 {

--- a/Editor/Validation/Continuous/ValidationWindow.Graph.cs
+++ b/Editor/Validation/Continuous/ValidationWindow.Graph.cs
@@ -24,6 +24,15 @@ namespace WallstopStudios.UnityHelpers.Editor.Validation.Continuous
         private ValidationGraphConnections _graphConnections;
         private readonly List<VisualElement> _graphNodes = new List<VisualElement>();
 
+        private static void SetGraphNodePosition(VisualElement element, Vector2 position)
+        {
+#if UNITY_6000_0_OR_NEWER
+            element.style.translate = new Translate(position.x, position.y, 0);
+#else
+            element.transform.position = position;
+#endif
+        }
+
         private VisualElement BuilderNode(string title, int index)
         {
             if (index == 0)
@@ -44,7 +53,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Validation.Continuous
                 if (!_graphMode || !handle.HasMouseCapture())
                     return;
                 _graphPositions[index] += evt.mouseDelta;
-                node.transform.position = _graphPositions[index];
+                SetGraphNodePosition(node, _graphPositions[index]);
                 _graphConnections.MarkDirtyRepaint();
                 evt.StopPropagation();
             });
@@ -82,7 +91,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Validation.Continuous
                     node.userData = row;
                     Label handle = AddLabel(node, "CHECK " + (index + 1), "sentinel-node-title");
                     node.Add(row);
-                    node.transform.position = condition.graphPosition;
+                    SetGraphNodePosition(node, condition.graphPosition);
                     handle.RegisterCallback<MouseDownEvent>(evt =>
                     {
                         if (evt.button != 0)
@@ -95,7 +104,7 @@ namespace WallstopStudios.UnityHelpers.Editor.Validation.Continuous
                         if (!handle.HasMouseCapture())
                             return;
                         condition.graphPosition += evt.mouseDelta;
-                        node.transform.position = condition.graphPosition;
+                        SetGraphNodePosition(node, condition.graphPosition);
                         _graphConnections.MarkDirtyRepaint();
                         evt.StopPropagation();
                     });
@@ -112,8 +121,8 @@ namespace WallstopStudios.UnityHelpers.Editor.Validation.Continuous
             _graphNodes.Add(_reportNode);
             _builderSurface.EnableInClassList("sentinel-graph", graph);
             _graphConnections.EnableInClassList("dx-hidden", !graph);
-            _targetNode.transform.position = graph ? _graphPositions[0] : Vector2.zero;
-            _reportNode.transform.position = graph ? _graphPositions[2] : Vector2.zero;
+            SetGraphNodePosition(_targetNode, graph ? _graphPositions[0] : Vector2.zero);
+            SetGraphNodePosition(_reportNode, graph ? _graphPositions[2] : Vector2.zero);
             _graphConnections.MarkDirtyRepaint();
         }
 

--- a/Generator~/WallstopStudios.UnityHelpers.DocSamplesCheck/WallstopStudios.UnityHelpers.DocSamplesCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.DocSamplesCheck/WallstopStudios.UnityHelpers.DocSamplesCheck.csproj
@@ -61,7 +61,7 @@
       is whether the NAMES resolve, so warnings about how the sample is shaped are noise here; the
       real build judges the package's own sources.
     -->
-    <NoWarn>$(NoWarn);CS0414;CS0649;CS0219;CS0618;CS0612;CS1591;CS1573;CS0169;CS0067;CS8321;CS0168;CS1998;CS0436;CS1701;NU1701</NoWarn>
+    <NoWarn>$(NoWarn);CS0414;CS0649;CS0219;CS0618;CS0612;CS1591;CS1573;CS0169;CS0067;CS8321;CS0168;CS1998;CS1701;NU1701</NoWarn>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/Generator~/WallstopStudios.UnityHelpers.EditorCheck/WallstopStudios.UnityHelpers.EditorCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.EditorCheck/WallstopStudios.UnityHelpers.EditorCheck.csproj
@@ -95,14 +95,9 @@
      10. IL2CPP and behaviour. A green build here is necessary and NOT sufficient; the Unity legs
          remain the real proof.
 
-    THREE NoWarn entries are harness artifacts rather than judgments about the sources, and each is
+    TWO NoWarn entries are harness artifacts rather than judgments about the sources, and each is
     a specific diagnostic rather than a category:
 
-      * CS0436, exactly one site: `Runtime/Core/Serialization/SerializationFailureException.cs`
-        polyfills `DoesNotReturnAttribute` under `UNITY_2021 || UNITY_2022 || UNITY_2023`. This
-        project defines `UNITY_2021` (Unity does), so the polyfill activates and collides with the
-        copy in Microsoft's `netstandard.dll`. The compiler picks the source type, which is the
-        outcome the polyfill wants. TypeCheck never sees this because it defines no UNITY_* symbols.
       * CS1701: `UnityEditor.dll` names `UnityEngine 0.0.0.0` and binds to the facade above.
       * NU1701: `Unity3D.SDK` publishes a bare `lib/` folder with no target framework, so restoring
         it into a netstandard2.1 project is a framework mismatch by construction. Scoped to that one
@@ -152,9 +147,9 @@
     -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS0414;CS0649;CS0219;CS0618;CS0612;CS1591;CS1573</NoWarn>
-    <!-- The three harness artifacts enumerated at the top of this file. Each is one diagnostic with
+    <!-- The two harness artifacts enumerated at the top of this file. Each is one diagnostic with
          one named cause, not a category swept under the rug. -->
-    <NoWarn>$(NoWarn);CS0436;CS1701;NU1701</NoWarn>
+    <NoWarn>$(NoWarn);CS1701;NU1701</NoWarn>
     <!-- Same split as TypeCheck: EPS01 is at zero and is escalated, the rest of the family is
          silenced because measured most of it is wrong about Span. Inventory on #517. -->
     <NoWarn>$(NoWarn);EPS02;EPS03;EPS04;EPS05;EPS06;EPS07;EPS08;EPS09;EPS10;EPS11;EPS12</NoWarn>
@@ -177,9 +172,8 @@
       >$(DefineConstants);SINGLE_THREADED</DefineConstants>
     <!--
       UNITY_EDITOR plus the symbol set a real Unity 2021.3 editor defines. These are not decoration:
-      `Editor/Tools/UnityMethodAnalyzer/*` branches on bare `UNITY_2021`, and so does the
-      DoesNotReturnAttribute polyfill in Runtime/Core/Serialization. Compiling the editor tree
-      without them would compile a configuration nobody runs.
+      `Editor/Tools/UnityMethodAnalyzer/*` branches on bare `UNITY_2021`. Compiling the editor tree
+      without these symbols would compile a configuration nobody runs.
     -->
     <UnityVersionDefines>UNITY_2021;UNITY_2021_3;UNITY_2021_3_OR_NEWER;UNITY_2021_2_OR_NEWER;UNITY_2021_1_OR_NEWER;UNITY_2020_3_OR_NEWER;UNITY_2020_2_OR_NEWER;UNITY_2020_1_OR_NEWER;UNITY_2019_4_OR_NEWER;UNITY_2019_1_OR_NEWER;UNITY_2018_1_OR_NEWER;UNITY_5_3_OR_NEWER</UnityVersionDefines>
     <DefineConstants>$(DefineConstants);UNITY_EDITOR;$(UnityVersionDefines)</DefineConstants>

--- a/Generator~/WallstopStudios.UnityHelpers.EditorTestCheck/WallstopStudios.UnityHelpers.EditorTestCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.EditorTestCheck/WallstopStudios.UnityHelpers.EditorTestCheck.csproj
@@ -178,9 +178,9 @@
         reason: `Tests/Editor/TestTypes/BackingFieldGroupAsset.cs` declares
         `[SerializeField] private int _outside`, a field Unity serializes and C# cannot see used.
         The real Unity build judges these; here they are noise.
-      * CS0436, CS1701 and NU1701 are the three harness artifacts EditorCheck's header enumerates -
-        the DoesNotReturnAttribute polyfill under UNITY_2021, `UnityEditor.dll`'s
-        `UnityEngine 0.0.0.0` reference binding to the facade, and `Unity3D.SDK`'s bare `lib/` folder.
+      * CS1701 and NU1701 are the two harness artifacts EditorCheck's header enumerates -
+        `UnityEditor.dll`'s `UnityEngine 0.0.0.0` reference binding to the facade, and
+        `Unity3D.SDK`'s bare `lib/` folder.
 
     Like its three siblings this project lives under `Generator~`, which Unity ignores by the
     trailing-tilde convention, and ships to nobody.
@@ -207,9 +207,9 @@
          `defineConstraints` entry, and the package gates test-only internals on it. -->
     <DefineConstants>$(DefineConstants);UNITY_INCLUDE_TESTS</DefineConstants>
     <NoWarn>$(NoWarn);CS0414;CS0649;CS0169;CS0219;CS0618;CS0612;CS1591;CS1573</NoWarn>
-    <!-- The three harness artifacts EditorCheck enumerates. Each is one diagnostic with one named
+    <!-- The two harness artifacts EditorCheck enumerates. Each is one diagnostic with one named
          cause, not a category swept under the rug. -->
-    <NoWarn>$(NoWarn);CS0436;CS1701;NU1701</NoWarn>
+    <NoWarn>$(NoWarn);CS1701;NU1701</NoWarn>
     <WallstopProto Condition="'$(WallstopProto)' == ''">true</WallstopProto>
     <DefineConstants Condition="'$(WallstopProto)' == 'true'"
       >$(DefineConstants);WALLSTOP_PROTO</DefineConstants>
@@ -238,8 +238,7 @@
     <!--
       UNITY_EDITOR plus the symbol set a real Unity 2021.3 editor defines, identical to EditorCheck's.
       These are not decoration: `Editor/Tools/UnityMethodAnalyzer/*` branches on bare `UNITY_2021`,
-      so does the DoesNotReturnAttribute polyfill in Runtime/Core/Serialization, and the editmode
-      fixtures live behind `UNITY_EDITOR` end to end.
+      and the editmode fixtures live behind `UNITY_EDITOR` end to end.
     -->
     <UnityVersionDefines>UNITY_2021;UNITY_2021_3;UNITY_2021_3_OR_NEWER;UNITY_2021_2_OR_NEWER;UNITY_2021_1_OR_NEWER;UNITY_2020_3_OR_NEWER;UNITY_2020_2_OR_NEWER;UNITY_2020_1_OR_NEWER;UNITY_2019_4_OR_NEWER;UNITY_2019_1_OR_NEWER;UNITY_2018_1_OR_NEWER;UNITY_5_3_OR_NEWER</UnityVersionDefines>
     <DefineConstants>$(DefineConstants);UNITY_EDITOR;$(UnityVersionDefines)</DefineConstants>

--- a/Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj
+++ b/Generator~/WallstopStudios.UnityHelpers.TestCheck/WallstopStudios.UnityHelpers.TestCheck.csproj
@@ -41,7 +41,7 @@
          (SingletonAutoLoader.ExecuteEntriesForTests, Helpers.LayerNameProvider, the concave-hull
          diagnostics). Without it the fixtures that drive them do not bind. -->
     <DefineConstants>$(DefineConstants);UNITY_INCLUDE_TESTS</DefineConstants>
-    <NoWarn>$(NoWarn);CS0414;CS0649;CS0219;CS0618;CS0612;CS0436;CS1701</NoWarn>
+    <NoWarn>$(NoWarn);CS0414;CS0649;CS0219;CS0618;CS0612;CS1701</NoWarn>
     <DefineConstants Condition="'$(WallstopProto)' == 'true'"
       >$(DefineConstants);WALLSTOP_PROTO</DefineConstants>
     <!-- See the TypeCheck project for why this exists (#347). The PlayMode fixtures behind the Odin

--- a/Runtime/Core/Attributes/ValidateAssignmentAttribute.cs
+++ b/Runtime/Core/Attributes/ValidateAssignmentAttribute.cs
@@ -140,7 +140,9 @@ namespace WallstopStudios.UnityHelpers.Core.Attributes
         /// </remarks>
         // Keep validation in development players; Release players intentionally omit warning-only calls.
         [System.Diagnostics.Conditional(CompilationSymbols.EnableUberLogging)]
+#pragma warning disable UAC0009 // Development builds retain the established validation contract.
         [System.Diagnostics.Conditional(CompilationSymbols.DevelopmentBuild)]
+#pragma warning restore UAC0009
         [System.Diagnostics.Conditional(CompilationSymbols.Debug)]
         [System.Diagnostics.Conditional(CompilationSymbols.UnityEditor)]
         [System.Diagnostics.Conditional(CompilationSymbols.WarnLogging)]

--- a/Runtime/Core/Extension/WallstopStudiosLogger.cs
+++ b/Runtime/Core/Extension/WallstopStudiosLogger.cs
@@ -195,7 +195,9 @@ namespace WallstopStudios.UnityHelpers.Core.Extension
         /// </param>
         [HideInCallstack]
         [System.Diagnostics.Conditional(CompilationSymbols.EnableUberLogging)]
+#pragma warning disable UAC0009 // Development builds are part of the public logging contract.
         [System.Diagnostics.Conditional(CompilationSymbols.DevelopmentBuild)]
+#pragma warning restore UAC0009
         [System.Diagnostics.Conditional(CompilationSymbols.Debug)]
         [System.Diagnostics.Conditional(CompilationSymbols.UnityEditor)]
         [System.Diagnostics.Conditional(CompilationSymbols.DebugLogging)]
@@ -225,7 +227,9 @@ namespace WallstopStudios.UnityHelpers.Core.Extension
         /// </param>
         [HideInCallstack]
         [System.Diagnostics.Conditional(CompilationSymbols.EnableUberLogging)]
+#pragma warning disable UAC0009 // Development builds are part of the public logging contract.
         [System.Diagnostics.Conditional(CompilationSymbols.DevelopmentBuild)]
+#pragma warning restore UAC0009
         [System.Diagnostics.Conditional(CompilationSymbols.Debug)]
         [System.Diagnostics.Conditional(CompilationSymbols.UnityEditor)]
         [System.Diagnostics.Conditional(CompilationSymbols.DebugLogging)]
@@ -255,7 +259,9 @@ namespace WallstopStudios.UnityHelpers.Core.Extension
         /// </param>
         [HideInCallstack]
         [System.Diagnostics.Conditional(CompilationSymbols.EnableUberLogging)]
+#pragma warning disable UAC0009 // Development builds are part of the public logging contract.
         [System.Diagnostics.Conditional(CompilationSymbols.DevelopmentBuild)]
+#pragma warning restore UAC0009
         [System.Diagnostics.Conditional(CompilationSymbols.Debug)]
         [System.Diagnostics.Conditional(CompilationSymbols.UnityEditor)]
         [System.Diagnostics.Conditional(CompilationSymbols.WarnLogging)]
@@ -285,7 +291,9 @@ namespace WallstopStudios.UnityHelpers.Core.Extension
         /// </param>
         [HideInCallstack]
         [System.Diagnostics.Conditional(CompilationSymbols.EnableUberLogging)]
+#pragma warning disable UAC0009 // Development builds are part of the public logging contract.
         [System.Diagnostics.Conditional(CompilationSymbols.DevelopmentBuild)]
+#pragma warning restore UAC0009
         [System.Diagnostics.Conditional(CompilationSymbols.Debug)]
         [System.Diagnostics.Conditional(CompilationSymbols.UnityEditor)]
         [System.Diagnostics.Conditional(CompilationSymbols.ErrorLogging)]

--- a/Runtime/Core/Helper/Partials/LogHelpers.cs
+++ b/Runtime/Core/Helper/Partials/LogHelpers.cs
@@ -22,7 +22,9 @@ namespace WallstopStudios.UnityHelpers.Core.Helper
         /// <see cref="WallstopStudiosLogger.LogWarn"/>, which it forwards to.
         /// </remarks>
         [System.Diagnostics.Conditional(CompilationSymbols.EnableUberLogging)]
+#pragma warning disable UAC0009 // Development builds are part of the public logging contract.
         [System.Diagnostics.Conditional(CompilationSymbols.DevelopmentBuild)]
+#pragma warning restore UAC0009
         [System.Diagnostics.Conditional(CompilationSymbols.Debug)]
         [System.Diagnostics.Conditional(CompilationSymbols.UnityEditor)]
         [System.Diagnostics.Conditional(CompilationSymbols.WarnLogging)]

--- a/Runtime/Core/Helper/ReflectionHelpers.TypeDiscovery.cs
+++ b/Runtime/Core/Helper/ReflectionHelpers.TypeDiscovery.cs
@@ -57,9 +57,15 @@ namespace WallstopStudios.UnityHelpers.Core.Helper
         {
             try
             {
+#if UNITY_6000_6_OR_NEWER
+                return UnityEngine
+                    .Assemblies.CurrentAssemblies.GetLoadedAssemblies()
+                    .Where(assembly => assembly != null && !assembly.IsDynamic);
+#else
                 return AppDomain
                     .CurrentDomain.GetAssemblies()
                     .Where(assembly => assembly != null && !assembly.IsDynamic);
+#endif
             }
             catch
             {

--- a/Runtime/Core/Serialization/ProtobufUnitySurrogates.cs
+++ b/Runtime/Core/Serialization/ProtobufUnitySurrogates.cs
@@ -16,7 +16,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct Vector2Surrogate
+    public partial struct Vector2Surrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -33,7 +33,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct Vector3Surrogate
+    public partial struct Vector3Surrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -60,7 +60,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct QuaternionSurrogate
+    public partial struct QuaternionSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -93,7 +93,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct ColorSurrogate
+    public partial struct ColorSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -125,7 +125,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct Color32Surrogate
+    public partial struct Color32Surrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -157,7 +157,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct RectSurrogate
+    public partial struct RectSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -189,7 +189,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct RectIntSurrogate
+    public partial struct RectIntSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -222,7 +222,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct BoundsSurrogate
+    public partial struct BoundsSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -265,7 +265,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct BoundsIntSurrogate
+    public partial struct BoundsIntSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -308,7 +308,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct Vector2IntSurrogate
+    public partial struct Vector2IntSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -326,7 +326,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct Vector3IntSurrogate
+    public partial struct Vector3IntSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -353,7 +353,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct ResolutionSurrogate
+    public partial struct ResolutionSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -462,7 +462,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct ParabolaSurrogate
+    public partial struct ParabolaSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]
@@ -496,7 +496,7 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
 
     [ProtoContract]
     [WProtoContract]
-    internal partial struct ImmutableBitSetSurrogate
+    public partial struct ImmutableBitSetSurrogate
     {
         [ProtoMember(1)]
         [WProtoMember(1)]

--- a/Runtime/Core/Serialization/ProtobufUnitySurrogates.cs
+++ b/Runtime/Core/Serialization/ProtobufUnitySurrogates.cs
@@ -773,7 +773,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             catch (Exception error)
             {
                 RegistrationFailures.Add(typeof(TReal).Name);
-#if !ENABLE_IL2CPP
+#if ENABLE_IL2CPP
+                _ = error;
+#else
                 // AOT always uses WallstopProto; expected protobuf-net refusals must not log startup errors.
                 Debug.LogError(
                     $"[UnityHelpers] protobuf-net already bound {typeof(TReal).Name}, so its "

--- a/Runtime/Core/Serialization/SerializationFailureException.cs
+++ b/Runtime/Core/Serialization/SerializationFailureException.cs
@@ -1,22 +1,6 @@
 // MIT License - Copyright (c) 2026 wallstop
 // Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
 
-#if UNITY_2021 || UNITY_2022 || UNITY_2023
-#define UNH_NEEDS_DOES_NOT_RETURN_ATTRIBUTE_POLYFILL
-#endif
-
-// Polyfill DoesNotReturn on older Unity profiles so Throw helpers retain analyzer annotations.
-
-#if !NET5_0_OR_GREATER && UNH_NEEDS_DOES_NOT_RETURN_ATTRIBUTE_POLYFILL
-namespace System.Diagnostics.CodeAnalysis
-{
-    using System;
-
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    internal sealed class DoesNotReturnAttribute : Attribute { }
-}
-#endif
-
 namespace WallstopStudios.UnityHelpers.Core.Serialization
 {
     using System;

--- a/Runtime/Core/Serialization/Serializer.cs
+++ b/Runtime/Core/Serialization/Serializer.cs
@@ -361,8 +361,10 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             Func<byte[], object>
         > SpecialCollectionDeserializerFactory = BuildSpecialCollectionDeserializer;
 
+#pragma warning disable UAC0023 // Intentional legacy, trusted-only compatibility API; see SystemBinary docs.
         private static readonly Utils.WallstopGenericPool<BinaryFormatter> BinaryFormatterPool =
             new(() => new BinaryFormatter());
+#pragma warning restore UAC0023
 
         private static readonly Utils.WallstopGenericPool<Utf8JsonWriter> JsonWriterPool = new(
             () => new Utf8JsonWriter(Stream.Null, new JsonWriterOptions { SkipValidation = true }),
@@ -815,7 +817,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
                 using Utils.PooledResource<BinaryFormatter> fmtLease = BinaryFormatterPool.Get(
                     out BinaryFormatter binaryFormatter
                 );
+#pragma warning disable UAC0023 // Intentional legacy, trusted-only compatibility API.
                 return (T)binaryFormatter.Deserialize(stream);
+#pragma warning restore UAC0023
             }
             catch (SerializationFailureException)
             {
@@ -875,7 +879,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             using Utils.PooledResource<BinaryFormatter> fmtLease = BinaryFormatterPool.Get(
                 out BinaryFormatter binaryFormatter
             );
+#pragma warning disable UAC0023 // Intentional legacy, trusted-only compatibility API.
             binaryFormatter.Serialize(stream, input);
+#pragma warning restore UAC0023
             byte[] buffer = null;
             stream.ToArrayExact(ref buffer);
             return buffer;
@@ -896,7 +902,9 @@ namespace WallstopStudios.UnityHelpers.Core.Serialization
             using Utils.PooledResource<BinaryFormatter> fmtLease = BinaryFormatterPool.Get(
                 out BinaryFormatter binaryFormatter
             );
+#pragma warning disable UAC0023 // Intentional legacy, trusted-only compatibility API.
             binaryFormatter.Serialize(stream, input);
+#pragma warning restore UAC0023
             return stream.ToArrayExact(ref buffer);
         }
 

--- a/Runtime/Utils/Buffers.cs
+++ b/Runtime/Utils/Buffers.cs
@@ -1,6 +1,12 @@
 // MIT License - Copyright (c) 2023 wallstop
 // Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
 
+#pragma warning disable UAC0009 // Preserve diagnostics in development players.
+#if DEVELOPMENT_BUILD
+#define WALLSTOP_DEVELOPMENT_BUILD
+#endif
+#pragma warning restore UAC0009
+
 // ReSharper disable ConvertClosureToMethodGroup
 namespace WallstopStudios.UnityHelpers.Utils
 {
@@ -440,7 +446,7 @@ namespace WallstopStudios.UnityHelpers.Utils
         private static void ReportCacheLimit(string cacheName, ref int limitHits)
         {
             int hits = Interlocked.Increment(ref limitHits);
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
             int maxEntries = WaitInstructionMaxDistinctEntries;
             if (0 < maxEntries && (hits == 1 || hits % WaitInstructionLimitWarningInterval == 0))
             {

--- a/Runtime/Utils/MatchColliderToSprite.cs
+++ b/Runtime/Utils/MatchColliderToSprite.cs
@@ -52,9 +52,12 @@ namespace WallstopStudios.UnityHelpers.Utils
             {
                 TryGetComponent(out polygonCollider);
             }
-            if (spriteRenderer == null)
+            if (
+                spriteRenderer == null
+                && TryGetComponent(out SpriteRenderer resolvedSpriteRenderer)
+            )
             {
-                TryGetComponent(out spriteRenderer);
+                spriteRenderer = resolvedSpriteRenderer;
             }
             if (spriteRenderer == null && image == null)
             {

--- a/Runtime/Utils/PoolPurgeSettings.cs
+++ b/Runtime/Utils/PoolPurgeSettings.cs
@@ -1,6 +1,12 @@
 // MIT License - Copyright (c) 2026 wallstop
 // Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
 
+#pragma warning disable UAC0009 // Preserve diagnostics in development players.
+#if DEVELOPMENT_BUILD
+#define WALLSTOP_DEVELOPMENT_BUILD
+#endif
+#pragma warning restore UAC0009
+
 namespace WallstopStudios.UnityHelpers.Utils
 {
     using System;
@@ -1781,7 +1787,7 @@ namespace WallstopStudios.UnityHelpers.Utils
                 catch (Exception e)
                 {
                     // One pool failure must not prevent cleanup of the others.
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
                     Debug.LogWarning($"[PoolPurgeSettings] Failed to purge pool: {e}");
 #endif
                     _ = e;
@@ -1838,7 +1844,7 @@ namespace WallstopStudios.UnityHelpers.Utils
                 catch (Exception e)
                 {
                     // One pool failure must not prevent cleanup of the others.
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
                     Debug.LogWarning($"[PoolPurgeSettings] Failed to force-purge pool: {e}");
 #endif
                     _ = e;
@@ -2075,7 +2081,7 @@ namespace WallstopStudios.UnityHelpers.Utils
                 catch (Exception e)
                 {
                     // One pool failure must not prevent cleanup of the others.
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
                     Debug.LogWarning($"[PoolPurgeSettings] Failed to purge pool for budget: {e}");
 #endif
                     _ = e;

--- a/Runtime/Utils/PoolTypeResolver.cs
+++ b/Runtime/Utils/PoolTypeResolver.cs
@@ -757,8 +757,13 @@ namespace WallstopStudios.UnityHelpers.Utils
                 }
             }
 
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            foreach (Assembly assembly in assemblies)
+#if UNITY_6000_6_OR_NEWER
+            IReadOnlyList<Assembly> loadedAssemblies =
+                UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
+#else
+            IReadOnlyList<Assembly> loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+#endif
+            foreach (Assembly assembly in loadedAssemblies)
             {
                 try
                 {

--- a/Runtime/Utils/RuntimeSingleton.cs
+++ b/Runtime/Utils/RuntimeSingleton.cs
@@ -1,6 +1,12 @@
 // MIT License - Copyright (c) 2024 wallstop
 // Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
 
+#pragma warning disable UAC0009 // Preserve diagnostics in development players.
+#if DEVELOPMENT_BUILD
+#define WALLSTOP_DEVELOPMENT_BUILD
+#endif
+#pragma warning restore UAC0009
+
 namespace WallstopStudios.UnityHelpers.Utils
 {
     using System;
@@ -73,7 +79,7 @@ namespace WallstopStudios.UnityHelpers.Utils
 
         private bool _isPendingDestruction;
 
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
         private static bool _creationRefusedWarningLogged;
 #endif
 
@@ -285,14 +291,14 @@ namespace WallstopStudios.UnityHelpers.Utils
             _instance = null;
             // A cache reset must also clear remembered misses.
             _creationRefusedFrame = -1;
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
             _creationRefusedWarningLogged = false;
 #endif
         }
 
         private static void WarnCreationRefused(Type type)
         {
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
             if (_creationRefusedWarningLogged)
             {
                 return;

--- a/Runtime/Utils/ScriptableObjectSingleton.cs
+++ b/Runtime/Utils/ScriptableObjectSingleton.cs
@@ -1,6 +1,12 @@
 // MIT License - Copyright (c) 2025 wallstop
 // Full license text: https://github.com/wallstop/unity-helpers/blob/main/LICENSE
 
+#pragma warning disable UAC0009 // Preserve diagnostics in development players.
+#if DEVELOPMENT_BUILD
+#define WALLSTOP_DEVELOPMENT_BUILD
+#endif
+#pragma warning restore UAC0009
+
 namespace WallstopStudios.UnityHelpers.Utils
 {
     using System;
@@ -517,7 +523,7 @@ namespace WallstopStudios.UnityHelpers.Utils
 
         private static void WarnMetadataFolderEmpty(Type type, string folder)
         {
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
             if (string.IsNullOrWhiteSpace(folder))
             {
                 return;
@@ -551,7 +557,7 @@ namespace WallstopStudios.UnityHelpers.Utils
 
         private static void WarnNoInstancesFound(Type type)
         {
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
 #if UNITY_EDITOR
             // Suppress warning during early initialization - asset may not be created yet
             if (!ScriptableObjectSingletonInitState.InitialEnsureCompleted)
@@ -579,7 +585,7 @@ namespace WallstopStudios.UnityHelpers.Utils
 
         private static void LogMetadataWarning(string message, ref bool flag)
         {
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || WALLSTOP_DEVELOPMENT_BUILD
             if (!flag)
             {
                 flag = true;

--- a/Samples~/Logging - Tag Formatter/Scripts/LoggingDemoController.cs
+++ b/Samples~/Logging - Tag Formatter/Scripts/LoggingDemoController.cs
@@ -7,6 +7,7 @@ namespace Samples.UnityHelpers.Logging
     using System.Runtime.CompilerServices;
     using UnityEngine;
     using WallstopStudios.UnityHelpers.Core.Extension;
+    using WallstopStudios.UnityHelpers.Core.Random;
 
     /// <summary>
     /// Runtime MonoBehaviour that exercises the logging extensions and exposes toggleable controls.
@@ -35,7 +36,9 @@ namespace Samples.UnityHelpers.Logging
         private string reportMessage = "Intruder spotted near maintenance tunnel";
 
         [SerializeField]
+#pragma warning disable WPROTO028 // Inspector-only sample input; this component is not a proto contract.
         private Vector2 sectorRange = new Vector2(1f, 6f);
+#pragma warning restore WPROTO028
 
         private bool localLoggingEnabled = true;
 
@@ -62,7 +65,9 @@ namespace Samples.UnityHelpers.Logging
 
         private void OnGUI()
         {
+#pragma warning disable WPROTO028 // Transient IMGUI layout is never serialized by WallstopProto.
             GUILayout.BeginArea(new Rect(16f, 16f, 360f, 260f), GUI.skin.box);
+#pragma warning restore WPROTO028
             GUILayout.Label("Logging Demo Controls", GUI.skin.label);
 
             HandlePrettyToggle();
@@ -151,8 +156,7 @@ namespace Samples.UnityHelpers.Logging
             string npc = string.IsNullOrWhiteSpace(npcCallsign) ? "Scout-17" : npcCallsign.Trim();
             string status = string.IsNullOrWhiteSpace(statusLabel) ? "alert" : statusLabel.Trim();
             string statusFormat = $"status={status}";
-            string location =
-                $"Sector-{UnityEngine.Random.Range(sectorRange.x, sectorRange.y):0.0}";
+            string location = $"Sector-{PRNG.Instance.NextFloat(sectorRange.x, sectorRange.y):0.0}";
 
             return FormattableStringFactory.Create(
                 "{0:npc} :: {1:" + statusFormat + "} @ {2:color=#7AD7FF}",

--- a/Samples~/Serialization - JSON/Scripts/JsonSerializationDemo.cs
+++ b/Samples~/Serialization - JSON/Scripts/JsonSerializationDemo.cs
@@ -11,10 +11,12 @@ namespace Samples.UnityHelpers.Serialization.Json
     [Serializable]
     public struct SampleSave
     {
+#pragma warning disable WPROTO028 // This sample demonstrates JSON, not WallstopProto serialization.
         public Vector3 position;
         public Quaternion rotation;
         public Color color;
         public Rect screenRect;
+#pragma warning restore WPROTO028
     }
 
     /// <summary>

--- a/Samples~/Spatial Structures - 2D and 3D/Scripts/HullUsageDemo.cs
+++ b/Samples~/Spatial Structures - 2D and 3D/Scripts/HullUsageDemo.cs
@@ -19,7 +19,9 @@ namespace Samples.UnityHelpers.SpatialStructures
 
         [Header("Gridless (Vector2)")]
         [SerializeField]
+#pragma warning disable WPROTO028 // Inspector-only sample input; this component is not a proto contract.
         private Vector2 gridlessBounds = new Vector2(10f, 5f);
+#pragma warning restore WPROTO028
 
         [SerializeField]
         [Range(4, 32)]
@@ -30,7 +32,9 @@ namespace Samples.UnityHelpers.SpatialStructures
         private Grid grid;
 
         [SerializeField]
+#pragma warning disable WPROTO028 // Inspector-only sample input; this component is not a proto contract.
         private Vector2Int gridFootprint = new Vector2Int(6, 4);
+#pragma warning restore WPROTO028
 
         [SerializeField]
         [Range(3, 12)]
@@ -97,6 +101,7 @@ namespace Samples.UnityHelpers.SpatialStructures
                 return;
             }
 
+#pragma warning disable WPROTO028 // Transient debug geometry is never serialized by WallstopProto.
             List<Vector3> loop = new List<Vector3>(hull.Count);
             for (int i = 0; i < hull.Count; i++)
             {
@@ -105,6 +110,7 @@ namespace Samples.UnityHelpers.SpatialStructures
             }
 
             DrawLoop(loop, Color.cyan);
+#pragma warning restore WPROTO028
         }
 
         private List<FastVector3Int> RunGridAwareExample()
@@ -159,6 +165,7 @@ namespace Samples.UnityHelpers.SpatialStructures
                 return;
             }
 
+#pragma warning disable WPROTO028 // Transient debug geometry is never serialized by WallstopProto.
             List<Vector3> loop = new List<Vector3>(hull.Count);
             for (int i = 0; i < hull.Count; i++)
             {
@@ -167,6 +174,7 @@ namespace Samples.UnityHelpers.SpatialStructures
             }
 
             DrawLoop(loop, Color.yellow);
+#pragma warning restore WPROTO028
         }
 
         private static void DrawLoop(IReadOnlyList<Vector3> points, Color color)

--- a/Samples~/Spatial Structures - 2D and 3D/Scripts/SpatialStructuresDemo.cs
+++ b/Samples~/Spatial Structures - 2D and 3D/Scripts/SpatialStructuresDemo.cs
@@ -33,7 +33,9 @@ namespace Samples.UnityHelpers.SpatialStructures
                 points.Add(new Vector2(x, y));
             }
 
+#pragma warning disable WPROTO028 // Transient query bounds are never serialized by WallstopProto.
             Bounds bounds = new Bounds(Vector3.zero, new Vector3(areaSize.x, areaSize.y, 0.1f));
+#pragma warning restore WPROTO028
 
             // QuadTree: radius query
             QuadTree2D<Vector2> quad = new QuadTree2D<Vector2>(points, p => p, bounds);

--- a/Samples~/UGUI - EnhancedImage/Scripts/EnhancedImageDemo.cs
+++ b/Samples~/UGUI - EnhancedImage/Scripts/EnhancedImageDemo.cs
@@ -26,14 +26,18 @@ namespace Samples.UnityHelpers.UGUI.EnhancedImage
             GameObject imageGo = new GameObject("EnhancedImage");
             imageGo.transform.SetParent(canvasGo.transform, false);
             EnhancedImage image = imageGo.AddComponent<EnhancedImage>();
+#pragma warning disable WPROTO028 // Transient UI geometry is never serialized by WallstopProto.
             image.rectTransform.sizeDelta = new Vector2(200f, 200f);
+#pragma warning restore WPROTO028
 
             if (materialTemplate != null)
             {
                 image.material = Object.Instantiate(materialTemplate);
             }
 
+#pragma warning disable WPROTO028 // Transient UI tint is never serialized by WallstopProto.
             image.HdrColor = new Color(1.6f, 1.2f, 0.8f, 1f);
+#pragma warning restore WPROTO028
         }
     }
 }

--- a/Samples~/UI Toolkit - MultiFile Selector (Editor)/Scripts/Editor/MultiFileSelectorSampleWindow.cs
+++ b/Samples~/UI Toolkit - MultiFile Selector (Editor)/Scripts/Editor/MultiFileSelectorSampleWindow.cs
@@ -19,7 +19,9 @@ namespace Samples.UnityHelpers.UIToolkit.Editor
         {
             MultiFileSelectorSampleWindow window = GetWindow<MultiFileSelectorSampleWindow>();
             window.titleContent = new GUIContent("MultiFile Selector Sample");
+#pragma warning disable WPROTO028 // Editor-window layout is never serialized by WallstopProto.
             window.minSize = new Vector2(640f, 420f);
+#pragma warning restore WPROTO028
         }
 
         private void CreateGUI()

--- a/Styles/Elements/Progress/ArcedProgressBar.cs
+++ b/Styles/Elements/Progress/ArcedProgressBar.cs
@@ -151,7 +151,9 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
             }
         }
 
+#pragma warning disable WPROTO028 // UI-only Unity value; this element is never a WallstopProto contract.
         private Color _trackColor = Color.gray;
+#pragma warning restore WPROTO028
 
 #if UNITY_6000_0_OR_NEWER
         [UxmlAttribute("track-color-attr")]
@@ -325,8 +327,10 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
             }
 
             Painter2D painter = mgc.painter2D;
+#pragma warning disable WPROTO028 // Transient paint geometry is never serialized by WallstopProto.
             Rect rect = contentRect;
             Vector2 center = rect.center;
+#pragma warning restore WPROTO028
 
             painter.lineWidth = _thickness;
             painter.lineCap = _roundedCaps ? LineCap.Round : LineCap.Butt;

--- a/Styles/Elements/Progress/ArcedProgressBar.cs
+++ b/Styles/Elements/Progress/ArcedProgressBar.cs
@@ -4,7 +4,6 @@
 namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
 {
     using System.ComponentModel;
-    using System.Diagnostics.CodeAnalysis;
     using Core.Helper;
     using UnityEngine;
     using UnityEngine.UIElements;
@@ -152,11 +151,6 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
             }
         }
 
-        [SuppressMessage(
-            "WallstopProto",
-            "WPROTO028",
-            Justification = "UI-only Unity value; this element is never a WallstopProto contract."
-        )]
         private Color _trackColor = Color.gray;
 
 #if UNITY_6000_0_OR_NEWER

--- a/Styles/Elements/Progress/ArcedProgressBar.cs
+++ b/Styles/Elements/Progress/ArcedProgressBar.cs
@@ -4,6 +4,7 @@
 namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
 {
     using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using Core.Helper;
     using UnityEngine;
     using UnityEngine.UIElements;
@@ -151,9 +152,12 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
             }
         }
 
-#pragma warning disable WPROTO028 // UI-only Unity value; this element is never a WallstopProto contract.
+        [SuppressMessage(
+            "WallstopProto",
+            "WPROTO028",
+            Justification = "UI-only Unity value; this element is never a WallstopProto contract."
+        )]
         private Color _trackColor = Color.gray;
-#pragma warning restore WPROTO028
 
 #if UNITY_6000_0_OR_NEWER
         [UxmlAttribute("track-color-attr")]

--- a/Styles/Elements/Progress/MarchingAntsProgressBar.cs
+++ b/Styles/Elements/Progress/MarchingAntsProgressBar.cs
@@ -5,6 +5,7 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
 {
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using UnityEngine;
     using UnityEngine.UIElements;
 
@@ -222,13 +223,23 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
 
         private float _currentDashOffset;
         private IVisualElementScheduledItem _animationUpdateItem;
-#pragma warning disable WPROTO028 // UI-only geometry cache; this element is never a WallstopProto contract.
+
+        [SuppressMessage(
+            "WallstopProto",
+            "WPROTO028",
+            Justification = "UI-only geometry cache; this element is never a WallstopProto contract."
+        )]
         private readonly List<Vector2> _pathPoints = new();
 #if UNITY_2022_1_OR_NEWER
         private bool _pathDirty = true;
 #endif
+
+        [SuppressMessage(
+            "WallstopProto",
+            "WPROTO028",
+            Justification = "UI-only geometry cache; this element is never a WallstopProto contract."
+        )]
         private Rect _lastKnownRect = Rect.zero;
-#pragma warning restore WPROTO028
 
 #if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<MarchingAntsProgressBar, UxmlTraits> { }

--- a/Styles/Elements/Progress/MarchingAntsProgressBar.cs
+++ b/Styles/Elements/Progress/MarchingAntsProgressBar.cs
@@ -5,7 +5,6 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
 {
     using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Diagnostics.CodeAnalysis;
     using UnityEngine;
     using UnityEngine.UIElements;
 
@@ -224,21 +223,11 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
         private float _currentDashOffset;
         private IVisualElementScheduledItem _animationUpdateItem;
 
-        [SuppressMessage(
-            "WallstopProto",
-            "WPROTO028",
-            Justification = "UI-only geometry cache; this element is never a WallstopProto contract."
-        )]
         private readonly List<Vector2> _pathPoints = new();
 #if UNITY_2022_1_OR_NEWER
         private bool _pathDirty = true;
 #endif
 
-        [SuppressMessage(
-            "WallstopProto",
-            "WPROTO028",
-            Justification = "UI-only geometry cache; this element is never a WallstopProto contract."
-        )]
         private Rect _lastKnownRect = Rect.zero;
 
 #if !UNITY_6000_0_OR_NEWER

--- a/Styles/Elements/Progress/MarchingAntsProgressBar.cs
+++ b/Styles/Elements/Progress/MarchingAntsProgressBar.cs
@@ -222,9 +222,13 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
 
         private float _currentDashOffset;
         private IVisualElementScheduledItem _animationUpdateItem;
+#pragma warning disable WPROTO028 // UI-only geometry cache; this element is never a WallstopProto contract.
         private readonly List<Vector2> _pathPoints = new();
+#if UNITY_2022_1_OR_NEWER
         private bool _pathDirty = true;
+#endif
         private Rect _lastKnownRect = Rect.zero;
+#pragma warning restore WPROTO028
 
 #if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<MarchingAntsProgressBar, UxmlTraits> { }
@@ -318,7 +322,9 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
                     bar.style.width = 200;
                 }
 
+#if UNITY_2022_1_OR_NEWER
                 bar._pathDirty = true;
+#endif
                 bar.schedule.Execute(() => bar.UpdateFillElementSize(bar.contentRect))
                     .ExecuteLater(0);
                 bar.UpdateFillContainerSize();
@@ -387,7 +393,9 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
 
             if (_lastKnownRect != evt.newRect)
             {
+#if UNITY_2022_1_OR_NEWER
                 _pathDirty = true;
+#endif
                 _lastKnownRect = evt.newRect;
                 UpdateFillElementSize(evt.newRect);
                 UpdateTrackAndFillElements();
@@ -456,7 +464,9 @@ namespace WallstopStudios.UnityHelpers.Styles.Elements.Progress
 
         private void UpdateTrackAndFillElements()
         {
+#if UNITY_2022_1_OR_NEWER
             _pathDirty = true;
+#endif
             _trackElement?.MarkDirtyRepaint();
             _fillElement?.MarkDirtyRepaint();
         }

--- a/docs/guides/bundled-assembly-conflicts.md
+++ b/docs/guides/bundled-assembly-conflicts.md
@@ -90,7 +90,10 @@ unconditionally.
 `System.Runtime.CompilerServices.Unsafe` is used across the runtime (`EnumExtensions`,
 `ReflectionHelpers`, `Objects`, `AbstractRandom`, `RuntimeSingleton`) and is **not** bundled. Every
 editor in the support matrix provides it, which the CI matrix demonstrates on every run: 2021.3,
-2022.3, 6000.3, and 6000.5 all compile the package. Adding a copy would put a fourth source in play
+2022.3, 6000.5, and 6000.6 all compile the package. CI rejects package-owned compiler and analyzer
+warnings emitted by the supported-version test runs and the staged release export. Test assembly
+and third-party dependency diagnostics remain outside that consumer-facing gate. Adding a copy
+would put a fourth source in play
 for a contested name, and competing sources are the mechanism behind every failure on this page.
 
 Both decisions (which assemblies are constrained and which are deliberately absent) are enforced

--- a/package.json
+++ b/package.json
@@ -339,6 +339,7 @@
     "test:wiki-generation": "bash scripts/tests/test-wiki-generation.sh",
     "test:shell-portability": "bash scripts/tests/test-shell-portability.sh",
     "test:unity-nunit-results": "bash scripts/tests/test-unity-nunit-results.sh",
+    "test:unity-compiler-warnings": "pwsh -NoProfile -File scripts/tests/test-unity-compiler-warnings.ps1 -VerboseOutput",
     "sync:upm-changelog": "pwsh -NoProfile -File scripts/release-tools/sync-upm-changelog.ps1",
     "check:upm-changelog": "pwsh -NoProfile -File scripts/release-tools/sync-upm-changelog.ps1 -Check",
     "test:npm-package-signature": "pwsh -NoProfile -File scripts/tests/test-npm-package-signature.ps1 -VerboseOutput",

--- a/scripts/run-repo-lint.js
+++ b/scripts/run-repo-lint.js
@@ -375,6 +375,11 @@ const CHECKS = [
     run: "pwsh -NoProfile -File scripts/tests/test-unity-environment-warnings.ps1 -VerboseOutput"
   },
   {
+    id: "unity-compiler-warnings",
+    name: "Unity compiler warnings",
+    run: "pwsh -NoProfile -File scripts/tests/test-unity-compiler-warnings.ps1 -VerboseOutput"
+  },
+  {
     id: "catastrophic-pattern-sync",
     name: "Catastrophic pattern sync",
     run: "pwsh -NoProfile -File scripts/tests/test-catastrophic-pattern-sync.ps1 -VerboseOutput"

--- a/scripts/tests/test-unity-acceptance.ps1
+++ b/scripts/tests/test-unity-acceptance.ps1
@@ -124,10 +124,10 @@ if ($env:ACCEPTANCE_CONTROL_START_ACTIVE -eq 'true') { $env:ACCEPTANCE_CONTROL_A
         $project = Join-Path $temporary "configuration-$level"
         $null = Initialize-EphemeralProject -Root $temporary -Version '2021.3.45f1' -Mode editmode -Path $project -ManagedStrippingLevel $level
         $generated = Get-Content -LiteralPath (Join-Path $project 'Assets/Editor/UhCiTestConfigurator.cs') -Raw
-        if (-not $generated.Contains("PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.Standalone, ManagedStrippingLevel.$level);")) {
+        if (-not $generated.Contains("PlayerSettings.SetManagedStrippingLevel(target, ManagedStrippingLevel.$level);")) {
             throw 'Ephemeral project dropped the selected stripping level.'
         }
-        if (-not $generated.Contains('stripping={PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.Standalone)}')) {
+        if (-not $generated.Contains('stripping={PlayerSettings.GetManagedStrippingLevel(target)}')) {
             throw 'Configurator must report the effective stripping level.'
         }
         $checks++

--- a/scripts/tests/test-unity-compiler-warnings.ps1
+++ b/scripts/tests/test-unity-compiler-warnings.ps1
@@ -1,0 +1,177 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Tests the zero-warning gate used by every Unity CI compile path.
+#>
+[CmdletBinding()]
+param(
+    [switch]$VerboseOutput
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '../unity/lib/credential-redaction.ps1')
+
+$scriptRoot = Split-Path -Parent $PSScriptRoot
+$target = Join-Path $scriptRoot 'unity/run-ci-tests.ps1'
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $target,
+    [ref]$tokens,
+    [ref]$errors
+)
+if (0 -lt @($errors).Count) {
+    throw "run-ci-tests.ps1 has parse errors: $($errors -join '; ')"
+}
+
+foreach ($functionName in @('Write-CiError', 'Assert-NoUnityCompilerWarnings')) {
+    $definition = $ast.Find(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $functionName
+        },
+        $true
+    )
+    if ($null -eq $definition) {
+        throw "Function '$functionName' not found in run-ci-tests.ps1."
+    }
+    Invoke-Expression $definition.Extent.Text
+}
+
+$passed = 0
+$failed = 0
+
+function Assert-That {
+    param([string]$Description, [bool]$Condition)
+
+    if ($Condition) {
+        if ($VerboseOutput) {
+            Write-Host "  PASS: $Description"
+        }
+        $script:passed++
+        return
+    }
+
+    Write-Host "  FAIL: $Description"
+    $script:failed++
+}
+
+function Invoke-Gate {
+    param(
+        [string[]]$Lines,
+        [int]$MaximumReported = 25
+    )
+
+    $logPath = Join-Path (
+        [System.IO.Path]::GetTempPath()
+    ) ("uh-compiler-warning-" + [System.Guid]::NewGuid().ToString('N') + '.log')
+    try {
+        Set-Content -LiteralPath $logPath -Value $Lines -Encoding utf8
+        $output = @()
+        $script:gateThrew = $false
+        $output = @(
+            & {
+                try {
+                Assert-NoUnityCompilerWarnings -LogPath $logPath -Label 'fixture' -PackageRoot $scriptRoot -MaximumReported $MaximumReported 6>&1 |
+                    ForEach-Object { "$_" }
+                } catch {
+                    $script:gateThrew = $true
+                    Write-Output $_.Exception.Message
+                }
+            } 6>&1
+        )
+        return @{ Output = $output; Threw = $script:gateThrew }
+    } finally {
+        if (Test-Path -LiteralPath $logPath -PathType Leaf) {
+            Remove-Item -LiteralPath $logPath -Force
+        }
+    }
+}
+
+$clean = Invoke-Gate -Lines @(
+    'Compilation completed successfully',
+    '[uh-test-stream] TEST-STARTED Fixture("warning WUH015: intentional test data")',
+    'A plain warning from Unity that is not a compiler diagnostic',
+    '0 warnings'
+)
+Assert-That 'non-diagnostic warning text stays green' (-not $clean.Threw)
+Assert-That 'a clean scan reports its subject count' (
+    @($clean.Output | Where-Object { $_ -like '*Scanned 4 fixture log line(s)*0 unique*' }).Count -eq 1
+)
+
+$warningLines = @(
+    ((Join-Path $scriptRoot 'Runtime/Thing.cs') + '(8,13): warning CS0618: obsolete'),
+    'Packages/com.wallstop-studios.unity-helpers/Editor/Thing.cs(9): warning WUH003: expensive equality',
+    '  warning CS8032: An instance of analyzer WallstopStudios.UnityHelpers.Analyzers cannot be created',
+    '*** Tundra build success***Assets/WallstopStudios/UnityHelpers/Styles/Thing.cs(4,1,4,8): warning UAC0006: Unity diagnostic',
+    'Samples~/Example/Thing.cs(5): warning WPROTO001: serialization contract warning',
+    'Library/PackageCache/com.wallstop-studios.unity-helpers@abc123/Runtime/Cached.cs(6): warning CS0612: cached package warning',
+    'CSC : warning CS8032: An instance of analyzer WallstopStudios.UnityHelpers.Proto cannot be created',
+    '[Worker0] CSC : warning CS1685: The predefined type is defined in WallstopStudios.UnityHelpers.Runtime and another assembly',
+    "warning AD0001: Analyzer 'WallstopStudios.UnityHelpers.Analyzers.UnityObjectNullAnalyzer' threw an exception",
+    'Library/Bee/artifacts/1900b0aE.dag/WallstopStudios.UnityHelpers.Proto.Generator/Generated.cs(7): warning WPROTO031: generated warning'
+)
+$warnings = Invoke-Gate -Lines $warningLines -MaximumReported 2
+Assert-That 'compiler and analyzer warnings fail the gate' $warnings.Threw
+Assert-That 'the failure reports the unique warning count' (
+    @($warnings.Output | Where-Object { $_ -like '*emitted 10 unique package, sample, or CI-harness compiler warning(s)*' }).Count -ge 1
+)
+Assert-That 'the report limit is honored' (
+    @($warnings.Output | Where-Object { $_ -like '::error::fixture emitted a compiler warning:*' }).Count -eq 2
+)
+Assert-That 'omitted warnings are counted' (
+    @($warnings.Output | Where-Object { $_ -like '*emitted 8 additional unique*' }).Count -eq 1
+)
+
+$unowned = Invoke-Gate -Lines @(
+    'Packages/com.example/Runtime/Dependency.cs(4,1): warning CS0618: dependency warning',
+    ((Join-Path $scriptRoot 'Tests/Editor/Fixture.cs') + '(9): warning CS0168: test warning'),
+    'warning WPROTO001: source-less analyzer prose',
+    'warning CS8032: An instance of analyzer Example.Analyzers cannot be created',
+    "warning AD0001: Analyzer 'Example.Analyzers.Rule' threw an exception",
+    'warning CS8032: An instance of analyzer WallstopStudios.UnityHelpersAdjacent cannot be created',
+    'Library/Bee/artifacts/example/Generated.cs(7): warning CS0618: unrelated generated warning'
+)
+Assert-That 'dependency, test, and unrelated source-less warnings stay outside the client gate' (-not $unowned.Threw)
+
+$harness = Invoke-Gate -Lines @(
+    'Assets/Editor/UhCiTestConfigurator.cs(12): warning CS0618: generated configurator warning',
+    'Assets/Editor/UnityHelpersPackageExporter.cs(23): warning CS0618: generated exporter warning'
+)
+Assert-That 'generated CI harness warnings fail the gate' $harness.Threw
+
+$duplicate = Invoke-Gate -Lines @($warningLines[0], $warningLines[0])
+Assert-That 'duplicate compiler lines are reported once' (
+    @($duplicate.Output | Where-Object { $_ -like '*emitted 1 unique package, sample, or CI-harness compiler warning(s)*' }).Count -ge 1
+)
+
+$missing = $false
+try {
+    Assert-NoUnityCompilerWarnings -LogPath (
+        Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString('N'))
+    ) -Label 'missing' -PackageRoot $scriptRoot
+} catch {
+    $missing = $_.Exception.Message -like '*could not read*'
+}
+Assert-That 'a missing log cannot masquerade as a clean scan' $missing
+
+$source = Get-Content -LiteralPath $target -Raw
+foreach ($requiredCall in @(
+    'Assert-NoUnityCompilerWarnings -LogPath $LogPath -Label $Label -PackageRoot $RepoRoot',
+    'Assert-NoUnityCompilerWarnings -LogPath $LogPath -Label ''Unity package export'' -PackageRoot $PackageRoot',
+    '-Label "Unity $UnityVersion standalone build"',
+    '-Label "Unity $UnityVersion $TestMode"'
+)) {
+    Assert-That "runner includes warning gate call: $requiredCall" $source.Contains($requiredCall)
+}
+Assert-That 'runner scans a preserved configure attempt after a retry' $source.Contains(
+    'Assert-NoUnityCompilerWarnings -LogPath $firstAttemptLogPath -Label "$Label (first attempt)" -PackageRoot $RepoRoot'
+)
+
+Write-Host "Unity compiler warnings: $passed passed, $failed failed."
+if (0 -lt $failed) {
+    exit 1
+}
+exit 0

--- a/scripts/tests/test-unity-compiler-warnings.ps1.meta
+++ b/scripts/tests/test-unity-compiler-warnings.ps1.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4e355190f1be94663e08a255664b81a1
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/tests/test-unity-configure-upm-retry.ps1
+++ b/scripts/tests/test-unity-configure-upm-retry.ps1
@@ -35,6 +35,7 @@ if ($parseErrors -and $parseErrors.Count -gt 0) {
 
 foreach ($name in @(
         'ConvertTo-SingleLineDiagnostic',
+        'Assert-NoUnityCompilerWarnings',
         'Test-UnityPackageManagerTransientFailure',
         'Test-UnityConfigurePackageManagerRetryableFailure',
         'Write-UnityPackageManagerTransientFailureWarnings',
@@ -61,6 +62,7 @@ $script:passed = 0
 $script:failed = 0
 $script:notices = New-Object System.Collections.Generic.List[string]
 $script:CatastrophicPatterns = @(Get-CatastrophicPatterns)
+$RepoRoot = Split-Path -Parent $scriptRoot
 
 function Assert-That {
     param([string]$Description, [bool]$Condition)

--- a/scripts/tests/test-unity-grouped-modes.js
+++ b/scripts/tests/test-unity-grouped-modes.js
@@ -20,13 +20,7 @@ for (const requestedVersion of ["", ...versions]) {
     const selectedModes = TEST_MODES.includes(requestedMode) ? [requestedMode] : TEST_MODES;
     assert.deepEqual(result["unity-versions"], selectedVersions);
     assert.deepEqual(result["test-modes"], selectedModes);
-    // Modes are steps inside each version job, not a second matrix axis.
-    assert.deepEqual(
-      result["matrix-exclude"],
-      versions
-        .filter((version) => !selectedVersions.includes(version))
-        .map((version) => ({ "unity-version": version }))
-    );
+    assert.deepEqual(Object.keys(result).sort(), ["test-modes", "unity-versions"]);
     cases++;
   }
 }
@@ -66,7 +60,7 @@ for (const acceptance of ["sentinel", "intmap", "serialization", "all"]) {
 const matrix = resolveTestMatrix(versions);
 matrix["unity-versions"].pop();
 assert.deepEqual(resolveTestMatrix(versions)["unity-versions"], versions);
-assert.equal(resolveTestMatrix(versions)["unity-versions"].length, 4);
+assert.equal(resolveTestMatrix(versions)["unity-versions"].length, versions.length);
 
 const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "unity-grouped-modes-"));
 try {

--- a/scripts/tests/test-unity-package-export.ps1
+++ b/scripts/tests/test-unity-package-export.ps1
@@ -9,7 +9,8 @@ $tokens = $null
 $errors = $null
 $ast = [System.Management.Automation.Language.Parser]::ParseFile($sourcePath, [ref]$tokens, [ref]$errors)
 if ($errors.Count) { throw 'Unity runner must parse.' }
-foreach ($name in @('Assert-UnityRunMode', 'Invoke-UnityPackageExport')) {
+. (Join-Path $PSScriptRoot '../unity/lib/credential-redaction.ps1')
+foreach ($name in @('Write-CiError', 'Assert-NoUnityCompilerWarnings', 'Assert-UnityRunMode', 'Invoke-UnityPackageExport')) {
     $definition = $ast.Find({ param($node)
         $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
     }, $true)
@@ -84,6 +85,7 @@ try {
         } elseif ($script:Outcome -eq 'empty') {
             [IO.File]::WriteAllText($ExportPackagePath, '')
         }
+        [IO.File]::WriteAllText($LogPath, 'Compilation completed successfully')
         if ($script:Outcome -like 'failure*') { return 1 }
         return 0
     }
@@ -92,7 +94,7 @@ try {
         New-Item -ItemType Directory -Force -Path (Split-Path $ExportPackagePath -Parent) | Out-Null
         Set-Content -LiteralPath $ExportPackagePath -Value 'stale package'
         Set-Content -LiteralPath "$ExportPackagePath.sha256" -Value 'stale hash'
-        $action = { Invoke-UnityPackageExport -EditorPath 'fake editor' -Project $ProjectPath -OutputPath $ExportPackagePath -LogPath $logPath }
+        $action = { Invoke-UnityPackageExport -EditorPath 'fake editor' -Project $ProjectPath -OutputPath $ExportPackagePath -LogPath $logPath -PackageRoot $temporary }
         if ($script:Outcome -eq 'success') {
             & $action
             $expected = (Get-FileHash -LiteralPath $ExportPackagePath -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -126,12 +128,13 @@ try {
     function Invoke-UnityLicenseActivate { param($EditorPath, $Serial, $Email, $Password, $LogPath) $script:Events.Add('activate') }
     function Invoke-UnityLicenseReturn { param($EditorPath, $Email, $Password, $LogPath) $script:Events.Add('return') }
     function Invoke-UnityPackageExport {
-        param($EditorPath, $Project, $OutputPath, $LogPath, $ExtraArguments)
+        param($EditorPath, $Project, $OutputPath, $LogPath, $PackageRoot, $ExtraArguments)
         $script:Events.Add('export')
         if ($script:ExportFails) { throw 'injected export failure' }
     }
     function Write-UnityCompilationSourceInventoryMarker { throw 'Export changed the test compilation inventory.' }
     $UnityEditorPath = 'fake editor'
+    $RepoRoot = $temporary
     $startupProbeLogPath = $logPath
     $activateLogPath = $logPath
     $returnLogPath = $logPath

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -1258,6 +1258,10 @@ $runCiTestsClearsStaleCompilationCache = (
     $runCiTestsContent.Contains('[System.StringComparison]::OrdinalIgnoreCase') -and
     $runCiTestsContent.Contains('.unity-helpers-repo-root.txt') -and
     $runCiTestsContent.Contains('.unity-helpers-source-inventory.txt') -and
+    $runCiTestsContent.Contains('unity-compilation-inventory-v2') -and
+    $runCiTestsContent.Contains('Runtime/Analyzers/WallstopStudios.UnityHelpers.Analyzers.dll') -and
+    $runCiTestsContent.Contains('Runtime/Analyzers/WallstopStudios.UnityHelpers.Proto.Generator.dll') -and
+    $runCiTestsContent.Contains('Get-FileHash -LiteralPath $fullPath -Algorithm SHA256') -and
     $runCiTestsContent.Contains('Clear-StaleUnityCompilationCache -Project $ProjectPath -RepoRoot $RepoRoot') -and
     $runCiTestsContent.Contains('Write-UnityCompilationSourceInventoryMarker -Project $ProjectPath -RepoRoot $RepoRoot') -and
     $runCiTestsContent.Contains("'Bee'") -and
@@ -1836,23 +1840,16 @@ $defaultModeContracts = @(
 $defaultMatrixIsVersionGrouped = (
     -not $jobTexts.ContainsKey('unity-tests-standalone') -and
     [regex]::Matches($unityTestsMatrixJob, '(?m)^      matrix:\s*$').Count -eq 1 -and
-    [regex]::Matches($unityTestsMatrixJob, '(?m)^        unity-version:\s*$').Count -eq 1 -and
-    [regex]::Matches($unityTestsMatrixJob, '(?m)^          - \d+\.\d+\.\d+f\d+\s*$').Count -eq 4 -and
+    $unityTestsMatrixJob.Contains('unity-version: ${{ fromJSON(needs.matrix-config.outputs.unity-versions) }}') -and
     [regex]::Matches($unityTestsMatrixJob, '(?m)^        test-mode:\s*$').Count -eq 0 -and
     -not $unityTestsMatrixJob.Contains('matrix.test-mode') -and
-    $unityTestsMatrixJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}') -and
     $unityTestsMatrixJob.Contains('needs.matrix-config.outputs.test-modes') -and
+    -not $workflowContent.Contains('matrix-exclude') -and
     -not $workflowContent.Contains('matrix-exclude-standalone') -and
     -not $workflowContent.Contains('matrix-include-standalone')
 )
-foreach ($version in @('2021.3.45f1', '2022.3.45f1', '6000.5.2f1', '6000.6.0f1')) {
-    $defaultMatrixIsVersionGrouped = (
-        $defaultMatrixIsVersionGrouped -and
-        [regex]::Matches($unityTestsMatrixJob, "(?m)^          - $([regex]::Escape($version))\s*$").Count -eq 1
-    )
-}
 if (-not $defaultMatrixIsVersionGrouped) {
-    Write-Host '::error file=.github/workflows/unity-tests.yml::The default Unity matrix must contain exactly one axis with the four supported Unity versions. Modes must be sequential steps within each version job, never a second matrix axis that multiplies the licensed runner queue.'
+    Write-Host '::error file=.github/workflows/unity-tests.yml::The default Unity matrix must consume the canonical selected-version output as its only axis. Modes must be sequential steps within each version job, never a second matrix axis that multiplies the licensed runner queue.'
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info 'Checked the default Unity matrix creates exactly one job per supported version.'
@@ -2062,8 +2059,8 @@ $matrixConfigAssemblyDiscoveryIsCentralized = (
     $workflowContent.Contains('integration-assembly-profiles: ${{ steps.assemblies.outputs.integration_profiles }}') -and
     $workflowContent.Contains('core-assembly-profiles: ${{ steps.assemblies.outputs.core_profiles }}') -and
     $workflowContent.Contains('test-modes: ${{ steps.resolve.outputs.test-modes }}') -and
-    $workflowContent.Contains('matrix-exclude: ${{ steps.resolve.outputs.matrix-exclude }}') -and
-    $unityTestsMatrixJob.Contains('exclude: ${{ fromJSON(needs.matrix-config.outputs.matrix-exclude) }}') -and
+    $workflowContent.Contains('unity-versions: ${{ steps.resolve.outputs.unity-versions }}') -and
+    $unityTestsMatrixJob.Contains('unity-version: ${{ fromJSON(needs.matrix-config.outputs.unity-versions) }}') -and
     $unityTestsMatrixJob.Contains('UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.editmode-integration-assemblies }}') -and
     $unityTestsMatrixJob.Contains('UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.playmode-integration-assemblies }}') -and
     $unityTestsMatrixJob.Contains('UH_TEST_ASSEMBLIES: ${{ needs.matrix-config.outputs.standalone-integration-assemblies }}') -and

--- a/scripts/unity/resolve-test-matrix.js
+++ b/scripts/unity/resolve-test-matrix.js
@@ -40,12 +40,7 @@ function resolveTestMatrix(
   }
   return {
     "unity-versions": selectedVersions,
-    "test-modes": selectedModes,
-    // The workflow matrix has only a version axis. Mode selection gates steps
-    // inside each version job, so only unselected versions need exclusions.
-    "matrix-exclude": versions
-      .filter((entry) => !selectedVersions.includes(entry))
-      .map((entry) => ({ "unity-version": entry }))
+    "test-modes": selectedModes
   };
 }
 

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -284,6 +284,61 @@ function Write-CiWarning {
     Write-Host "::warning::$Message"
 }
 
+function Assert-NoUnityCompilerWarnings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$PackageRoot,
+        [int]$MaximumReported = 25
+    )
+
+    if (-not (Test-Path -LiteralPath $LogPath -PathType Leaf)) {
+        throw "$Label compiler-warning gate could not read '$LogPath'."
+    }
+
+    # A Unity project can contain third-party dependencies and this repository's own test
+    # assemblies. Neither is shipped to package consumers. Gate the package's production source,
+    # opt-in samples, and the small generated CI harness instead of claiming ownership of every
+    # warning emitted anywhere in the host project.
+    $packageRoot = [System.IO.Path]::GetFullPath($PackageRoot).TrimEnd('/', '\')
+    $escapedPackageRoot = [regex]::Escape($packageRoot) -replace '(?:\\/|/)','[\\/]'
+    $diagnosticSuffix = '\.cs\(\d+(?:,\d+){0,3}\):\s*warning\s+[A-Z][A-Z0-9]*\d{3,4}\s*:'
+    $ownedSourcePattern = '(?i)(?:' +
+        $escapedPackageRoot + '[\\/](?:Runtime|Editor|Styles|Samples~?)[\\/]|' +
+        'Packages[\\/]com\.wallstop-studios\.unity-helpers[\\/](?:Runtime|Editor|Styles|Samples~?)[\\/]|' +
+        'Library[\\/]PackageCache[\\/]com\.wallstop-studios\.unity-helpers(?:@[^\\/]+)?[\\/](?:Runtime|Editor|Styles|Samples~?)[\\/]|' +
+        'Assets[\\/]WallstopStudios[\\/]UnityHelpers[\\/](?:Runtime|Editor|Styles|Samples)[\\/]|' +
+        '^(?:Runtime|Editor|Styles|Samples~?)[\\/])[^\r\n]*?' + $diagnosticSuffix
+    $harnessPattern = '(?i)Assets[\\/]Editor[\\/](?:UhCi[^\\/]*|UnityHelpersPackageExporter)' + $diagnosticSuffix
+    $generatedSourcePattern = '(?i)Library[\\/]Bee[\\/][^\r\n]*WallstopStudios\.UnityHelpers(?![A-Za-z0-9_])[^\r\n]*?' + $diagnosticSuffix
+    $sourceLessDiagnosticPrefix = '(?i)^\s*(?:[^\r\n]*?\bCSC\s*:\s*)?warning\s+[A-Z][A-Z0-9]*\d{3,4}\s*:'
+    $packageAttributedSourceLessPattern = $sourceLessDiagnosticPrefix + '[^\r\n]*(?:WallstopStudios\.UnityHelpers(?![A-Za-z0-9_])|com\.wallstop-studios\.unity-helpers(?![A-Za-z0-9_-]))'
+    $logLines = @(Get-Content -LiteralPath $LogPath -ErrorAction Stop)
+    $warnings = @(
+        $logLines |
+            Where-Object {
+                $_ -notmatch '(?i)[\\/]Tests[\\/]' -and
+                ($_ -match $ownedSourcePattern -or $_ -match $harnessPattern -or $_ -match $generatedSourcePattern -or $_ -match $packageAttributedSourceLessPattern)
+            } |
+            ForEach-Object { ("$_").Trim() } |
+            Sort-Object -Unique
+    )
+
+    Write-Host "[compiler-warnings] Scanned $($logLines.Count) $Label log line(s); found $($warnings.Count) unique package, sample, or CI-harness compiler warning(s)."
+    if ($warnings.Count -lt 1) {
+        return
+    }
+
+    foreach ($warning in @($warnings | Select-Object -First $MaximumReported)) {
+        Write-CiError "$Label emitted a compiler warning: $(ConvertTo-UnitySafeLogText -Text $warning)"
+    }
+    if ($MaximumReported -lt $warnings.Count) {
+        Write-CiError "$Label emitted $($warnings.Count - $MaximumReported) additional unique compiler warning(s); inspect $LogPath."
+    }
+    throw "$Label emitted $($warnings.Count) unique package, sample, or CI-harness compiler warning(s). Unity CI requires zero client-visible warnings on every supported editor."
+}
+
 # SINGLE SOURCE OF TRUTH for the catastrophic-pattern list that both
 # Write-UnityCatastrophicErrorAnnotations (new ::error:: annotation surface)
 # AND Write-UnityResultFailureDiagnostics (older line-numbered selected-line
@@ -649,7 +704,7 @@ function Get-UnityCompilationSourceInventory {
         [System.IO.Path]::AltDirectorySeparatorChar
     )
     $sourceExtensions = @('.cs', '.asmdef', '.asmref', '.rsp')
-    $relativePaths = @(
+    $inventoryEntries = @(
         # These are the source-bearing roots imported by the local UPM package and
         # its testable assemblies. Samples~/ and Generator~/ are not imported into
         # the ephemeral project and must not invalidate its warm compilation cache.
@@ -672,9 +727,25 @@ function Get-UnityCompilationSourceInventory {
                 $relativePath.Replace([System.IO.Path]::DirectorySeparatorChar, '/')
             }
         }
+
+        # Analyzer binaries and their Unity importer settings affect diagnostics without changing
+        # a C# source path. Include both so a restored Library cannot silently reuse compilation
+        # performed under a different warning policy.
+        foreach ($relativePath in @(
+                'Runtime/Analyzers/WallstopStudios.UnityHelpers.Analyzers.dll',
+                'Runtime/Analyzers/WallstopStudios.UnityHelpers.Analyzers.dll.meta',
+                'Runtime/Analyzers/WallstopStudios.UnityHelpers.Proto.Generator.dll',
+                'Runtime/Analyzers/WallstopStudios.UnityHelpers.Proto.Generator.dll.meta'
+            )) {
+            $fullPath = Join-Path $normalizedRoot $relativePath
+            if (Test-Path -LiteralPath $fullPath -PathType Leaf) {
+                $contentHash = (Get-FileHash -LiteralPath $fullPath -Algorithm SHA256).Hash
+                "$relativePath`t$contentHash"
+            }
+        }
     )
 
-    return (@($relativePaths | Sort-Object -CaseSensitive) -join "`n")
+    return ((@('unity-compilation-inventory-v2') + @($inventoryEntries | Sort-Object -CaseSensitive)) -join "`n")
 }
 
 function Write-UnityCompilationSourceInventoryMarker {
@@ -750,7 +821,7 @@ function Clear-StaleUnityCompilationCache {
         $reasons += if ($null -eq $previousSourceInventory) {
             'source-inventory marker is missing or unreadable'
         } else {
-            'the package source path set changed'
+            'the package source path or analyzer inventory changed'
         }
     }
 
@@ -1541,24 +1612,25 @@ public static class UhCiTestConfigurator
 
         // The scripting backend is parameterized: the runner passes the IL2CPP or
         // the Mono backend for the Mono perf leg via -Backend.
-        PlayerSettings.SetScriptingBackend(BuildTargetGroup.Standalone, ScriptingImplementation.$Backend);
+        NamedBuildTarget target = NamedBuildTarget.Standalone;
+        PlayerSettings.SetScriptingBackend(target, ScriptingImplementation.$Backend);
         // Use the non-deprecated ApiCompatibilityLevel.NET_Standard (targets .NET
         // Standard 2.1). The deprecated 2.0 form and the non-existent 2.1 enum
         // member are intentionally NOT used.
-        PlayerSettings.SetApiCompatibilityLevel(BuildTargetGroup.Standalone, ApiCompatibilityLevel.NET_Standard);
-        PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.Standalone, ManagedStrippingLevel.$StrippingLevel);
+        PlayerSettings.SetApiCompatibilityLevel(target, ApiCompatibilityLevel.NET_Standard);
+        PlayerSettings.SetManagedStrippingLevel(target, ManagedStrippingLevel.$StrippingLevel);
         // Pin the IL2CPP C++ compiler configuration explicitly ($CompilerConfiguration).
         // An ephemeral CI project has no committed default, so the pin removes the
         // variable instead of trusting any implicit default. The standalone leg passes
         // Debug because Release ICEs MSVC on the generated test C++ -- see the
         // -Il2CppCompilerConfiguration parameter docs for the run and the exact file.
         // Harmless under Mono.
-        PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.Standalone, Il2CppCompilerConfiguration.$CompilerConfiguration);
+        PlayerSettings.SetIl2CppCompilerConfiguration(target, Il2CppCompilerConfiguration.$CompilerConfiguration);
 
         // Print the EFFECTIVE Unity config so the artifact log PROVES Mono/IL2CPP
         // + .NET Standard 2.1 + Release for this run.
-        PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.Standalone, out string[] effectiveDefines);
-        Debug.Log(`$"UH perf config: backend={PlayerSettings.GetScriptingBackend(BuildTargetGroup.Standalone)}, api={PlayerSettings.GetApiCompatibilityLevel(BuildTargetGroup.Standalone)}, codeOpt={UnityEditor.Compilation.CompilationPipeline.codeOptimization}, il2cppConfig={PlayerSettings.GetIl2CppCompilerConfiguration(BuildTargetGroup.Standalone)}, stripping={PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.Standalone)}, defines=[{string.Join(`";`", effectiveDefines ?? new string[0])}]");
+        PlayerSettings.GetScriptingDefineSymbols(target, out string[] effectiveDefines);
+        Debug.Log(`$"UH perf config: backend={PlayerSettings.GetScriptingBackend(target)}, api={PlayerSettings.GetApiCompatibilityLevel(target)}, codeOpt={UnityEditor.Compilation.CompilationPipeline.codeOptimization}, il2cppConfig={PlayerSettings.GetIl2CppCompilerConfiguration(target)}, stripping={PlayerSettings.GetManagedStrippingLevel(target)}, defines=[{string.Join(`";`", effectiveDefines ?? new string[0])}]");
 
         // Persist the PlayerSettings mutations (scripting backend/api/stripping AND
         // any injected scripting defines) to ProjectSettings.asset so the SEPARATE
@@ -1709,8 +1781,9 @@ $developmentOption
             }
             playerOptions.locationPathName = outPath;
         }
-        Debug.Log("UH player build config: backend=" + UnityEditor.PlayerSettings.GetScriptingBackend(UnityEditor.BuildTargetGroup.Standalone)
-            + ", stripping=" + UnityEditor.PlayerSettings.GetManagedStrippingLevel(UnityEditor.BuildTargetGroup.Standalone)
+        UnityEditor.Build.NamedBuildTarget target = UnityEditor.Build.NamedBuildTarget.Standalone;
+        Debug.Log("UH player build config: backend=" + UnityEditor.PlayerSettings.GetScriptingBackend(target)
+            + ", stripping=" + UnityEditor.PlayerSettings.GetManagedStrippingLevel(target)
             + ", development=" + ((playerOptions.options & UnityEditor.BuildOptions.Development) != 0));
         return playerOptions;
     }
@@ -3624,6 +3697,7 @@ function Invoke-UnityConfigurePass {
             -StallSeconds (Get-EditorTestStallSeconds)
     }
 
+    $firstAttemptLogPath = $null
     $configureStartedUtc = [DateTime]::UtcNow
     try {
         $configureExit = & $invokeConfigure $Label
@@ -3643,9 +3717,10 @@ function Invoke-UnityConfigurePass {
     ) {
         Write-CiWarning "Unity Package Manager canceled package resolution before the configure marker existed; clearing UPM state and retrying once."
         Write-UnityPackageManagerTransientFailureWarnings -LogPath $LogPath
-        $firstAttemptLogPath = Join-Path (Split-Path -Parent $LogPath) ("{0}.first-attempt.log" -f [System.IO.Path]::GetFileNameWithoutExtension($LogPath))
+        $preservedLogPath = Join-Path (Split-Path -Parent $LogPath) ("{0}.first-attempt.log" -f [System.IO.Path]::GetFileNameWithoutExtension($LogPath))
         try {
-            Copy-Item -LiteralPath $LogPath -Destination $firstAttemptLogPath -Force -ErrorAction Stop
+            Copy-Item -LiteralPath $LogPath -Destination $preservedLogPath -Force -ErrorAction Stop
+            $firstAttemptLogPath = $preservedLogPath
             Write-CiNotice "Saved first failed Unity configure log before retry: $firstAttemptLogPath"
         } catch {
             Write-CiWarning "Could not preserve first failed Unity configure log before retry: $($_.Exception.Message)"
@@ -3676,6 +3751,10 @@ function Invoke-UnityConfigurePass {
         Write-UnityBenignExitWarning -Label $Label -ExitCode $configureExit -LogPath $LogPath
     }
     Write-AnalyzerSetupDiagnostics -Project $ProjectPath -LogPath $LogPath -Label $Label
+    if (-not [string]::IsNullOrWhiteSpace($firstAttemptLogPath)) {
+        Assert-NoUnityCompilerWarnings -LogPath $firstAttemptLogPath -Label "$Label (first attempt)" -PackageRoot $RepoRoot
+    }
+    Assert-NoUnityCompilerWarnings -LogPath $LogPath -Label $Label -PackageRoot $RepoRoot
 }
 
 function Assert-UnityRunMode {
@@ -3729,6 +3808,7 @@ function Invoke-UnityPackageExport {
         [Parameter(Mandatory = $true)][string]$Project,
         [Parameter(Mandatory = $true)][string]$OutputPath,
         [Parameter(Mandatory = $true)][string]$LogPath,
+        [Parameter(Mandatory = $true)][string]$PackageRoot,
         [string[]]$ExtraArguments = @()
     )
 
@@ -3750,6 +3830,7 @@ function Invoke-UnityPackageExport {
         (Get-Item -LiteralPath $OutputPath).Length -le 0) {
         throw "Unity package export did not produce a fresh non-empty file: $OutputPath. See $LogPath."
     }
+    Assert-NoUnityCompilerWarnings -LogPath $LogPath -Label 'Unity package export' -PackageRoot $PackageRoot
     $hash = (Get-FileHash -LiteralPath $OutputPath -Algorithm SHA256).Hash.ToLowerInvariant()
     Set-Content -LiteralPath $hashPath -Value "$hash  $([IO.Path]::GetFileName($OutputPath))" -Encoding ascii
     Write-Host "Unity package exported: $OutputPath (SHA256 $hash)"
@@ -4042,7 +4123,8 @@ try {
 
     if ($TestMode -eq 'export') {
         Invoke-UnityPackageExport -EditorPath $UnityEditorPath -Project $ProjectPath `
-            -OutputPath $ExportPackagePath -LogPath $logPath -ExtraArguments $acceleratorArgs
+            -OutputPath $ExportPackagePath -LogPath $logPath -PackageRoot $RepoRoot `
+            -ExtraArguments $acceleratorArgs
         return
     }
 
@@ -4179,6 +4261,10 @@ try {
         if ($buildResult.TimedOut -or $buildResult.ExitCode -ne 0) {
             Write-UnityBenignExitWarning -Label "Build standalone IL2CPP test player (Unity $UnityVersion)" -ExitCode $buildResult.ExitCode -TimedOut:$buildResult.TimedOut -LogPath $logPath
         }
+        Assert-NoUnityCompilerWarnings `
+            -LogPath $logPath `
+            -Label "Unity $UnityVersion standalone build" `
+            -PackageRoot $RepoRoot
 
         # MISSED-CASE GUARD: even when the exe exists, scan the build log for the
         # signatures of a NON-redirected AutoRun build (PlayerWithTests /
@@ -4275,6 +4361,10 @@ try {
             -Project $ProjectPath
         Write-AnalyzerSetupDiagnostics -Project $ProjectPath -LogPath $logPath -Label "$UnityVersion $TestMode test compile"
         Test-NUnitResults -Path $resultsPath -Label "Unity $UnityVersion $TestMode" -LogPath $logPath -Project $ProjectPath -UnityExitCode $runExit -RequirePassedTests:$requireFilteredPass
+        Assert-NoUnityCompilerWarnings `
+            -LogPath $logPath `
+            -Label "Unity $UnityVersion $TestMode" `
+            -PackageRoot $RepoRoot
     }
     # Commit the inventory only after the selected mode produced valid passing
     # NUnit output. If import/compilation fails, the old or missing marker remains

--- a/scripts/unity/stage-unitypackage.js
+++ b/scripts/unity/stage-unitypackage.js
@@ -32,6 +32,7 @@ const REQUIRED_ENTRIES = [
 const EXPORTER_SOURCE = `using System;
 using System.IO;
 using UnityEditor;
+using UnityEditor.AssetPackage;
 
 public static class UnityHelpersPackageExporter
 {
@@ -51,11 +52,11 @@ public static class UnityHelpersPackageExporter
 
         Directory.CreateDirectory(outputDirectory);
         AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
-        AssetDatabase.ExportPackage(
+        Package.Export(new ExportPackageParameters(
             "Assets/WallstopStudios/UnityHelpers",
             outputPath,
-            ExportPackageOptions.Recurse
-        );
+            flags: ExportPackageOptions.Recurse
+        ));
 
         FileInfo exported = new FileInfo(outputPath);
         if (!exported.Exists || exported.Length <= 0)


### PR DESCRIPTION
DISCLOSURE: LLM-GENERATED TEXT

**Why:**

Unity package compilation must stay warning-free across every supported Unity version and test mode, without adding CI launches or reducing coverage.

**What:**

- Fix package-owned compiler and analyzer warnings across Runtime, Editor, Styles, and imported sample code.
- Fail existing Unity test, export, and standalone passes when their logs contain package-owned diagnostics, including preserved first-attempt retry logs.
- Drive the workflow matrix from the canonical resolver while preserving every Unity version, backend, mode, and test dimension.
- Include shipped analyzer binaries in the compilation-cache inventory so analyzer changes invalidate stale warm caches.
- Replace obsolete Unity APIs with supported version-gated equivalents and retain exact DEVELOPMENT_BUILD behavior.

Fixes #770
Refs #766

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactor (code change that neither fixes a bug nor adds a feature)

## CI Cost and Coverage

- No jobs, Unity versions, backends, test modes, or existing test passes were removed.
- Warning enforcement scans logs already produced by the existing Unity processes; it adds no Unity launches.
- Dynamic matrix resolution removes duplicated version declarations and retains contract checks for all matrix dimensions.
- Imported Samples~ compilation remains covered by the existing fresh release export on Unity 6000.6; expanding that to every version would increase CI time and is intentionally out of scope.
- A follow-up optimization was identified: reuse job-scoped Unity setup/activation/probing, potentially eliminating 9 redundant setup sequences (27 Unity launches) across grouped jobs after measured fail-closed A/B validation.

## Validation

- [x] Full C# typecheck matrix, including explicit DEVELOPMENT_BUILD: 0 warnings, 0 errors
- [x] Shipped analyzer reproducibility verification
- [x] 87/87 fast repository checks
- [x] Unity warning-gate controls: 15/15
- [x] Grouped-mode controls: 167/167
- [x] Package-export controls: 27/27
- [x] Acceptance-runner controls: 66/66
- [x] npm package validation: 2,176 files
- [x] Agent preflight and staged diff checks

## Checklist

- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG
- [x] My changes do not introduce breaking changes, or breaking changes are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches serialization surrogates visibility, IL2CPP protobuf registration logging, and CI failure semantics on every Unity leg; behavioral risk is low but any missed warning class or over-broad gate pattern could block releases or hide real issues.
> 
> **Overview**
> Adds a **zero-warning gate** on existing Unity CI logs so configure, test, standalone build, and package export fail when package-owned compiler/analyzer diagnostics appear (including preserved configure retry logs), with new fixture tests and repo lint wiring.
> 
> **Source fixes** clear the warnings that gate targets: UAC/WPROTO pragmas on intentional APIs, `WALLSTOP_DEVELOPMENT_BUILD` for dev-player diagnostics, Unity 6 `NamedBuildTarget` / UI Toolkit `translate` / `CurrentAssemblies.GetLoadedAssemblies()`, removal of the `DoesNotReturn` polyfill (and related CS0436 harness suppressions), public protobuf surrogates, and assorted editor/runtime hygiene (`MatchColliderToSprite`, animation UI `[NonSerialized]`, sample suppressions).
> 
> **CI plumbing** drives the workflow matrix from `resolve-test-matrix` `unity-versions` only (drops `matrix-exclude`), extends compilation-cache inventory v2 with analyzer DLL hashes, and updates staged export to `Package.Export` plus obsolete API replacements in generated configurators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083ae32d0c37fe480ac4f60c4832fd52081d095a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->